### PR TITLE
CM3: Make ACTLR bit definitions conditional

### DIFF
--- a/CMSIS/Core/Include/core_cm3.h
+++ b/CMSIS/Core/Include/core_cm3.h
@@ -668,7 +668,7 @@ typedef struct
 #define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
 
 /* Auxiliary Control Register Definitions */
-
+#if defined (__CM3_REV) && (__CM3_REV >= 0x200U)
 #define SCnSCB_ACTLR_DISFOLD_Pos            2U                                         /*!< ACTLR: DISFOLD Position */
 #define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
 
@@ -677,6 +677,7 @@ typedef struct
 
 #define SCnSCB_ACTLR_DISMCYCINT_Pos         0U                                         /*!< ACTLR: DISMCYCINT Position */
 #define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+#endif
 
 /*@} end of group CMSIS_SCnotSCB */
 


### PR DESCRIPTION
The ACTLR register itself is conditional on chip revision, but its bit definitions were always defined.

Make the the bit definitions also conditional, so it is possible to produce portable code that sets DISDEFWBUF if available:

    #ifdef SCnSCB_ACTLR_DISDEFWBUF_Msk
       SCnSCB->ACTLR |= SCnSCB_ACTLR_DISDEFWBUF_Msk;
    #endif