### PR TITLE
rtx: fix weak linkage for osRtxUserSVC

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_lib.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_lib.c
@@ -434,8 +434,8 @@ extern const uint8_t *irqRtxLibRef;
        const uint8_t *irqRtxLibRef = &irqRtxLib;
 
 // Default User SVC Table
-__WEAK
 extern void * const osRtxUserSVC[];
+__WEAK
        void * const osRtxUserSVC[1] = { (void *)0 };
 
 


### PR DESCRIPTION
The variable definition should specify linkage. This resulted in an error
for IAR that this symbol is duplicated (rtx_lib and svc_user code files).

reference: #149

Please review, as I am not fully certain why this  is causing problems for IAR. ARM and  GCC ARM are building without errors. From IAR docs: ``Using the __weak object attribute on an external declaration of a symbol makes all references to that symbol in the module weak.`` Thus should be weak. This results however (before this patch is applied) in:

```
Error[Li006]: duplicate definitions for "osRtxUserSVC"; in "\K64F\IAR\mbed-os\rtos\rtx2\TARGET_CORTEX_M\rtx_lib.o"
          , and "BUILD\K64F\IAR\mbed-os\rtos\rtx2\T
          ARGET_CORTEX_M\svc_user.o"
[ERROR] Error[Li006]: duplicate definitions for "osRtxUserSVC"; in "\K64F\IAR\mbed-os\rtos\rtx2\TARGET_CORTEX_M\rtx_lib.o"
          , and "BUILD\K64F\IAR\mbed-os\rtos\rtx2\T
          ARGET_CORTEX_M\svc_user.o"

```