### PR TITLE
GCC: add WFI/WFE compiler barriers

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -839,7 +839,7 @@ __STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
   \brief   Wait For Interrupt
   \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
  */
-#define __WFI()                             __ASM volatile ("wfi")
+#define __WFI()                             __ASM volatile ("wfi":::"memory")
 
 
 /**
@@ -847,7 +847,7 @@ __STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
   \details Wait For Event is a hint instruction that permits the processor to enter
            a low-power state until one of a number of events occurs.
  */
-#define __WFE()                             __ASM volatile ("wfe")
+#define __WFE()                             __ASM volatile ("wfe":::"memory")
 
 
 /**

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -114,12 +114,12 @@
 /**
   \brief   Wait For Interrupt
  */
-#define __WFI()                             __ASM volatile ("wfi")
+#define __WFI()                             __ASM volatile ("wfi":::"memory")
 
 /**
   \brief   Wait For Event
  */
-#define __WFE()                             __ASM volatile ("wfe")
+#define __WFE()                             __ASM volatile ("wfe":::"memory")
 
 /**
   \brief   Send Event


### PR DESCRIPTION
Add "memory" clobber to __WFI and __WFE. Architecturally these should always be immediately preceded by a __DSB (eg to ensure the write buffer is drained). Without a barrier on WFI, the following compiler reordering would be permitted:

     __DSB();             __DSB();
     __WFI();       ->    val_in_ram = 3;
     val_in_ram = 3;      __WFI();

This could cause some power issues with the external bus not being idle.

The added barrier should have no impact on code size, assuming these instructions are always accompanied by DSB, as DSB does have its own memory clobber already.

SEV not modified as there are no issues with the equivalent reordering; we only need the SEV to not be reordered before the DSB, which is ensured by volatile.

Relates to issue #499.