### PR TITLE
RTX: make API more typesafe

### DIFF
--- a/CMSIS/RTOS2/Include/cmsis_os2.h
+++ b/CMSIS/RTOS2/Include/cmsis_os2.h
@@ -208,25 +208,32 @@ typedef enum {
  
  
 /// \details Thread ID identifies the thread.
-typedef void *osThreadId_t;
+struct osRtxThread_s;
+typedef struct osRtxThread_s *osThreadId_t;
  
 /// \details Timer ID identifies the timer.
-typedef void *osTimerId_t;
+struct osRtxTimer_s;
+typedef struct osRtxTimer_s *osTimerId_t;
  
 /// \details Event Flags ID identifies the event flags.
-typedef void *osEventFlagsId_t;
+struct osRtxEventFlags_s;
+typedef struct osRtxEventFlags_s *osEventFlagsId_t;
  
 /// \details Mutex ID identifies the mutex.
-typedef void *osMutexId_t;
+struct osRtxMutex_s;
+typedef struct osRtxMutex_s *osMutexId_t;
  
 /// \details Semaphore ID identifies the semaphore.
-typedef void *osSemaphoreId_t;
+struct osRtxSemaphore_s;
+typedef struct osRtxSemaphore_s *osSemaphoreId_t;
  
 /// \details Memory Pool ID identifies the memory pool.
-typedef void *osMemoryPoolId_t;
+struct osRtxMemoryPool_s;
+typedef struct osRtxMemoryPool_s *osMemoryPoolId_t;
  
 /// \details Message Queue ID identifies the message queue.
-typedef void *osMessageQueueId_t;
+struct osRtxMessageQueue_s;
+typedef struct osRtxMessageQueue_s *osMessageQueueId_t;
  
  
 #ifndef TZ_MODULEID_T

--- a/CMSIS/RTOS2/RTX/Include/rtx_os.h
+++ b/CMSIS/RTOS2/RTX/Include/rtx_os.h
@@ -163,7 +163,7 @@ typedef struct osRtxTimer_s {
 //  ==== Event Flags definitions ====
  
 /// Event Flags Control Block
-typedef struct {
+typedef struct osRtxEventFlags_s {
   uint8_t                          id;  ///< Object Identifier
   uint8_t              reserved_state;  ///< Object State (not used)
   uint8_t                       flags;  ///< Object Flags
@@ -195,7 +195,7 @@ typedef struct osRtxMutex_s {
 //  ==== Semaphore definitions ====
  
 /// Semaphore Control Block
-typedef struct {
+typedef struct osRtxSemaphore_s {
   uint8_t                          id;  ///< Object Identifier
   uint8_t              reserved_state;  ///< Object State (not used)
   uint8_t                       flags;  ///< Object Flags
@@ -220,7 +220,7 @@ typedef struct {
 } osRtxMpInfo_t;
  
 /// Memory Pool Control Block
-typedef struct {
+typedef struct osRtxMemoryPool_s {
   uint8_t                          id;  ///< Object Identifier
   uint8_t              reserved_state;  ///< Object State (not used)
   uint8_t                       flags;  ///< Object Flags
@@ -244,7 +244,7 @@ typedef struct osRtxMessage_s {
 } osRtxMessage_t;
  
 /// Message Queue Control Block
-typedef struct {
+typedef struct osRtxMessageQueue_s {
   uint8_t                          id;  ///< Object Identifier
   uint8_t              reserved_state;  ///< Object State (not used)
   uint8_t                       flags;  ///< Object Flags
@@ -262,7 +262,7 @@ typedef struct {
 //  ==== Generic Object definitions ====
  
 /// Generic Object Control Block
-typedef struct {
+typedef struct osRtxObject_s {
   uint8_t                          id;  ///< Object Identifier
   uint8_t                       state;  ///< Object State
   uint8_t                       flags;  ///< Object Flags


### PR DESCRIPTION
Actual API is very type unsafe because underlying opaque types are
simple 'void *' pointers and nearly everything can be casted implicitly
to it.

E.g.

| int a;
|
| osThreadFlagsSet(&a, 1);

will be accepted by C compilers with strictest warnings levels.

Patch makes 'osXXX_t' strongly typed so that such errors can be
detected at runtime.

Signed-off-by: Enrico Scholz <enrico.scholz@sigma-chemnitz.de>