### PR TITLE
Bugfix: terminate_list may be corrupted upon join() or detach()

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_thread.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_thread.c
@@ -1176,6 +1176,7 @@ void svcRtxThreadExit (void) {
     // Update Thread State and put it into Terminate Thread list
     thread->state = osRtxThreadTerminated;
     thread->thread_prev = NULL;
+    osRtxInfo.thread.terminate_list->thread_prev = thread;
     thread->thread_next = osRtxInfo.thread.terminate_list;
     osRtxInfo.thread.terminate_list = thread;
   }
@@ -1241,6 +1242,7 @@ osStatus_t svcRtxThreadTerminate (osThreadId_t thread_id) {
     // Update Thread State and put it into Terminate Thread list
     thread->state = osRtxThreadTerminated;
     thread->thread_prev = NULL;
+    osRtxInfo.thread.terminate_list->thread_prev = thread;
     thread->thread_next = osRtxInfo.thread.terminate_list;
     osRtxInfo.thread.terminate_list = thread;
   }


### PR DESCRIPTION
terminate_list is supposed to be a double linked list. At least osRtxThreadListUnlink() expects one. The thread->prev pointer of already terminated threads were kept to nullptr, building a sinle linked list. The function osRtxThreadListUnlink() may corrupt the terminate_list when join() or detach() is called in a different order than the threads that terminated before.