### PR TITLE
Systick handler switch to secure/nonsecure

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/ARM/irq_armv8mbl.s
+++ b/CMSIS/RTOS2/RTX/Source/ARM/irq_armv8mbl.s
@@ -225,8 +225,9 @@ Sys_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-                LSLS     R7,R7,#25              ; Check domain of interrupted thread
-                BMI      Sys_ContextSave1       ; Branch if secure
+                MOV      R0,LR                  ; Get EXC_RETURN
+                LSLS     R0,R0,#25              ; Check domain of interrupted thread
+                BPL      Sys_ContextSave1       ; Branch if non-secure
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2

--- a/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mbl.S
+++ b/CMSIS/RTOS2/RTX/Source/GCC/irq_armv8mbl.S
@@ -229,8 +229,9 @@ Sys_ContextSave:
         BL       TZ_StoreContext_S      // Store secure context
         MOV      LR,R7                  // Set EXC_RETURN
         POP      {R1,R2,R3,R7}          // Restore registers
-        LSLS     R7,R7,#25              // Check domain of interrupted thread
-        BMI      Sys_ContextSave1       // Branch if secure
+        MOV      R0,LR                  // Get EXC_RETURN
+        LSLS     R0,R0,#25              // Check domain of interrupted thread
+        BPL      Sys_ContextSave1       // Branch if non-secure
         MRS      R0,PSP                 // Get PSP
         STR      R0,[R1,#TCB_SP_OFS]    // Store SP
         B        Sys_ContextSave2

--- a/CMSIS/RTOS2/RTX/Source/IAR/irq_armv8mbl_common.s
+++ b/CMSIS/RTOS2/RTX/Source/IAR/irq_armv8mbl_common.s
@@ -218,8 +218,9 @@ Sys_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-                LSLS     R7,R7,#25              ; Check domain of interrupted thread
-                BMI      Sys_ContextSave1       ; Branch if secure
+                MOV      R0,LR                  ; Get EXC_RETURN
+                LSLS     R0,R0,#25              ; Check domain of interrupted thread
+                BPL      Sys_ContextSave1       ; Branch if non-secure
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2


### PR DESCRIPTION
Switch to secure/nonsecure context save/restore is based on 6th bit in LR register, correct the bug (R7 instead of LR was used for decision)

Issue: https://github.com/ARM-software/CMSIS_5/issues/257