### PR TITLE
Split rfft_fast_init_f32 into separate initializer functions.

### DIFF
--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -2224,6 +2224,23 @@ arm_status arm_rfft_fast_init_f32 (
    arm_rfft_fast_instance_f32 * S,
    uint16_t fftLen);
 
+arm_status arm_rfft_32_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+arm_status arm_rfft_64_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+arm_status arm_rfft_128_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+arm_status arm_rfft_256_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+arm_status arm_rfft_512_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+arm_status arm_rfft_1024_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+arm_status arm_rfft_2048_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+arm_status arm_rfft_4096_fast_init_f32 ( arm_rfft_fast_instance_f32 * S );
+
+
 void arm_rfft_fast_f32(
   arm_rfft_fast_instance_f32 * S,
   float32_t * p, float32_t * pOut,

--- a/CMSIS/DSP/Source/TransformFunctions/arm_rfft_fast_init_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_rfft_fast_init_f32.c
@@ -247,76 +247,40 @@ arm_status arm_rfft_fast_init_f32(
   arm_rfft_fast_instance_f32 * S,
   uint16_t fftLen)
 {
-  arm_cfft_instance_f32 * Sint;
-  /*  Initialise the default arm status */
-  arm_status status = ARM_MATH_SUCCESS;
-  /*  Initialise the FFT length */
-  Sint = &(S->Sint);
-  Sint->fftLen = fftLen/2;
-  S->fftLenRFFT = fftLen;
+  typedef arm_status(*fft_init_ptr)( arm_rfft_fast_instance_f32 *);
+  fft_init_ptr fptr = 0x0;
 
-  /*  Initializations of structure parameters depending on the FFT length */
-  switch (Sint->fftLen)
+  switch (fftLen)
   {
+  case 4096U:
+    fptr = arm_rfft_4096_fast_init_f32;
+    break;
   case 2048U:
-    /*  Initializations of structure parameters for 2048 point FFT */
-    /*  Initialise the bit reversal table length */
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_2048_TABLE_LENGTH;
-    /*  Initialise the bit reversal table pointer */
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable2048;
-    /*  Initialise the Twiddle coefficient pointers */
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_2048;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_4096;
+    fptr = arm_rfft_2048_fast_init_f32;
     break;
   case 1024U:
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_1024_TABLE_LENGTH;
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable1024;
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_1024;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_2048;
+    fptr = arm_rfft_1024_fast_init_f32;
     break;
   case 512U:
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_512_TABLE_LENGTH;
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable512;
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_512;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_1024;
+    fptr = arm_rfft_512_fast_init_f32;
     break;
   case 256U:
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_256_TABLE_LENGTH;
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable256;
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_256;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_512;
+    fptr = arm_rfft_256_fast_init_f32;
     break;
   case 128U:
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_128_TABLE_LENGTH;
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable128;
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_128;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_256;
+    fptr = arm_rfft_128_fast_init_f32;
     break;
   case 64U:
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_64_TABLE_LENGTH;
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable64;
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_64;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_128;
+    fptr = arm_rfft_64_fast_init_f32;
     break;
   case 32U:
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_32_TABLE_LENGTH;
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable32;
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_32;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_64;
-    break;
-  case 16U:
-    Sint->bitRevLength = ARMBITREVINDEXTABLE_16_TABLE_LENGTH;
-    Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable16;
-		Sint->pTwiddle     = (float32_t *) twiddleCoef_16;
-		S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_32;
-    break;
-  default:
-    /*  Reporting argument error if fftSize is not valid value */
-    status = ARM_MATH_ARGUMENT_ERROR;
+    fptr = arm_rfft_32_fast_init_f32;
     break;
   }
 
-  return (status);
+  if( ! fptr ) return ARM_MATH_ARGUMENT_ERROR;
+  return fptr( S );
+
 }
 
 /**

--- a/CMSIS/DSP/Source/TransformFunctions/arm_rfft_fast_init_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_rfft_fast_init_f32.c
@@ -38,6 +38,199 @@
  * @{
  */
 
+
+/**
+* @brief  Initialization function for the 32pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_32_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 16U;
+  S->fftLenRFFT = 32U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_16_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable16;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_16;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_32;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
+/**
+* @brief  Initialization function for the 64pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_64_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 32U;
+  S->fftLenRFFT = 64U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_32_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable32;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_32;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_64;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
+/**
+* @brief  Initialization function for the 128pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_128_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 64U;
+  S->fftLenRFFT = 128U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_64_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable64;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_64;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_128;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
+/**
+* @brief  Initialization function for the 256pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_256_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 128U;
+  S->fftLenRFFT = 256U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_128_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable128;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_128;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_256;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
+/**
+* @brief  Initialization function for the 512pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_512_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 256U;
+  S->fftLenRFFT = 512U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_256_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable256;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_256;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_512;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
+/**
+* @brief  Initialization function for the 1024pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_1024_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 512U;
+  S->fftLenRFFT = 1024U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_512_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable512;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_512;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_1024;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
+/**
+* @brief  Initialization function for the 2048pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_2048_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 1024U;
+  S->fftLenRFFT = 2048U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_1024_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable1024;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_1024;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_2048;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
+/**
+* @brief  Initialization function for the 4096pt floating-point real FFT.
+* @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.
+* @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if an error is detected.
+*/
+arm_status arm_rfft_4096_fast_init_f32( arm_rfft_fast_instance_f32 * S ) {
+
+  arm_cfft_instance_f32 * Sint;
+
+  if( !S ) return ARM_MATH_ARGUMENT_ERROR;
+
+  Sint = &(S->Sint);
+  Sint->fftLen = 2048U;
+  S->fftLenRFFT = 1024U;
+
+  Sint->bitRevLength = ARMBITREVINDEXTABLE_2048_TABLE_LENGTH;
+  Sint->pBitRevTable = (uint16_t *)armBitRevIndexTable2048;
+  Sint->pTwiddle     = (float32_t *) twiddleCoef_2048;
+  S->pTwiddleRFFT    = (float32_t *) twiddleCoef_rfft_4096;
+
+  return ARM_MATH_SUCCESS;
+
+}
+
 /**
 * @brief  Initialization function for the floating-point real FFT.
 * @param[in,out] *S             points to an arm_rfft_fast_instance_f32 structure.


### PR DESCRIPTION
The rationale here is that if the caller knows the size FFT they require
at compile time, only the look-up tables required for that size are
placed in the data segment (ROM).  This saves between ~40k to ~80k of
ROM when only using a single FFT size.