### PR TITLE
Remove unnecessary inclusion of RTE_Components.h in RTX header

### DIFF
--- a/CMSIS/RTOS2/RTX/Include/rtx_evr.h
+++ b/CMSIS/RTOS2/RTX/Include/rtx_evr.h
@@ -38,8 +38,6 @@
 #define   OS_EVR_WAIT           OS_EVR_THREAD
 #endif
 
-#include "RTE_Components.h"
-
 #ifdef    RTE_Compiler_EventRecorder
 
 //lint -emacro((835,845),EventID) [MISRA Note 13]


### PR DESCRIPTION
One of the RTOS2 RTX headers, rtx_evr.h, includes directly the header RTE_Components.h, which seems to be not necessary as it is already included by RTX_Config.h.

With this patch the direct inclusion of the RTE_Components.h in rtx_evr.h is removed, rather than being put under the `#ifdef _RTE_`, as it seems to be redundant. If the inclusion is necessary, I still advise that to be put at least under the `#ifdef _RTE_`, so that builds that don't provide a RTE_Components.h will not fail.