### PR TITLE
Fix alignment issue with Memorypool implementation - (Fixes issue: ht…

### DIFF
--- a/CMSIS/RTOS/Template/CPP/MemoryPool.h
+++ b/CMSIS/RTOS/Template/CPP/MemoryPool.h
@@ -54,7 +54,7 @@ private:
     osPoolId    _pool_id;
     osPoolDef_t _pool_def;
 #ifdef CMSIS_OS_RTX
-    uint32_t    _pool_m[3+((sizeof(T)+3)/4)*(pool_sz)];
+    uint32_t    _pool_m[OS_MEMORY_POOL_GET_ALIGNED_BLOCK_SIZE(sizeof(T))*(pool_sz)];
 #endif
 };
 

--- a/CMSIS/RTOS2/Include/cmsis_os2.h
+++ b/CMSIS/RTOS2/Include/cmsis_os2.h
@@ -631,7 +631,11 @@ osStatus_t osSemaphoreDelete (osSemaphoreId_t semaphore_id);
  
  
 //  ==== Memory Pool Management Functions ====
- 
+
+// Macro to capture the knowledge of alignment requirements for block_size, so clients can use this macro
+// instead of replicating the alignment knowledge locally.
+#define          OS_MEMORY_POOL_GET_ALIGNED_BLOCK_SIZE(unaligned_block_size)    ( (unaligned_block_size + 3U) & ~3UL ) 
+
 /// Create and Initialize a Memory Pool object.
 /// \param[in]     block_count   maximum number of memory blocks in memory pool.
 /// \param[in]     block_size    memory block size in bytes.

--- a/CMSIS/RTOS2/RTX/Source/rtx_mempool.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_mempool.c
@@ -202,7 +202,7 @@ osMemoryPoolId_t svcRtxMemoryPoolNew (uint32_t block_count, uint32_t block_size,
     EvrRtxMemoryPoolError(NULL, osErrorParameter);
     return NULL;
   }
-  block_size = (block_size + 3U) & ~3UL;
+  block_size = OS_MEMORY_POOL_GET_ALIGNED_BLOCK_SIZE( block_size );
   if ((__CLZ(block_count) + __CLZ(block_size)) < 32) {
     EvrRtxMemoryPoolError(NULL, osErrorParameter);
     return NULL;


### PR DESCRIPTION
Proposed fix for mbed-os issue - https://github.com/ARMmbed/mbed-os/issues/4910. Please review.

Note that there is another pull request for this issue in mbed-os repo - https://github.com/ARMmbed/mbed-os/pull/4941

This fix is little different that it captures the knowledge of alignment in CMSIS in cmsis_os2.h header file. The alignment requirement should not be replicated in different places and should be captured by the platform(in this case its CMSIS) so other clients like MemoryPool.h can use that to get the aligned block size instead of duplicating the alignment knowledge. This also provides better maintenance long term. Adding @c1728p9 as well. 