### PR TITLE
Fix comiplation with Clang for MCU with FPU

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -713,7 +713,11 @@ __attribute__((always_inline)) __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
 {
 #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
      (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+  #ifdef __clang__
+  __builtin_arm_set_fpscr(fpscr);
+  #else
   __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc", "memory");
+  #endif
 #else
   (void)fpscr;
 #endif


### PR DESCRIPTION
I have met an issue with using Clang as a front-end for GNU ARM GCC. During compilation I got an issue with `vfpcc` register about which Clang knows nothing:
```make
cmsis\include\cmsis_gcc.h:719:54: error: unknown register name 'vfpcc' in asm __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc", "memory");
```
The fix that I have found is to use `__builtin_arm_set_fpscr()`, but it is unavailable for GCC up to 4.8. So that some preprocessor definitions were used.

Clang version I use:
```bash
$ clang --version
clang version 3.9.1 (tags/RELEASE_391/final)
Target: x86_64-w64-windows-gnu
Thread model: posix
InstalledDir: C:\msys64\mingw64\bin
```

GNU ARM GCC version:
```bash
$ arm-none-eabi-gcc --version
arm-none-eabi-gcc.exe (GNU Tools for ARM Embedded Processors 6-2017-q1-update) 6.3.1 20170215 (release) [ARM/embedded-6-branch revision 245512]
Copyright (C) 2016 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```