### PR TITLE
fixes to support C++17 in mixed-language headers

### DIFF
--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -43,9 +43,9 @@
 #ifndef   __STATIC_INLINE
   #define __STATIC_INLINE                        static __inline
 #endif
-#ifndef   __STATIC_FORCEINLINE                 
+#ifndef   __STATIC_FORCEINLINE
   #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static __inline
-#endif                                           
+#endif
 #ifndef   __NO_RETURN
   #define __NO_RETURN                            __attribute__((__noreturn__))
 #endif
@@ -109,6 +109,11 @@
 #endif
 #ifndef   __RESTRICT
   #define __RESTRICT                             __restrict
+#endif
+#if (__cplusplus - 0) >= 201703L
+  #define __REGISTER
+#else
+  #define __REGISTER                             register
 #endif
 
 
@@ -237,7 +242,7 @@ __STATIC_FORCEINLINE uint32_t __get_xPSR(void)
  */
 __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, psp"  : "=r" (result) );
   return(result);
@@ -252,7 +257,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
   return(result);
@@ -291,7 +296,7 @@ __STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
  */
 __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, msp" : "=r" (result) );
   return(result);
@@ -306,7 +311,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
   return(result);
@@ -346,7 +351,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
   return(result);
@@ -570,7 +575,7 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence zero is returned always in non-secure
   mode.
-  
+
   \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
   \return               PSPLIM Register value
  */
@@ -581,7 +586,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
     // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
   return result;
 #endif
@@ -603,7 +608,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
   return result;
 #endif
@@ -616,7 +621,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence the write is silently ignored in non-secure
   mode.
-  
+
   \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
   \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
  */
@@ -669,7 +674,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, msplim" : "=r" (result) );
   return result;
 #endif
@@ -691,7 +696,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
   return result;
 #endif

--- a/CMSIS/Core/Include/cmsis_compiler.h
+++ b/CMSIS/Core/Include/cmsis_compiler.h
@@ -261,6 +261,12 @@
   #error Unknown compiler.
 #endif
 
+/* Support the register storage class specifier in mixed-language
+ * headers that might be referenced when using a C++17 or later
+ * compiler. */
+#ifndef __REGISTER
+#define __REGISTER register
+#endif
+
 
 #endif /* __CMSIS_COMPILER_H */
-

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -113,6 +113,11 @@
 #ifndef   __RESTRICT
   #define __RESTRICT                             __restrict
 #endif
+#if (__cplusplus - 0) >= 201703L
+  #define __REGISTER
+#else
+  #define __REGISTER                             register
+#endif
 
 
 /* ###########################  Core Function Access  ########################### */
@@ -246,7 +251,7 @@ __STATIC_FORCEINLINE uint32_t __get_xPSR(void)
  */
 __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, psp"  : "=r" (result) );
   return(result);
@@ -261,7 +266,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
   return(result);
@@ -300,7 +305,7 @@ __STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
  */
 __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, msp" : "=r" (result) );
   return(result);
@@ -315,7 +320,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
   return(result);
@@ -355,7 +360,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
 {
-  register uint32_t result;
+  __REGISTER uint32_t result;
 
   __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
   return(result);
@@ -596,7 +601,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
     // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
   return result;
 #endif
@@ -617,7 +622,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
   return result;
 #endif
@@ -683,7 +688,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, msplim" : "=r" (result) );
   return result;
 #endif
@@ -705,7 +710,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  __REGISTER uint32_t result;
   __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
   return result;
 #endif

--- a/CMSIS/Core/Include/core_cm7.h
+++ b/CMSIS/Core/Include/core_cm7.h
@@ -2308,9 +2308,9 @@ __STATIC_INLINE void SCB_EnableDCache (void)
 __STATIC_INLINE void SCB_DisableDCache (void)
 {
   #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    register uint32_t ccsidr;
-    register uint32_t sets;
-    register uint32_t ways;
+    __REGISTER uint32_t ccsidr;
+    __REGISTER uint32_t sets;
+    __REGISTER uint32_t ways;
 
     SCB->CSSELR = 0U; /*(0U << 1U) | 0U;*/  /* Level 1 data cache */
     __DSB();


### PR DESCRIPTION
First commit satisfies the basic needs of issue #345.  These modifications have been tested with gcc-arm-none-eabi-7-2017-q4-major (GCC 7.2.1) with c++14 and c++17.  They've also been made for armclang, but I have not tested that toolchain.

The second commit generalizes it slightly, to cover the use of the deprecated/removed qualifier in the cm7 header (the only other appearance of the qualifier in the Core headers).  I have no cm7 code so have not been able to test this change.

