### PR TITLE
Clarification on the usage of <c> and <!c> in the Configuration Wizard

### DIFF
--- a/CMSIS/DoxyGen/Pack/src/config_wizard.txt
+++ b/CMSIS/DoxyGen/Pack/src/config_wizard.txt
@@ -101,7 +101,7 @@ The following table lists the Configuration Wizard Annotations:
     <tr>
       <td>\<c><sup>*</sup></td>
       <td>yes</td>
-      <td>Comment sequence block until block end when disabled.
+      <td>Code enable: creates a checkbox to uncomment or comment code. All lines, including those with white spaces, get commented with double slashes (//) at the first found character when you disable the checkbox.
       \code
       // <c1> Comment sequence block until block end when disabled
       //<i> This may carry the block's description
@@ -119,7 +119,7 @@ The following table lists the Configuration Wizard Annotations:
     <tr>
       <td>\<!c><sup>*</sup></td>
       <td>yes</td>
-      <td>Comment sequence block until block end when enabled.
+      <td>Code disable: creates a checkbox to comment or uncomment code. All lines, including those with white spaces, get commented with double slashes (//) at the first found character when you enable the checkbox.
       \code
       // <!c1> Comment sequence block until block end when enabled
       //<i> This may carry the block's description


### PR DESCRIPTION
Changed the documentation to make the user better understand what he can do with <c> and <!c> in Configuration Wizard