### PR TITLE
Optimizing stack setup on SVC calls

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/ARM/irq_cm4f.s
+++ b/CMSIS/RTOS2/RTX/Source/ARM/irq_cm4f.s
@@ -46,7 +46,10 @@ SVC_Handler     PROC
                 IMPORT   osRtxUserSVC
                 IMPORT   osRtxInfo
 
-                MRS      R0,PSP                 ; Get PSP
+                TST      LR, #0x4               ; Check EXC_RETURN for bit 2
+                ITE      EQ                     ; if Equal
+                MRSEQ    R0, MSP                ; MSP was in use, put MSP in R0
+                MRSNE    R0, PSP                ; else, PSP was in use, put PSP in R0
                 LDR      R1,[R0,#24]            ; Load saved PC from stack
                 LDRB     R1,[R1,#-2]            ; Load SVC number
                 CBNZ     R1,SVC_User            ; Branch if not SVC 0

--- a/CMSIS/RTOS2/RTX/Source/rtx_core_cm.h
+++ b/CMSIS/RTOS2/RTX/Source/rtx_core_cm.h
@@ -100,20 +100,6 @@
 #define __SVC_INDIRECT(n) __svc_indirect_r7(n)
 #endif
 
-#if    (__FPU_USED == 1U)
-#define SVC_SETUP_PSP                                                          \
-  uint32_t control = __get_CONTROL();                                          \
-  if ((control & 2U) == 0U) {                                                  \
-    __set_PSP((__get_MSP() - ((control & 4U) ? 104U : 32U)) & ~7U);            \
-  }
-#else
-#define SVC_SETUP_PSP                                                          \
-  uint32_t control = __get_CONTROL();                                          \
-  if ((control & 2U) == 0U) {                                                  \
-    __set_PSP((__get_MSP() -                          32U)  & ~7U);            \
-  }
-#endif
-
 #define SVC0_0N(f,t)                                                           \
 __SVC_INDIRECT(0) t    svc##f (t(*)());                                        \
                   t svcRtx##f (void);                                          \
@@ -135,7 +121,6 @@ __SVC_INDIRECT(0) t    svc##f (t(*)());                                        \
                   t svcRtx##f (void);                                          \
 __attribute__((always_inline))                                                 \
 __STATIC_INLINE   t  __svc##f (void) {                                         \
-  SVC_SETUP_PSP                                                                \
   return svc##f(svcRtx##f);                                                    \
 }
 
@@ -160,7 +145,6 @@ __SVC_INDIRECT(0) t    svc##f (t(*)(t1),t1);                                   \
                   t svcRtx##f (t1 a1);                                         \
 __attribute__((always_inline))                                                 \
 __STATIC_INLINE   t  __svc##f (t1 a1) {                                        \
-  SVC_SETUP_PSP                                                                \
   return svc##f(svcRtx##f,a1);                                                 \
 }
 
@@ -177,7 +161,6 @@ __SVC_INDIRECT(0) t    svc##f (t(*)(t1,t2),t1,t2);                             \
                   t svcRtx##f (t1 a1, t2 a2);                                  \
 __attribute__((always_inline))                                                 \
 __STATIC_INLINE   t  __svc##f (t1 a1, t2 a2) {                                 \
-  SVC_SETUP_PSP                                                                \
   return svc##f(svcRtx##f,a1,a2);                                              \
 }
 
@@ -194,7 +177,6 @@ __SVC_INDIRECT(0) t    svc##f (t(*)(t1,t2,t3),t1,t2,t3);                       \
                   t svcRtx##f (t1 a1, t2 a2, t3 a3);                           \
 __attribute__((always_inline))                                                 \
 __STATIC_INLINE   t  __svc##f (t1 a1, t2 a2, t3 a3) {                          \
-  SVC_SETUP_PSP                                                                \
   return svc##f(svcRtx##f,a1,a2,a3);                                           \
 }
 
@@ -211,7 +193,6 @@ __SVC_INDIRECT(0) t    svc##f (t(*)(t1,t2,t3,t4),t1,t2,t3,t4);                 \
                   t svcRtx##f (t1 a1, t2 a2, t3 a3, t4 a4);                    \
 __attribute__((always_inline))                                                 \
 __STATIC_INLINE   t  __svc##f (t1 a1, t2 a2, t3 a3, t4 a4) {                   \
-  SVC_SETUP_PSP                                                                \
   return svc##f(svcRtx##f,a1,a2,a3,a4);                                        \
 }
 


### PR DESCRIPTION
This is work in progress needing initial feedback on proposed changes.

The optimization we are proposing is to remove the SVC_SETUP_PSP on svc_indirect() calls and check for which stack(MSP or PSP) was active when SVC call was made and then using that stack pointer(MSP or PSP) accordingly in SVCHandler. By doing this we saved around 260 bytes of code space when I tried building a test with mbed-os and there will be some improvement in performance as well since calls to intrinsic macros like __get_CONTROL, __set_PSP, __get_MSP in SVC_SETUP_PSP can be avoided although I have not measured quantitatively. Adding @c1728p9 as well.