### PR TITLE
TZ context function required only during secure build

### DIFF
--- a/CMSIS/RTOS2/RTX/Examples/TrustZoneV8M/RTOS/CM33_s/tz_context.c
+++ b/CMSIS/RTOS2/RTX/Examples/TrustZoneV8M/RTOS/CM33_s/tz_context.c
@@ -24,6 +24,7 @@
  * Title:        Context Management for ARMv8-M TrustZone - Sample implementation
  *
  *---------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
  
 #include "RTE_Components.h"
 #include CMSIS_device_header
@@ -201,3 +202,4 @@ uint32_t TZ_StoreContext_S (TZ_MemoryId_t id) {
 
   return 1U;    // Success
 }
+#endif


### PR DESCRIPTION
Context Management functions are required only in secure build. In Mbed OS like applications, which have common build system a user might accidentally include function definitions in non-secure build, hence guard is required.

@bulislaw @JonatanAntoni  