### PR TITLE
Fix define around EvrRtxKernelInitialized

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_evr.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_evr.c
@@ -326,7 +326,7 @@ __WEAK void EvrRtxKernelInitialize (void) {
 }
 #endif
 
-#if (!defined(EVR_RTX_DISABLE) && (OS_EVR_KERNEL != 0) && !defined(EVR_RTX_KERNEL_INITIALIZE_COMPLETED_DISABLE))
+#if (!defined(EVR_RTX_DISABLE) && (OS_EVR_KERNEL != 0) && !defined(EVR_RTX_KERNEL_INITIALIZED_DISABLE))
 __WEAK void EvrRtxKernelInitialized (void) {
 #if defined(RTE_Compiler_EventRecorder)
   (void)EventRecord2(EvtRtxKernelInitialized, 0U, 0U);


### PR DESCRIPTION
Rename the define EVR_RTX_KERNEL_INITIALIZE_COMPLETED_DISABLE to
EVR_RTX_KERNEL_INITIALIZED_DISABLE so it matches the reset of the
codebase.

The commit 858f429461e04921644f41eca9d7b63248434bd2 -
"RTX5: minor change in events (name consistency)" initially
changed this define but missed this one spot.