### PR TITLE
rtos2: rtx5: ARMCC5: move the variables in .bss.os section to ZI section

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_lib.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_lib.c
@@ -33,6 +33,14 @@
 #endif
 #include "rtx_evr.h"
 
+// ARMCC 5 requires the zero_init section attribute to be present or the section is
+// put to the data section and not to bss. Other compilers will issue a warning for
+// unknown section attribute, so we need to use a macro for this.
+#if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 6010050))
+#define SECTION_ZERO_INIT(name) __attribute__((section(name), zero_init))
+#else
+#define SECTION_ZERO_INIT(name) __attribute__((section(name)))
+#endif
 
 // System Configuration
 // ====================
@@ -43,7 +51,7 @@
 #error "Invalid Dynamic Memory size!"
 #endif
 static uint64_t os_mem[OS_DYNAMIC_MEM_SIZE/8] \
-__attribute__((section(".bss.os")));
+SECTION_ZERO_INIT(".bss.os");
 #endif
 
 // Kernel Tick Frequency
@@ -53,7 +61,7 @@ __attribute__((section(".bss.os")));
 
 // ISR FIFO Queue
 static void *os_isr_queue[OS_ISR_FIFO_QUEUE] \
-__attribute__((section(".bss.os")));
+SECTION_ZERO_INIT(".bss.os");
 
 
 // Thread Configuration
@@ -80,12 +88,12 @@ __attribute__((section(".bss.os")));
 
 // Thread Control Blocks
 static osRtxThread_t os_thread_cb[OS_THREAD_NUM] \
-__attribute__((section(".bss.os.thread.cb")));
+SECTION_ZERO_INIT(".bss.os.thread.cb");
 
 // Thread Default Stack
 #if (OS_THREAD_DEF_STACK_NUM != 0)
 static uint64_t os_thread_def_stack[OS_THREAD_DEF_STACK_NUM*(OS_STACK_SIZE/8)] \
-__attribute__((section(".bss.os.thread.stack")));
+SECTION_ZERO_INIT(".bss.os.thread.stack");
 #endif
 
 // Memory Pool for Thread Control Blocks
@@ -103,7 +111,7 @@ __attribute__((section(".data.os.thread.mpi"))) =
 // Memory Pool for Thread Stack
 #if (OS_THREAD_USER_STACK_SIZE != 0)
 static uint64_t os_thread_stack[2 + OS_THREAD_NUM + (OS_THREAD_USER_STACK_SIZE/8)] \
-__attribute__((section(".bss.os.thread.stack")));
+SECTION_ZERO_INIT(".bss.os.thread.stack");
 #endif
 
 #endif  // (OS_THREAD_OBJ_MEM != 0)
@@ -119,11 +127,11 @@ extern void osRtxThreadStackCheck (void);
 
 // Idle Thread Control Block
 static osRtxThread_t os_idle_thread_cb \
-__attribute__((section(".bss.os.thread.cb")));
+SECTION_ZERO_INIT(".bss.os.thread.cb");
 
 // Idle Thread Stack
 static uint64_t os_idle_thread_stack[OS_IDLE_THREAD_STACK_SIZE/8] \
-__attribute__((section(".bss.os.thread.stack")));
+SECTION_ZERO_INIT(".bss.os.thread.stack");
 
 // Idle Thread Attributes
 static const osThreadAttr_t os_idle_thread_attr = {
@@ -158,7 +166,7 @@ static const osThreadAttr_t os_idle_thread_attr = {
 
 // Timer Control Blocks
 static osRtxTimer_t os_timer_cb[OS_TIMER_NUM] \
-__attribute__((section(".bss.os.timer.cb")));
+SECTION_ZERO_INIT(".bss.os.timer.cb");
 
 // Memory Pool for Timer Control Blocks
 static osRtxMpInfo_t os_mpi_timer \
@@ -176,11 +184,11 @@ __attribute__((section(".data.os.timer.mpi"))) =
 
 // Timer Thread Control Block
 static osRtxThread_t os_timer_thread_cb \
-__attribute__((section(".bss.os.thread.cb")));
+SECTION_ZERO_INIT(".bss.os.thread.cb");
 
 // Timer Thread Stack
 static uint64_t os_timer_thread_stack[OS_TIMER_THREAD_STACK_SIZE/8] \
-__attribute__((section(".bss.os.thread.stack")));
+SECTION_ZERO_INIT(".bss.os.thread.stack");
 
 // Timer Thread Attributes
 static const osThreadAttr_t os_timer_thread_attr = {
@@ -206,11 +214,11 @@ static const osThreadAttr_t os_timer_thread_attr = {
 
 // Timer Message Queue Control Block
 static osRtxMessageQueue_t os_timer_mq_cb \
-__attribute__((section(".bss.os.msgqueue.cb")));
+SECTION_ZERO_INIT(".bss.os.msgqueue.cb");
 
 // Timer Message Queue Data
 static uint32_t os_timer_mq_data[osRtxMessageQueueMemSize(OS_TIMER_CB_QUEUE,8)/4] \
-__attribute__((section(".bss.os.msgqueue.mem")));
+SECTION_ZERO_INIT(".bss.os.msgqueue.mem");
 
 // Timer Message Queue Attributes
 static const osMessageQueueAttr_t os_timer_mq_attr = {
@@ -241,7 +249,7 @@ extern void osRtxTimerThread (void *argument);
 
 // Event Flags Control Blocks
 static osRtxEventFlags_t os_ef_cb[OS_EVFLAGS_NUM] \
-__attribute__((section(".bss.os.evflags.cb")));
+SECTION_ZERO_INIT(".bss.os.evflags.cb");
 
 // Memory Pool for Event Flags Control Blocks
 static osRtxMpInfo_t os_mpi_ef \
@@ -262,7 +270,7 @@ __attribute__((section(".data.os.evflags.mpi"))) =
 
 // Mutex Control Blocks
 static osRtxMutex_t os_mutex_cb[OS_MUTEX_NUM] \
-__attribute__((section(".bss.os.mutex.cb")));
+SECTION_ZERO_INIT(".bss.os.mutex.cb");
 
 // Memory Pool for Mutex Control Blocks
 static osRtxMpInfo_t os_mpi_mutex \
@@ -283,7 +291,7 @@ __attribute__((section(".data.os.mutex.mpi"))) =
 
 // Semaphore Control Blocks
 static osRtxSemaphore_t os_semaphore_cb[OS_SEMAPHORE_NUM] \
-__attribute__((section(".bss.os.semaphore.cb")));
+SECTION_ZERO_INIT(".bss.os.semaphore.cb");
 
 // Memory Pool for Semaphore Control Blocks
 static osRtxMpInfo_t os_mpi_semaphore \
@@ -304,7 +312,7 @@ __attribute__((section(".data.os.semaphore.mpi"))) =
 
 // Memory Pool Control Blocks
 static osRtxMemoryPool_t os_mp_cb[OS_MEMPOOL_NUM] \
-__attribute__((section(".bss.os.mempool.cb")));
+SECTION_ZERO_INIT(".bss.os.mempool.cb");
 
 // Memory Pool for Memory Pool Control Blocks
 static osRtxMpInfo_t os_mpi_mp \
@@ -317,7 +325,7 @@ __attribute__((section(".data.os.mempool.mpi"))) =
 #error "Invalid Data Memory size for Memory Pools!"
 #endif
 static uint64_t os_mp_data[2 + OS_MEMPOOL_NUM + (OS_MEMPOOL_DATA_SIZE/8)] \
-__attribute__((section(".bss.os.mempool.mem")));
+SECTION_ZERO_INIT(".bss.os.mempool.mem");
 #endif
 
 #endif  // (OS_MEMPOOL_OBJ_MEM != 0)
@@ -334,7 +342,7 @@ __attribute__((section(".bss.os.mempool.mem")));
 
 // Message Queue Control Blocks
 static osRtxMessageQueue_t os_mq_cb[OS_MSGQUEUE_NUM] \
-__attribute__((section(".bss.os.msgqueue.cb")));
+SECTION_ZERO_INIT(".bss.os.msgqueue.cb");
 
 // Memory Pool for Message Queue Control Blocks
 static osRtxMpInfo_t os_mpi_mq \
@@ -347,7 +355,7 @@ __attribute__((section(".data.os.msgqueue.mpi"))) =
 #error "Invalid Data Memory size for Message Queues!"
 #endif
 static uint64_t os_mq_data[2 + OS_MSGQUEUE_NUM + (OS_MSGQUEUE_DATA_SIZE/8)] \
-__attribute__((section(".bss.os.msgqueue.mem")));
+SECTION_ZERO_INIT(".bss.os.msgqueue.mem");
 #endif
 
 #endif  // (OS_MSGQUEUE_OBJ_MEM != 0)
@@ -692,11 +700,11 @@ void osRtxKernelPreInit (void) {
 
 // Memory for libspace
 static uint32_t os_libspace[OS_THREAD_LIBSPACE_NUM+1][LIBSPACE_SIZE/4] \
-__attribute__((section(".bss.os.libspace")));
+SECTION_ZERO_INIT(".bss.os.libspace");
 
 // Thread IDs for libspace
 static osThreadId_t os_libspace_id[OS_THREAD_LIBSPACE_NUM] \
-__attribute__((section(".bss.os.libspace")));
+SECTION_ZERO_INIT(".bss.os.libspace");
 
 // Check if Kernel has been started
 static uint32_t os_kernel_is_active (void) {


### PR DESCRIPTION
The thread stacks and other large variables in rtx_lib.c were directed
to .bss.os section, which puts them to zero initialized section in GCC,
but on ARMC5 they were put to data section which consumes precious ROM.

In reality the data section compression may make this a NOP change,
but it will at least make the total results now more reliable.

Effects of this PR on the output of mbed compile of one application:
```
--8<--8<--
--- memory_before_bss_change.txt    2018-06-18 16:45:51.928844313 +0300
+++ memory_after_bss_change.txt     2018-06-18 16:57:27.753532437 +0300
@@ -5,6 +5,9 @@
 +----------------------------------------------------------+--------+-------+-------+
 | Module                                                   |  .text | .data |  .bss |
 +----------------------------------------------------------+--------+-------+-------+
@@ -366,7 +369,7 @@
 | mbed-os/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.o  |    801 |   164 |     0 |
-| mbed-os/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_lib.o     |    406 |  2117 |     0 |
+| mbed-os/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_lib.o     |    406 |     1 |  2116 |
 | mbed-os/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_memory.o  |    260 |     0 |     0 |
@@ -412,9 +415,9 @@
-| Subtotals                                                | 163559 |  3380 | 15168 |
+| Subtotals                                                | 163559 |  1264 | 17284 |
 +----------------------------------------------------------+--------+-------+-------+
 Total Static RAM memory (data + bss): 18548 bytes
-Total Flash memory (text + data): 166939 bytes
+Total Flash memory (text + data): 164823 bytes
```