### PR TITLE
Fix M4 targets without FPU

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/ARM/irq_cm4f.s
+++ b/CMSIS/RTOS2/RTX/Source/ARM/irq_cm4f.s
@@ -74,8 +74,10 @@ SVC_Context
 
 SVC_ContextSave
                 STMDB    R12!,{R4-R11}          ; Save R4..R11
+#ifdef __FPU_PRESENT
                 TST      LR,#0x10               ; Check if extended stack frame
                 VSTMDBEQ R12!,{S16-S31}         ;  Save VFP S16.S31
+#endif
 
                 STR      R12,[R1,#TCB_SP_OFS]   ; Store SP
                 STRB     LR, [R1,#TCB_SF_OFS]   ; Store stack frame information
@@ -88,8 +90,10 @@ SVC_ContextRestore
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
                 ORR      LR,R1,#0xFFFFFF00      ; Set EXC_RETURN
 
+#ifdef __FPU_PRESENT
                 TST      LR,#0x10               ; Check if extended stack frame
                 VLDMIAEQ R0!,{S16-S31}          ;  Restore VFP S16..S31
+#endif
                 LDMIA    R0!,{R4-R11}           ; Restore R4..R11
                 MSR      PSP,R0                 ; Set PSP
 

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_cm4f.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_cm4f.S
@@ -78,9 +78,11 @@ SVC_Context:
 
 SVC_ContextSave:
         STMDB    R12!,{R4-R11}          // Save R4..R11
+#ifdef __FPU_PRESENT
         TST      LR,#0x10               // Check if extended stack frame
         IT       EQ
         VSTMDBEQ R12!,{S16-S31}         //  Save VFP S16.S31
+#endif
 
         STR      R12,[R1,#TCB_SP_OFS]   // Store SP
         STRB     LR, [R1,#TCB_SF_OFS]   // Store stack frame information
@@ -93,9 +95,11 @@ SVC_ContextRestore:
         LDR      R0,[R2,#TCB_SP_OFS]    // Load SP
         ORR      LR,R1,#0xFFFFFF00      // Set EXC_RETURN
 
+#ifdef __FPU_PRESENT
         TST      LR,#0x10               // Check if extended stack frame
         IT       EQ
         VLDMIAEQ R0!,{S16-S31}          //  Restore VFP S16..S31
+#endif
         LDMIA    R0!,{R4-R11}           // Restore R4..R11
         MSR      PSP,R0                 // Set PSP
 

--- a/CMSIS/RTOS2/RTX/Source/IAR/irq_cm4f.s
+++ b/CMSIS/RTOS2/RTX/Source/IAR/irq_cm4f.s
@@ -77,9 +77,11 @@ SVC_Context
 
 SVC_ContextSave
                 STMDB    R12!,{R4-R11}          ; Save R4..R11
+#ifdef __FPU_PRESENT
                 TST      LR,#0x10               ; Check if extended stack frame
                 IT       EQ
                 VSTMDBEQ R12!,{S16-S31}         ;  Save VFP S16.S31
+#endif
 
                 STR      R12,[R1,#TCB_SP_OFS]   ; Store SP
                 STRB     LR, [R1,#TCB_SF_OFS]   ; Store stack frame information
@@ -92,9 +94,11 @@ SVC_ContextRestore
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
                 ORR      LR,R1,#0xFFFFFF00      ; Set EXC_RETURN
 
+#ifdef __FPU_PRESENT
                 TST      LR,#0x10               ; Check if extended stack frame
                 IT       EQ
                 VLDMIAEQ R0!,{S16-S31}          ;  Restore VFP S16..S31
+#endif
                 LDMIA    R0!,{R4-R11}           ; Restore R4..R11
                 MSR      PSP,R0                 ; Set PSP
 


### PR DESCRIPTION
Some platforms with M4 don't have FPU eg FRDM-KW24D

CC: @RobertRostohar 