### PR TITLE
Remove `register` keyword from public headers

### DIFF
--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -237,7 +237,7 @@ __STATIC_FORCEINLINE uint32_t __get_xPSR(void)
  */
 __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp"  : "=r" (result) );
   return(result);
@@ -252,7 +252,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
   return(result);
@@ -291,7 +291,7 @@ __STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
  */
 __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp" : "=r" (result) );
   return(result);
@@ -306,7 +306,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
   return(result);
@@ -346,7 +346,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
   return(result);
@@ -581,7 +581,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
     // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
   return result;
 #endif
@@ -603,7 +603,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
   return result;
 #endif
@@ -669,7 +669,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, msplim" : "=r" (result) );
   return result;
 #endif
@@ -691,7 +691,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
   return result;
 #endif

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -246,7 +246,7 @@ __STATIC_FORCEINLINE uint32_t __get_xPSR(void)
  */
 __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp"  : "=r" (result) );
   return(result);
@@ -261,7 +261,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
   return(result);
@@ -300,7 +300,7 @@ __STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
  */
 __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp" : "=r" (result) );
   return(result);
@@ -315,7 +315,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
   return(result);
@@ -355,7 +355,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
   return(result);
@@ -596,7 +596,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
     // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
   return result;
 #endif
@@ -617,7 +617,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   // without main extensions, the non-secure PSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
   return result;
 #endif
@@ -683,7 +683,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, msplim" : "=r" (result) );
   return result;
 #endif
@@ -705,7 +705,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
   // without main extensions, the non-secure MSPLIM is RAZ/WI
   return 0U;
 #else
-  register uint32_t result;
+  uint32_t result;
   __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
   return result;
 #endif

--- a/CMSIS/Core/Include/core_cm7.h
+++ b/CMSIS/Core/Include/core_cm7.h
@@ -2308,9 +2308,9 @@ __STATIC_INLINE void SCB_EnableDCache (void)
 __STATIC_INLINE void SCB_DisableDCache (void)
 {
   #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    register uint32_t ccsidr;
-    register uint32_t sets;
-    register uint32_t ways;
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
 
     SCB->CSSELR = 0U; /*(0U << 1U) | 0U;*/  /* Level 1 data cache */
     __DSB();


### PR DESCRIPTION
In C++17 `register` keyword was removed. Current gcc 8.1.0 produces
following warning if `-std=c++17` flag is used:

warning: ISO C++17 does not allow 'register' storage class specifier
[-Wregister]

GCC almost completely ignores `register` keyword, with rare exception of
`-O0` when additional copy from/to stack may be generated.

For simplicity of the codebase it is better to just remove this
problematic keyword where it is not strictly required.

See: http://en.cppreference.com/w/cpp/language/storage_duration

Closes issue #345