### PR TITLE
Core(M): Fix -Wundef for __ARM_FEATURE_DSP

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -1536,7 +1536,7 @@ __STATIC_FORCEINLINE uint32_t __STLEX(uint32_t value, volatile uint32_t *ptr)
   @{
 */
 
-#if (__ARM_FEATURE_DSP == 1)                             /* ToDo ARMCLANG: This should be ARCH >= ARMv7-M + SIMD */
+#if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))  /* ToDo ARMCLANG: This should be ARCH >= ARMv7-M + SIMD */
 
 __STATIC_FORCEINLINE uint32_t __SADD8(uint32_t op1, uint32_t op2)
 {


### PR DESCRIPTION
This prevents multiple warnings when compiling with GCC
```
ext/cmsis/cmsis_gcc.h:1539:6: warning: "__ARM_FEATURE_DSP" is not defined, evaluates to 0 [-Wundef]
 #if (__ARM_FEATURE_DSP == 1)                             /* ToDo ARMCLANG: This should be ARCH >= ARMv7-M + SIMD */
      ^~~~~~~~~~~~~~~~~
```

I also fixed the same issue for ICC.

@JonatanAntoni: I believe the `ToDo` does not apply anymore, since you now have a separate header for armclang anyways. I took the liberty of removing it, is that correct?