### PR TITLE
RTOS2/RTX5: Enhanced ThreadTerminate to not allow termination of idle…

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_thread.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_thread.c
@@ -1194,6 +1194,13 @@ osStatus_t svcRtxThreadTerminate (osThreadId_t thread_id) {
     return osErrorParameter;
   }
 
+  // Don't allow termination of timer or idle thread
+  if ((thread == osRtxInfo.timer.thread) ||
+      (thread == osRtxInfo.thread.idle)) {
+    EvrRtxThreadError(thread, osErrorParameter);
+    return osErrorResource;
+  }
+
   // Check object state
   switch (thread->state & osRtxThreadStateMask) {
     case osRtxThreadRunning:


### PR DESCRIPTION
… or timer threads.

Terminating these internal RTX threads leads to undefined behavior and may crash the system.
We should decide whether
- not to expose thread ids of these threads to the outside at all, i.e. through osThreadEnumerate, or
- not to allow termination of these threads.

This patch catches termination of these threads.