### PR TITLE
Rtx5: inhibit 'unused parameter' warning when RtxTimerThread is empty…

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_lib.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_lib.c
@@ -219,7 +219,7 @@ static const osMessageQueueAttr_t os_timer_mq_attr = {
 #else
 
 extern void osRtxTimerThread (void *argument);
-       void osRtxTimerThread (void *argument) {}
+       void osRtxTimerThread (void *argument __attribute__((unused))) {}
 
 #endif  // ((OS_TIMER_THREAD_STACK_SIZE != 0) && (OS_TIMER_CB_QUEUE != 0))
 


### PR DESCRIPTION
… and compile with '-Wextra' flag