### PR TITLE
Update cmsis_iccarm.h

### DIFF
--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -150,7 +150,7 @@
 #endif
 
 #ifndef   __RESTRICT
-  #define __RESTRICT            restrict
+  #define __RESTRICT            __restrict
 #endif
 
 #ifndef   __STATIC_INLINE


### PR DESCRIPTION
Changing the definition of __RESTRICT to be __restrict, which is consistent with the other toolchains and works for both C and C++.