### PR TITLE
Fix arm math warnings

### DIFF
--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -294,7 +294,7 @@
 #define _ARM_MATH_H
 
 /* ignore some GCC warnings */
-#if defined ( __GNUC__ )
+#if defined ( __GNUC__ ) && !defined ( __CC_ARM )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
@@ -7214,7 +7214,7 @@ void arm_rfft_fast_f32(
 #endif
 
 
-#if defined ( __GNUC__ )
+#if defined ( __GNUC__ ) && !defined ( __CC_ARM )
 #pragma GCC diagnostic pop
 #endif
 

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -429,7 +429,7 @@ extern "C"
    * @brief definition to read/write two 16 bit values.
    */
 #if   defined ( __CC_ARM )
-  #define __SIMD32_TYPE int32_t __packed
+  #define __SIMD32_TYPE int32_t
   #define CMSIS_UNUSED __attribute__((unused))
   #define CMSIS_INLINE __attribute__((always_inline))
 


### PR DESCRIPTION
2 fixes that should fix #188.

Please review (mainly the second commit regarding packed attribute warning for ARMCC).