### PR TITLE
GCC/Clang: cope with __set_CPSR changing condition codes

### DIFF
--- a/CMSIS/Core_A/Include/cmsis_armclang.h
+++ b/CMSIS/Core_A/Include/cmsis_armclang.h
@@ -343,7 +343,7 @@ __STATIC_FORCEINLINE uint32_t __get_CPSR(void)
  */
 __STATIC_FORCEINLINE void __set_CPSR(uint32_t cpsr)
 {
-__ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "memory");
+__ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
 }
 
 /** \brief  Get Mode

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -519,7 +519,7 @@ __STATIC_FORCEINLINE uint32_t __get_CPSR(void)
  */
 __STATIC_FORCEINLINE void __set_CPSR(uint32_t cpsr)
 {
-__ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "memory");
+__ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
 }
 
 /** \brief  Get Mode


### PR DESCRIPTION
Add a "cc" clobber to `__set_CPSR` to reflect the fact that it could be changing the condition codes.