### PR TITLE
CMSIS-Core: #203 compiler macro for packed union

### DIFF
--- a/CMSIS/Core/Include/cmsis_armcc.h
+++ b/CMSIS/Core/Include/cmsis_armcc.h
@@ -73,6 +73,9 @@
 #ifndef   __PACKED_STRUCT
   #define __PACKED_STRUCT                        __packed struct
 #endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         __packed union
+#endif
 #ifndef   __UNALIGNED_UINT32        /* deprecated */
   #define __UNALIGNED_UINT32(x)                  (*((__packed uint32_t *)(x)))
 #endif

--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -56,6 +56,9 @@
 #ifndef   __PACKED_STRUCT
   #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
 #endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
 #ifndef   __UNALIGNED_UINT32        /* deprecated */
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wpacked"

--- a/CMSIS/Core/Include/cmsis_compiler.h
+++ b/CMSIS/Core/Include/cmsis_compiler.h
@@ -96,6 +96,9 @@
   #ifndef   __PACKED_STRUCT
     #define __PACKED_STRUCT                        __packed struct
   #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         __packed union
+  #endif
   #ifndef   __UNALIGNED_UINT32        /* deprecated */
     __packed struct T_UINT32 { uint32_t v; };
     #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
@@ -174,6 +177,9 @@
   #ifndef   __PACKED_STRUCT
     #define __PACKED_STRUCT                        struct __attribute__((packed))
   #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __attribute__((packed))
+  #endif
   #ifndef   __UNALIGNED_UINT32        /* deprecated */
     struct __attribute__((packed)) T_UINT32 { uint32_t v; };
     #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
@@ -233,6 +239,9 @@
   #ifndef   __PACKED_STRUCT
     #define __PACKED_STRUCT                        struct __packed__
   #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __packed__
+  #endif
   #ifndef   __UNALIGNED_UINT32        /* deprecated */
     struct __packed__ T_UINT32 { uint32_t v; };
     #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
@@ -289,6 +298,9 @@
   #endif
   #ifndef   __PACKED_STRUCT
     #define __PACKED_STRUCT                        @packed struct
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         @packed union
   #endif
   #ifndef   __UNALIGNED_UINT32        /* deprecated */
     @packed struct T_UINT32 { uint32_t v; };

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -61,6 +61,9 @@
 #ifndef   __PACKED_STRUCT
   #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
 #endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
 #ifndef   __UNALIGNED_UINT32        /* deprecated */
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wpacked"


### PR DESCRIPTION
Hi,

Has discussed in ticket #203, this is a proposal to have a macro which handle pack union attribute to work with different compilers.

I have checked with armclang 6.6, armcc 5.06 update 4 and gcc 5.4.0