### PR TITLE
RTX: Fix GCC ASM .file and .include for *.S

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mbl.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mbl.S
@@ -24,7 +24,7 @@
 ; */
 
 
-        .file    "irq_armv8mbl.s"
+        .file    "irq_armv8mbl.S"
         .syntax  unified
 
         .ifndef  __DOMAIN_NS

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mbl_ns.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mbl_ns.S
@@ -1,3 +1,3 @@
         .equ     __DOMAIN_NS, 1
-        .include "../Source/GCC/irq_armv8mbl.s"
+        .include "../Source/GCC/irq_armv8mbl.S"
         .end

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml.S
@@ -24,7 +24,7 @@
  */
 
 
-        .file    "irq_armv8mml.s"
+        .file    "irq_armv8mml.S"
         .syntax  unified
 
         .ifndef  __DOMAIN_NS

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml_fp.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml_fp.S
@@ -1,3 +1,3 @@
         .equ     __FPU_USED,  1
-        .include "../Source/GCC/irq_armv8mml.s"
+        .include "../Source/GCC/irq_armv8mml.S"
         .end

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml_fp_ns.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml_fp_ns.S
@@ -1,4 +1,4 @@
         .equ     __FPU_USED,  1
         .equ     __DOMAIN_NS, 1
-        .include "../Source/GCC/irq_armv8mml.s"
+        .include "../Source/GCC/irq_armv8mml.S"
         .end

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml_ns.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mml_ns.S
@@ -1,3 +1,3 @@
         .equ     __DOMAIN_NS, 1
-        .include "../Source/GCC/irq_armv8mml.s"
+        .include "../Source/GCC/irq_armv8mml.S"
         .end

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_cm0.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_cm0.S
@@ -24,7 +24,7 @@
  */
 
 
-        .file    "irq_cm0.s"
+        .file    "irq_cm0.S"
         .syntax  unified
 
         .equ     I_T_RUN_OFS, 28        // osRtxInfo.thread.run offset

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_cm3.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_cm3.S
@@ -24,7 +24,7 @@
  */
 
 
-        .file    "irq_cm3.s"
+        .file    "irq_cm3.S"
         .syntax  unified
 
         .equ     I_T_RUN_OFS, 28        // osRtxInfo.thread.run offset

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_cm4f.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_cm4f.S
@@ -24,7 +24,7 @@
  */
 
 
-        .file    "irq_cm4f.s"
+        .file    "irq_cm4f.S"
         .syntax  unified
 
         .equ     I_T_RUN_OFS, 28        // osRtxInfo.thread.run offset


### PR DESCRIPTION
The GCC ASM files were renamed from *.s to *.S. However, the names by
which these files are referenced were not completely updated. This leads
to problems on case sensitive file systems.

Update the name by which the GCC ASM files are referenced, so as not to
break the build on case sensitive file systems.

Fixes: 9f7ce666db32 "RTX: renamed GCC ASM files extension (*.s to *.S)"

@RobertRostohar