### PR TITLE
Core(A)/armclang: Remove ISB/DSB/DMB barriers

### DIFF
--- a/CMSIS/Core_A/Include/cmsis_armclang.h
+++ b/CMSIS/Core_A/Include/cmsis_armclang.h
@@ -127,29 +127,17 @@
 /**
   \brief   Instruction Synchronization Barrier
  */
-#define __ISB() do {\
-                   __schedule_barrier();\
-                   __builtin_arm_isb(0xF);\
-                   __schedule_barrier();\
-                } while (0U)
+#define __ISB()                           __builtin_arm_isb(0xF)
 
 /**
   \brief   Data Synchronization Barrier
  */
-#define __DSB() do {\
-                   __schedule_barrier();\
-                   __builtin_arm_dsb(0xF);\
-                   __schedule_barrier();\
-                } while (0U)
+#define __DSB()                           __builtin_arm_dsb(0xF)
 
 /**
   \brief   Data Memory Barrier
  */
-#define __DMB() do {\
-                   __schedule_barrier();\
-                   __builtin_arm_dmb(0xF);\
-                   __schedule_barrier();\
-                } while (0U)
+#define __DMB()                           __builtin_arm_dmb(0xF)
 
 /**
   \brief   Reverse byte order (32 bit)


### PR DESCRIPTION
Core(M) versions of files already do not have explicit barriers, so this makes Core(A) consistent - the built-ins are specified as having barriers anyway.