### PR TITLE
Enable the system header pragma for clang

### DIFF
--- a/CMSIS/Core/Include/cmsis_version.h
+++ b/CMSIS/Core/Include/cmsis_version.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_armv8mbl.h
+++ b/CMSIS/Core/Include/core_armv8mbl.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_armv8mml.h
+++ b/CMSIS/Core/Include/core_armv8mml.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_cm0.h
+++ b/CMSIS/Core/Include/core_cm0.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_cm0plus.h
+++ b/CMSIS/Core/Include/core_cm0plus.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_cm23.h
+++ b/CMSIS/Core/Include/core_cm23.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_cm3.h
+++ b/CMSIS/Core/Include/core_cm3.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_cm33.h
+++ b/CMSIS/Core/Include/core_cm33.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_cm4.h
+++ b/CMSIS/Core/Include/core_cm4.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_cm7.h
+++ b/CMSIS/Core/Include/core_cm7.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_sc000.h
+++ b/CMSIS/Core/Include/core_sc000.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 

--- a/CMSIS/Core/Include/core_sc300.h
+++ b/CMSIS/Core/Include/core_sc300.h
@@ -24,7 +24,7 @@
 
 #if   defined ( __ICCARM__ )
  #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__clang__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
   #pragma clang system_header   /* treat file as system include file */
 #endif
 


### PR DESCRIPTION
The `#pragma clang system_header` is available since atleast clang 3.3, allow using it