### PR TITLE
events: fix semicolon for event timer macros

### DIFF
--- a/CMSIS/RTOS2/RTX/Include/rtx_evr.h
+++ b/CMSIS/RTOS2/RTX/Include/rtx_evr.h
@@ -833,7 +833,7 @@ extern void EvrRtxThreadDelayCompleted (void);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_ERROR_DISABLE))
 extern void EvrRtxTimerError (osTimerId_t timer_id, int32_t status);
 #else
-#define EvrRtxTimerError(timer_id, status);
+#define EvrRtxTimerError(timer_id, status)
 #endif
 
 /**
@@ -844,7 +844,7 @@ extern void EvrRtxTimerError (osTimerId_t timer_id, int32_t status);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_CALLBACK_DISABLE))
 extern void EvrRtxTimerCallback (osTimerFunc_t func, void *argument);
 #else
-#define EvrRtxTimerCallback(func, argument);
+#define EvrRtxTimerCallback(func, argument)
 #endif
 
 /**
@@ -857,7 +857,7 @@ extern void EvrRtxTimerCallback (osTimerFunc_t func, void *argument);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_NEW_DISABLE))
 extern void EvrRtxTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, const osTimerAttr_t *attr);
 #else
-#define EvrRtxTimerNew(func, type, argument, attr);
+#define EvrRtxTimerNew(func, type, argument, attr)
 #endif
 
 /**
@@ -868,7 +868,7 @@ extern void EvrRtxTimerNew (osTimerFunc_t func, osTimerType_t type, void *argume
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_CREATED_DISABLE))
 extern void EvrRtxTimerCreated (osTimerId_t timer_id, const char *name);
 #else
-#define EvrRtxTimerCreated(timer_id, name);
+#define EvrRtxTimerCreated(timer_id, name)
 #endif
 
 /**
@@ -879,7 +879,7 @@ extern void EvrRtxTimerCreated (osTimerId_t timer_id, const char *name);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_GET_NAME_DISABLE))
 extern void EvrRtxTimerGetName (osTimerId_t timer_id, const char *name);
 #else
-#define EvrRtxTimerGetName(timer_id, name);
+#define EvrRtxTimerGetName(timer_id, name)
 #endif
 
 /**
@@ -890,7 +890,7 @@ extern void EvrRtxTimerGetName (osTimerId_t timer_id, const char *name);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_START_DISABLE))
 extern void EvrRtxTimerStart (osTimerId_t timer_id, uint32_t ticks);
 #else
-#define EvrRtxTimerStart(timer_id, ticks);
+#define EvrRtxTimerStart(timer_id, ticks)
 #endif
 
 /**
@@ -900,7 +900,7 @@ extern void EvrRtxTimerStart (osTimerId_t timer_id, uint32_t ticks);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_STARTED_DISABLE))
 extern void EvrRtxTimerStarted (osTimerId_t timer_id);
 #else
-#define EvrRtxTimerStarted(timer_id);
+#define EvrRtxTimerStarted(timer_id)
 #endif
 
 /**
@@ -910,7 +910,7 @@ extern void EvrRtxTimerStarted (osTimerId_t timer_id);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_STOP_DISABLE))
 extern void EvrRtxTimerStop (osTimerId_t timer_id);
 #else
-#define EvrRtxTimerStop(timer_id);
+#define EvrRtxTimerStop(timer_id)
 #endif
 
 /**
@@ -920,7 +920,7 @@ extern void EvrRtxTimerStop (osTimerId_t timer_id);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_STOPPED_DISABLE))
 extern void EvrRtxTimerStopped (osTimerId_t timer_id);
 #else
-#define EvrRtxTimerStopped(timer_id);
+#define EvrRtxTimerStopped(timer_id)
 #endif
 
 /**
@@ -931,7 +931,7 @@ extern void EvrRtxTimerStopped (osTimerId_t timer_id);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_IS_RUNNING_DISABLE))
 extern void EvrRtxTimerIsRunning (osTimerId_t timer_id, uint32_t running);
 #else
-#define EvrRtxTimerIsRunning(timer_id, running);
+#define EvrRtxTimerIsRunning(timer_id, running)
 #endif
 
 /**
@@ -941,7 +941,7 @@ extern void EvrRtxTimerIsRunning (osTimerId_t timer_id, uint32_t running);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_DELETE_DISABLE))
 extern void EvrRtxTimerDelete (osTimerId_t timer_id);
 #else
-#define EvrRtxTimerDelete(timer_id);
+#define EvrRtxTimerDelete(timer_id)
 #endif
 
 /**
@@ -951,7 +951,7 @@ extern void EvrRtxTimerDelete (osTimerId_t timer_id);
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_TIMER != 0) && !defined(EVR_RTX_TIMER_DESTROYED_DISABLE))
 extern void EvrRtxTimerDestroyed (osTimerId_t timer_id);
 #else
-#define EvrRtxTimerDestroyed(timer_id);
+#define EvrRtxTimerDestroyed(timer_id)
 #endif
 
 


### PR DESCRIPTION
Comes from https://github.com/ARMmbed/mbed-os/pull/7355. Thanks to @deepikabhavnani for finding.

@JonatanAntoni @RobertRostohar Please review