### PR TITLE
IAR: RRX doesn't modify flags, but has flags as input

### DIFF
--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -572,7 +572,7 @@ __packed struct  __iar_u32 { uint32_t v; };
     __IAR_FT uint32_t __RRX(uint32_t value)
     {
       uint32_t result;
-      __ASM("RRX      %0, %1" : "=r"(result) : "r" (value) : "cc");
+      __ASM volatile("RRX      %0, %1" : "=r"(result) : "r" (value));
       return(result);
     }
 


### PR DESCRIPTION
<strike>Add missing "cc" clobber for RRX assembly in gcc and clang

(It's unclear how RRX could be meaningfully used from C without control of the C flag for input and output, but if this intrinsic exists, it must at least not upset the surrounding code by writing to the PSR).

"cc" clobber was already present in IAR asm, and armcc version uses the embedded assembler.
</strike>

IAR assembler version of RRX had a "cc" clobber for RRX, but this is unneeded - it doesn't modify the condition codes - it's not "RRXS".

Instead the assembler should have a volatile, as already seen in GCC and Clang versions to reflect the CC input to the instruction.

CMSIS intrinsics use "volatile" attributes to force ordering of instructions that work on the PSR, either input or output.

A "cc" clobber does not have that effect, at least in gcc; it only indicates "changes condition codes", not "reads condition codes", so CC-clobbering instructions can be reordered. This reflects that in general the compilers make no guarantees about preserving flag state between assembler sequences, meaning that __RRX will always be prone to unreliability.

But the volatile marker increases the chances of stuff coming out in the right order.