### PR TITLE
cmsis: fix IAR architecture macros

### DIFF
--- a/CMSIS/Core/Include/cmsis_compiler.h
+++ b/CMSIS/Core/Include/cmsis_compiler.h
@@ -53,6 +53,7 @@
  */
 #elif defined ( __ICCARM__ )
 
+
   #ifndef   __ASM
     #define __ASM                                  __asm
   #endif
@@ -64,6 +65,21 @@
   #endif
 
   #include <cmsis_iar.h>
+
+  /* CMSIS compiler control architecture macros */
+  #if (__CORE__ == __ARM6M__) || (__CORE__ == __ARM6SM__)
+    #ifndef __ARM_ARCH_6M__
+      #define __ARM_ARCH_6M__                      1
+    #endif
+  #elif (__CORE__ == __ARM7M__)
+    #ifndef __ARM_ARCH_7M__
+      #define __ARM_ARCH_7M__                      1
+    #endif
+  #elif (__CORE__ == __ARM7EM__)
+    #ifndef __ARM_ARCH_7EM__
+      #define __ARM_ARCH_7EM__                     1
+    #endif
+  #endif
 
   #ifndef   __NO_RETURN
     #define __NO_RETURN                            __noreturn

--- a/CMSIS/RTOS2/RTX/Library/IAR/IDE/RTX_CM.ewp
+++ b/CMSIS/RTOS2/RTX/Library/IAR/IDE/RTX_CM.ewp
@@ -182,7 +182,7 @@
         <option>
           <name>CCDefines</name>
           <state>NDEBUG</state>
-          <state>__ARM_ARCH_6M__</state>
+          <state></state>
           <state>CMSIS_device_header="ARMCM0.h"</state>
         </option>
         <option>
@@ -1152,7 +1152,7 @@
         <option>
           <name>CCDefines</name>
           <state>NDEBUG</state>
-          <state>__ARM_ARCH_7M__</state>
+          <state></state>
           <state>CMSIS_device_header="ARMCM3.h"</state>
         </option>
         <option>
@@ -2122,7 +2122,7 @@
         <option>
           <name>CCDefines</name>
           <state>NDEBUG</state>
-          <state>__ARM_ARCH_7EM__</state>
+          <state></state>
           <state>CMSIS_device_header="ARMCM4_FP.h"</state>
         </option>
         <option>


### PR DESCRIPTION
``__CORE__`` is IAR specific, similar to ``__ARM_ARCH_`` macros that GCC defines. Plus I removed those macros from ewp file.

reference: #149 

Note: I am working on different code base where I was testing this patch, please test it or let me know how I could test this within this code base (run any local tests). I tried to open .eww project but as in the reference, I probably have newer IAR version thus the project is not compatible.