### PR TITLE
CMSIS-Core(A): Fixed the position of "extern "C""

### DIFF
--- a/CMSIS/Core_A/Include/core_ca.h
+++ b/CMSIS/Core_A/Include/core_ca.h
@@ -28,13 +28,12 @@
   #pragma clang system_header   /* treat file as system include file */
 #endif
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 #ifndef __CORE_CA_H_GENERIC
 #define __CORE_CA_H_GENERIC
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /*******************************************************************************
  *                 CMSIS definitions


### PR DESCRIPTION
Fixed a bug that compilation fails if core_ca.h is included twice.