### PR TITLE
Fixed bug in GCC version of function atomic_link_put

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/core_cm.h
+++ b/CMSIS/RTOS2/RTX/Source/core_cm.h
@@ -1502,7 +1502,7 @@ __STATIC_INLINE void atomic_link_put (void **root, void *link) {
     "dmb\n\t"
     "ldrex %[val1],[%[root]]\n\t"
     "ldr   %[val2],[%[link]]\n\t"
-    "cmp   %[val2],%[val2]\n\t"
+    "cmp   %[val2],%[val1]\n\t"
     "bne   1b\n\t"
     "strex %[res],%[link],[%[root]]\n\t"
     "cbz   %[res],2f\n\t"


### PR DESCRIPTION
The GCC version of the function 'atomic_link_put' compares two identical values. This compare always matches, which causes race conditions when using 'osRtxMemoryPoolAlloc' in the interrupt context.