### PR TITLE
RTX5: Make rtx_core_ca.h cope with compiler in Thumb mode

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_core_ca.h
+++ b/CMSIS/RTOS2/RTX/Source/rtx_core_ca.h
@@ -104,26 +104,26 @@ __STATIC_INLINE uint32_t StackOffsetR0 (uint8_t stack_frame) {
 /// Get xPSR Register - emulate M profile: SP_usr - (8*4)
 /// \return      xPSR Register value
 #if defined(__CC_ARM)
+#pragma push
+#pragma arm
 static __asm    uint32_t __get_PSP (void) {
-  arm
   sub   sp, sp, #4
   stm   sp, {sp}^
   pop   {r0}
   sub   r0, r0, #32
   bx    lr
 }
+#pragma pop
 #else
 #ifdef __ICCARM__
 __arm
+#else
+__attribute__((target("arm")))
 #endif
 __STATIC_INLINE uint32_t __get_PSP (void) {
   register uint32_t ret;
 
   __ASM volatile (
-#ifndef __ICCARM__
-    ".syntax unified\n\t"
-    ".arm\n\t"
-#endif
     "sub  sp,sp,#4\n\t"
     "stm  sp,{sp}^\n\t"
     "pop  {%[ret]}\n\t"


### PR DESCRIPTION
Assembler in rtx_core_ca.h is on the whole unified syntax such that it should work fine if assembled as either ARM or Thumb-2.

The exception was `__get_PSP`, which uses STM^, which is only available in ARM state.

Flagging for this function was incorrect, except for IAR - it switched assembler state without telling the compiler, meaning that the resulting assembler output could be incorrect, and that the function itself would not be correctly marked as an ARM function - the CPU would enter in Thumb state.

Alternative fix would be to switch to System mode, which would work as either ARM or Thumb-2 assembler, like the rest of the file, but this is the minimal change.

Fixes #526.