### PR TITLE
Update cmsis_os.h

### DIFF
--- a/CMSIS/RTOS/RTX/INC/cmsis_os.h
+++ b/CMSIS/RTOS/RTX/INC/cmsis_os.h
@@ -67,6 +67,7 @@
 #define os_InRegs
 #endif
 
+#ifndef __NO_RETURN
 #if   defined(__CC_ARM)
 #define __NO_RETURN __declspec(noreturn)
 #elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
@@ -78,6 +79,7 @@
 #else
 #define __NO_RETURN
 #endif
+#endif // __NO_RETURN
 
 #include <stdint.h>
 #include <stddef.h>


### PR DESCRIPTION
If compiled with ARM Compiler V6 a warning is generated (see Log Output below)
Adding an #ifndef __NO_RETURN to cmsis_os.h resolves this problem.

C:/Keil/Keil_v5/ARM/PACK/ARM/CMSIS/5.2.0/CMSIS/RTOS/RTX/INC\cmsis_os.h(73): warning: '__NO_RETURN' macro redefined [-Wmacro-redefined] #define NO_RETURN attribute__((noreturn))
C:/Keil/Keil_v5/ARM/PACK/ARM/CMSIS/5.2.0/CMSIS/Include/cmsis_armclang.h(50): note: previous definition is here
  #define NO_RETURN                            attribute__((__noreturn__))
1 warning generated.