### PR TITLE
Revert "Core(M): Added memory clobbers to get_PRIMASK..."

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -383,7 +383,7 @@ __STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, primask" : "=r" (result) :: "memory");
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
   return(result);
 }
 
@@ -398,7 +398,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PRIMASK_NS(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) :: "memory");
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
   return(result);
 }
 #endif


### PR DESCRIPTION
GCC bug was fixed in October 2017 - change went to GCC 6.5, 7.3 and 8.1.

Remove the unnecessary memory clobbers to improve optimisation, on the assumption that people will have updated their compilers.

This reverts commit 35205629798192794d4918cef1d949141e32de4e.