### PR TITLE
IAR: LDRT et al must be asm volatile

### DIFF
--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -811,37 +811,37 @@ __packed struct  __iar_u32 { uint32_t v; };
   __IAR_FT uint8_t __LDRBT(volatile uint8_t *addr)
   {
     uint32_t res;
-    __ASM("LDRBT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
+    __ASM volatile ("LDRBT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
     return ((uint8_t)res);
   }
 
   __IAR_FT uint16_t __LDRHT(volatile uint16_t *addr)
   {
     uint32_t res;
-    __ASM("LDRHT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
+    __ASM volatile ("LDRHT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
     return ((uint16_t)res);
   }
 
   __IAR_FT uint32_t __LDRT(volatile uint32_t *addr)
   {
     uint32_t res;
-    __ASM("LDRT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
+    __ASM volatile ("LDRT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
     return res;
   }
 
   __IAR_FT void __STRBT(uint8_t value, volatile uint8_t *addr)
   {
-    __ASM("STRBT %1, [%0]" : : "r" (addr), "r" ((uint32_t)value) : "memory");
+    __ASM volatile ("STRBT %1, [%0]" : : "r" (addr), "r" ((uint32_t)value) : "memory");
   }
 
   __IAR_FT void __STRHT(uint16_t value, volatile uint16_t *addr)
   {
-    __ASM("STRHT %1, [%0]" : : "r" (addr), "r" ((uint32_t)value) : "memory");
+    __ASM volatile ("STRHT %1, [%0]" : : "r" (addr), "r" ((uint32_t)value) : "memory");
   }
 
   __IAR_FT void __STRT(uint32_t value, volatile uint32_t *addr)
   {
-    __ASM("STRT %1, [%0]" : : "r" (addr), "r" (value) : "memory");
+    __ASM volatile ("STRT %1, [%0]" : : "r" (addr), "r" (value) : "memory");
   }
 
 #endif /* (__CORTEX_M >= 0x03) */


### PR DESCRIPTION
As these functions take volatile pointers, the API is promising that the loads and stores will happen, so the assembler statements need volatile qualifiers too.

If the functions took non-volatile pointers, or had a separate non-volatile overload for C++, then the volatile could be omitted - the instructions are normal loads and stores with no side-effects.

GCC and clang assembler already is "asm volatile", and armcc uses intrinsics.

Relates to issue #499.