### PR TITLE
GCC: ISB does not require a memory clobber

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -865,7 +865,7 @@ __STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
  */
 __STATIC_FORCEINLINE void __ISB(void)
 {
-  __ASM volatile ("isb 0xF":::"memory");
+  __ASM volatile ("isb 0xF");
 }
 
 

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -134,7 +134,7 @@
  */
 __STATIC_FORCEINLINE  void __ISB(void)
 {
-  __ASM volatile ("isb 0xF":::"memory");
+  __ASM volatile ("isb 0xF");
 }
 
 


### PR DESCRIPTION
ISB purely synchronises the instruction stream - there is no inherent need to include a memory clobber.

If memory accesses need to be synchronised, there would be some other neighbouring intrinsic such as DMB with a memory clobber, and this would synchronise against that via the volatile.

In other cases, this might be synchronising against just an MCR or similar, so avoiding the memory clobber in that case can improve optimisation - again ordering will be maintained via the volatile.