### PR TITLE
Const-qualify all read-only pointers in CMSIS-DSP (#349)

### DIFF
--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/abs.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/abs.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_abs_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/add.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/add.c
@@ -1,8 +1,8 @@
 #include "ref.h"
 
 void ref_add_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/dot_prod.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/dot_prod.c
@@ -1,8 +1,8 @@
 #include "ref.h"
 
 void ref_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   uint32_t blockSize,
   float32_t * result)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/mult.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/mult.c
@@ -1,8 +1,8 @@
 #include "ref.h"
 
 void ref_mult_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/negate.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/negate.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_negate_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/offset.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/offset.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_offset_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t offset,
   float32_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/scale.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/scale.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_scale_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t scale,
   float32_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/sub.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/BasicMathFunctions/sub.c
@@ -1,8 +1,8 @@
 #include "ref.h"
 
 void ref_sub_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_conj.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_conj.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_cmplx_conj_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_dot_prod.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_dot_prod.c
@@ -1,8 +1,8 @@
 #include "ref.h"
 
 void ref_cmplx_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   uint32_t numSamples,
   float32_t * realResult,
   float32_t * imagResult)

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mag.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mag.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_cmplx_mag_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mag_squared.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mag_squared.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_cmplx_mag_squared_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mult_cmplx.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mult_cmplx.c
@@ -1,8 +1,8 @@
 #include "ref.h"
 
 void ref_cmplx_mult_cmplx_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mult_real.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/ComplexMathFunctions/cmplx_mult_real.c
@@ -1,8 +1,8 @@
 #include "ref.h"
 
 void ref_cmplx_mult_real_f32(
-  float32_t * pSrcCmplx,
-  float32_t * pSrcReal,
+  const float32_t * pSrcCmplx,
+  const float32_t * pSrcReal,
   float32_t * pCmplxDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/biquad.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/biquad.c
@@ -2,7 +2,7 @@
 
 void ref_biquad_cascade_df2T_f32(
 	const arm_biquad_cascade_df2T_instance_f32 * S,
-	float32_t * pSrc,
+	const float32_t * pSrc,
 	float32_t * pDst,
 	uint32_t blockSize)
 {
@@ -72,7 +72,7 @@ void ref_biquad_cascade_df2T_f32(
 
 void ref_biquad_cascade_stereo_df2T_f32(
 	const arm_biquad_cascade_stereo_df2T_instance_f32 * S,
-	float32_t * pSrc,
+	const float32_t * pSrc,
 	float32_t * pDst,
 	uint32_t blockSize)
 {
@@ -220,7 +220,7 @@ void ref_biquad_cascade_df2T_f64(
 
 void ref_biquad_cascade_df1_f32(
   const arm_biquad_casd_df1_inst_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
@@ -309,7 +309,7 @@ void ref_biquad_cas_df1_32x64_q31(
   q31_t *pIn = pSrc;                             /*  input pointer initialization  			*/
   q31_t *pOut = pDst;                            /*  output pointer initialization 			*/
   q63_t *pState = S->pState;                     /*  state pointer initialization  			*/
-  q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  			*/
+  const q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  			*/
   q63_t acc;                                     /*  accumulator                   			*/
   q31_t Xn1, Xn2;                                /*  Input Filter state variables  			*/
   q63_t Yn1, Yn2;                                /*  Output Filter state variables 			*/
@@ -401,7 +401,7 @@ void ref_biquad_cascade_df1_q31(
   q31_t *pIn = pSrc;                             /*  input pointer initialization  */
   q31_t *pOut = pDst;                            /*  output pointer initialization */
   q31_t *pState = S->pState;                     /*  pState pointer initialization */
-  q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
+  const q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
   q31_t Xn1, Xn2, Yn1, Yn2;                      /*  Filter state variables        */
   q31_t b0, b1, b2, a1, a2;                      /*  Filter coefficients           */
   q31_t Xn;                                      /*  temporary input               */
@@ -496,7 +496,7 @@ void ref_biquad_cascade_df1_fast_q31(
   q31_t *pIn = pSrc;                             /*  input pointer initialization  */
   q31_t *pOut = pDst;                            /*  output pointer initialization */
   q31_t *pState = S->pState;                     /*  pState pointer initialization */
-  q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
+  const q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
   q31_t Xn;                                      /*  temporary input               */
   int32_t shift = (int32_t) S->postShift + 1;    /*  Shift to be applied to the output */
   uint32_t sample, stage = S->numStages;         /*  loop counters                     */
@@ -576,7 +576,7 @@ void ref_biquad_cascade_df1_fast_q15(
 	q31_t acc;                                     			/*  Accumulator                              */
 	int32_t shift = (15 - (int32_t) S->postShift); 			/*  Post shift                               */
 	q15_t *pState = S->pState;                     			/*  State pointer                            */
-	q15_t *pCoeffs = S->pCoeffs;                   			/*  Coefficient pointer                      */
+	const q15_t *pCoeffs = S->pCoeffs;                   			/*  Coefficient pointer                      */
   uint32_t sample, stage = (uint32_t) S->numStages;   /*  Stage loop counter                          */
 
   do
@@ -651,7 +651,7 @@ void ref_biquad_cascade_df1_q15(
 	q63_t acc;                                     			/*  Accumulator                              */
 	int32_t shift = (15 - (int32_t) S->postShift); 			/*  Post shift                               */
 	q15_t *pState = S->pState;                     			/*  State pointer                            */
-	q15_t *pCoeffs = S->pCoeffs;                   			/*  Coefficient pointer                      */
+	const q15_t *pCoeffs = S->pCoeffs;                   			/*  Coefficient pointer                      */
   uint32_t sample, stage = (uint32_t) S->numStages;   /*  Stage loop counter                          */
 
   do

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/conv.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/conv.c
@@ -1,9 +1,9 @@
 #include "ref.h"
 
 void ref_conv_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t 		srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t 		srcBLen,
   float32_t * pDst)
 {
@@ -32,9 +32,9 @@ void ref_conv_f32(
 }
 
 arm_status ref_conv_partial_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst,
   uint32_t firstIndex,

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/correlate.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/correlate.c
@@ -1,9 +1,9 @@
 #include "ref.h"
 
 void ref_correlate_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst)
 {
@@ -91,9 +91,9 @@ void ref_correlate_q31(
   uint32_t srcBLen,
   q31_t * pDst)
 {
-  q31_t *pIn1 = pSrcA;                           /* inputA pointer               */
-  q31_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
-  q63_t sum;                                     /* Accumulators                  */
+  const q31_t *pIn1 = pSrcA;                     /* inputA pointer               */
+  const q31_t *pIn2 = pSrcB + (srcBLen - 1U);    /* inputB pointer               */
+  q63_t sum;                                     /* Accumulators                 */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */
   uint32_t tot = 0U;                             /* Length */
@@ -162,8 +162,8 @@ void ref_correlate_fast_q31(
   uint32_t srcBLen,
   q31_t * pDst)
 {
-  q31_t *pIn1 = pSrcA;                           /* inputA pointer               */
-  q31_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
+  const q31_t *pIn1 = pSrcA;                           /* inputA pointer               */
+  const q31_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
   q63_t sum;                                     /* Accumulators                  */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */
@@ -234,8 +234,8 @@ void ref_correlate_q15(
   uint32_t srcBLen,
   q15_t * pDst)
 {
-  q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
-  q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
+  const q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
+  const q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
   q63_t sum;                                     /* Accumulators                  */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */
@@ -305,8 +305,8 @@ void ref_correlate_fast_q15(
   uint32_t srcBLen,
   q15_t * pDst)
 {
-  q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
-  q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
+  const q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
+  const q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
   q63_t sum;                                     /* Accumulators                  */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */
@@ -377,8 +377,8 @@ void ref_correlate_fast_opt_q15(
   q15_t * pDst,
   q15_t * pScratch)
 {
-  q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
-  q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
+  const q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
+  const q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
   q31_t sum;                                     /* Accumulators                  */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */
@@ -448,8 +448,8 @@ void ref_correlate_q7(
   uint32_t srcBLen,
   q7_t * pDst)
 {
-  q7_t *pIn1 = pSrcA;                            /* inputA pointer */
-  q7_t *pIn2 = pSrcB + (srcBLen - 1U);           /* inputB pointer */
+  const q7_t *pIn1 = pSrcA;                            /* inputA pointer */
+  const q7_t *pIn2 = pSrcB + (srcBLen - 1U);           /* inputB pointer */
   q31_t sum;                                     /* Accumulator */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir.c
@@ -2,7 +2,7 @@
 
 void ref_fir_f32(
 	const arm_fir_instance_f32 * S,
-	float32_t * pSrc,
+	const float32_t * pSrc,
 	float32_t * pDst,
 	uint32_t blockSize)
 {
@@ -61,7 +61,7 @@ void ref_fir_q31(
   uint32_t blockSize)
 {
    q31_t *pState = S->pState;                 /* State pointer */
-   q31_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+   const q31_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
    q31_t *pStateCurnt;                        /* Points to the current sample of the state */
    uint32_t numTaps = S->numTaps;             /* Number of filter coefficients in the filter */
    uint32_t i;                    						/* Loop counters */
@@ -115,7 +115,7 @@ void ref_fir_fast_q31(
   uint32_t blockSize)
 {
    q31_t *pState = S->pState;                 /* State pointer */
-   q31_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+   const q31_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
    q31_t *pStateCurnt;                        /* Points to the current sample of the state */
    uint32_t numTaps = S->numTaps;             /* Number of filter coefficients in the filter */
    uint32_t i;                    						/* Loop counters */
@@ -169,7 +169,7 @@ void ref_fir_q15(
   uint32_t blockSize)
 {
    q15_t *pState = S->pState;                 /* State pointer */
-   q15_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+   const q15_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
    q15_t *pStateCurnt;                        /* Points to the current sample of the state */
    uint32_t numTaps = S->numTaps;             /* Number of filter coefficients in the filter */
    uint32_t i;                    						/* Loop counters */
@@ -223,7 +223,7 @@ void ref_fir_fast_q15(
   uint32_t blockSize)
 {
    q15_t *pState = S->pState;                 /* State pointer */
-   q15_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+   const q15_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
    q15_t *pStateCurnt;                        /* Points to the current sample of the state */
    uint32_t numTaps = S->numTaps;             /* Number of filter coefficients in the filter */
    uint32_t i;                    						/* Loop counters */
@@ -277,7 +277,7 @@ void ref_fir_q7(
   uint32_t blockSize)
 {
    q7_t *pState = S->pState;                 /* State pointer */
-   q7_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+   const q7_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
    q7_t *pStateCurnt;                        /* Points to the current sample of the state */
    uint32_t numTaps = S->numTaps;            /* Number of filter coefficients in the filter */
    uint32_t i;                    					 /* Loop counters */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_decimate.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_decimate.c
@@ -2,7 +2,7 @@
 
 void ref_fir_decimate_f32(
   const arm_fir_decimate_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
@@ -83,7 +83,7 @@ void ref_fir_decimate_q31(
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
   q63_t sum0;                                    /* Accumulator */
@@ -160,7 +160,7 @@ void ref_fir_decimate_fast_q31(
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
   q31_t sum0;                                    /* Accumulator */
@@ -237,7 +237,7 @@ void ref_fir_decimate_q15(
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
   q63_t sum0;                                    /* Accumulator */
@@ -314,7 +314,7 @@ void ref_fir_decimate_fast_q15(
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q15_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
   q31_t sum0;                                    /* Accumulator */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_interpolate.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_interpolate.c
@@ -2,7 +2,7 @@
 
 void ref_fir_interpolate_f32(
   const arm_fir_interpolate_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
@@ -98,7 +98,7 @@ void ref_fir_interpolate_q31(
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers */
 
@@ -199,7 +199,7 @@ void ref_fir_interpolate_q15(
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer                                            */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer                                      */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer                                      */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state                */
   q15_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers     */
   q63_t sum;                                     /* Accumulator */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_lattice.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_lattice.c
@@ -2,7 +2,7 @@
 
 void ref_fir_lattice_f32(
   const arm_fir_lattice_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
@@ -83,8 +83,8 @@ void ref_fir_lattice_q31(
   uint32_t blockSize)
 {
   q31_t *pState;                                 /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
-  q31_t *px;                                     /* temporary state pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *px;                                     /* temporary state pointer */
   q31_t *pk;                                     /* temporary coefficient pointer */
   q31_t fcurr, fnext, gcurr, gnext;              /* temporary variables */
   uint32_t numStages = S->numStages;             /* Length of the filter */
@@ -160,8 +160,8 @@ void ref_fir_lattice_q15(
   uint32_t blockSize)
 {
   q15_t *pState;                                 /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
-  q15_t *px;                                     /* temporary state pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *px;                                     /* temporary state pointer */
   q15_t *pk;                                     /* temporary coefficient pointer */
   q31_t fcurnt, fnext, gcurnt, gnext;            /* temporary variables */
   uint32_t numStages = S->numStages;             /* Length of the filter */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_sparse.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/fir_sparse.c
@@ -2,7 +2,7 @@
 
 void ref_fir_sparse_f32(
   arm_fir_sparse_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   float32_t * pScratchIn,
   uint32_t blockSize)
@@ -117,9 +117,9 @@ void ref_fir_sparse_q31(
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
-  q31_t *px;                                     /* Scratch buffer pointer */
-  q31_t *py = pState;                            /* Temporary pointers for state buffer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *px;                                     /* Scratch buffer pointer */
+  const q31_t *py = pState;                            /* Temporary pointers for state buffer */
   q31_t *pb = pScratchIn;                        /* Temporary pointers for scratch buffer */
   q31_t *pOut;                                   /* Destination pointer */
   q63_t out;                                     /* Temporary output variable */
@@ -247,10 +247,10 @@ void ref_fir_sparse_q15(
   q15_t *pState = S->pState;                     /* State pointer */
   q15_t *pIn = pSrc;                             /* Working pointer for input */
   q15_t *pOut = pDst;                            /* Working pointer for output */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
-  q15_t *px;                                     /* Temporary pointers for scratch buffer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *px;                                     /* Temporary pointers for scratch buffer */
   q15_t *pb = pScratchIn;                        /* Temporary pointers for scratch buffer */
-  q15_t *py = pState;                            /* Temporary pointers for state buffer */
+  const q15_t *py = pState;                            /* Temporary pointers for state buffer */
   int32_t *pTapDelay = S->pTapDelay;             /* Pointer to the array containing offset of the non-zero tap values. */
   uint32_t delaySize = S->maxDelay + blockSize;  /* state length */
   uint16_t numTaps = S->numTaps;                 /* Filter order */
@@ -366,9 +366,9 @@ void ref_fir_sparse_q7(
   uint32_t blockSize)
 {
   q7_t *pState = S->pState;                      /* State pointer */
-  q7_t *pCoeffs = S->pCoeffs;                    /* Coefficient pointer */
-  q7_t *px;                                      /* Scratch buffer pointer */
-  q7_t *py = pState;                             /* Temporary pointers for state buffer */
+  const q7_t *pCoeffs = S->pCoeffs;                    /* Coefficient pointer */
+  const q7_t *px;                                      /* Scratch buffer pointer */
+  const q7_t *py = pState;                             /* Temporary pointers for state buffer */
   q7_t *pb = pScratchIn;                         /* Temporary pointers for scratch buffer */
   q7_t *pOut = pDst;                             /* Destination pointer */
   int32_t *pTapDelay = S->pTapDelay;             /* Pointer to the array containing offset of the non-zero tap values. */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/iir_lattice.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/iir_lattice.c
@@ -2,7 +2,7 @@
 
 void ref_iir_lattice_f32(
   const arm_iir_lattice_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
@@ -95,7 +95,7 @@ void ref_iir_lattice_q31(
   q31_t fcurr, fnext = 0, gcurr = 0, gnext;      /* Temporary variables for lattice stages */
   q63_t acc;                                     /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* Temporary variables for counts */
-  q31_t *px1, *px2, *pk, *pv;                    /* Temporary pointers for state and coef */
+  const q31_t *px1, *px2, *pk, *pv;                    /* Temporary pointers for state and coef */
   uint32_t numStages = S->numStages;             /* number of stages */
   q31_t *pState;                                 /* State pointer */
   q31_t *pStateCurnt;                            /* State current pointer */
@@ -188,7 +188,7 @@ void ref_iir_lattice_q15(
   uint32_t stgCnt;                               /* Temporary variables for counts */
   q63_t acc;                                     /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* Temporary variables for counts */
-  q15_t *px1, *px2, *pk, *pv;                    /* temporary pointers for state and coef */
+  const q15_t *px1, *px2, *pk, *pv;                    /* temporary pointers for state and coef */
   uint32_t numStages = S->numStages;             /* number of stages */
   q15_t *pState;                                 /* State pointer */
   q15_t *pStateCurnt;                            /* State current pointer */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/lms.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/lms.c
@@ -436,7 +436,7 @@ void ref_lms_q15(
   q63_t acc;                                     /* Accumulator */
   q15_t e = 0;                                   /* error of data sample */
   q15_t alpha;                                   /* Intermediate constant for taps update */
-  q31_t coef;                                    /* Teporary variable for coefficient */
+  q31_t coef;                                    /* Temporary variable for coefficient */
   q31_t acc_l, acc_h;
   int32_t lShift = 15 - (int32_t)S->postShift;   /*  Post shift  */
   int32_t uShift = 32 - lShift;
@@ -558,7 +558,7 @@ void ref_lms_norm_q15(
   q15_t errorXmu, oneByEnergy;                   /* Temporary variables to store error and mu product and reciprocal of energy */
   //q31_t errorXmu;                   				 /* Temporary variables to store error and mu product and reciprocal of energy */
   q15_t postShift;                               /* Post shift to be applied to weight after reciprocal calculation */
-  q31_t coef;                                    /* Teporary variable for coefficient */
+  q31_t coef;                                    /* Temporary variable for coefficient */
   q31_t acc_l, acc_h;
   int32_t lShift = 15 - (int32_t)S->postShift;  /*  Post shift  */
   int32_t uShift = 32 - lShift;

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/lms.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/FilteringFunctions/lms.c
@@ -2,7 +2,7 @@
 
 void ref_lms_f32(
   const arm_lms_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pRef,
   float32_t * pOut,
   float32_t * pErr,
@@ -73,7 +73,7 @@ void ref_lms_f32(
 
 void ref_lms_norm_f32(
   arm_lms_norm_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pRef,
   float32_t * pOut,
   float32_t * pErr,
@@ -167,10 +167,10 @@ void ref_lms_q31(
 {
   q31_t *pState = S->pState;                     /* State pointer */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t mu = S->mu;                              /* Adaptive factor */
-  q31_t *px;                                     /* Temporary pointer for state */
+  const q31_t *px;                                     /* Temporary pointer for state */
   q31_t *pb;                                     /* Temporary pointer for coefficient buffer */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */
   q63_t acc;                                     /* Accumulator */
@@ -282,9 +282,9 @@ void ref_lms_norm_q31(
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q31_t *px, *pb;                                /* Temporary pointers for state and coefficient buffers */
+  const q31_t *px, *pb;                                /* Temporary pointers for state and coefficient buffers */
   q31_t mu = S->mu;                              /* Adaptive factor */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */
@@ -427,10 +427,10 @@ void ref_lms_q15(
 {
   q15_t *pState = S->pState;                     /* State pointer */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q15_t mu = S->mu;                              /* Adaptive factor */
-  q15_t *px;                                     /* Temporary pointer for state */
+  const q15_t *px;                                     /* Temporary pointer for state */
   q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */
   q63_t acc;                                     /* Accumulator */
@@ -544,9 +544,9 @@ void ref_lms_norm_q15(
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q15_t *px, *pb;                                /* Temporary pointers for state and coefficient buffers */
+  const q15_t *px, *pb;                                /* Temporary pointers for state and coefficient buffers */
   q15_t mu = S->mu;                              /* Adaptive factor */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/max.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/max.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_max_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/mean.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/mean.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_mean_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/min.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/min.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_min_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/power.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/power.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_power_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/rms.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/rms.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_rms_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/std.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/std.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_std_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/var.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/StatisticsFunctions/var.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_var_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/SupportFunctions/copy.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/SupportFunctions/copy.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_copy_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/SupportFunctions/float_to_fixed.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/SupportFunctions/float_to_fixed.c
@@ -1,7 +1,7 @@
 #include "ref.h"
 
 void ref_float_to_q31(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
@@ -18,7 +18,7 @@ void ref_float_to_q31(
 }
 	
 void ref_float_to_q15(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
@@ -35,7 +35,7 @@ void ref_float_to_q15(
 }
 	
 void ref_float_to_q7(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/TransformFunctions/cfft.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/TransformFunctions/cfft.c
@@ -219,7 +219,7 @@ void ref_cfft_q15(
 
 void ref_cfft_radix2_f32(
 	const arm_cfft_radix2_instance_f32 * S,
-	float32_t * pSrc)
+	const float32_t * pSrc)
 {
 	switch(S->fftLen)
 	{
@@ -409,7 +409,7 @@ void ref_cfft_radix2_q15(
 
 void ref_cfft_radix4_f32(
 	const arm_cfft_radix4_instance_f32 * S,
-	float32_t * pSrc)
+	const float32_t * pSrc)
 {		
 	switch(S->fftLen)
 	{

--- a/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/TransformFunctions/rfft.c
+++ b/CMSIS/DSP/DSP_Lib_TestSuite/RefLibs/src/TransformFunctions/rfft.c
@@ -3,7 +3,7 @@
 	
 void ref_rfft_f32(
 	arm_rfft_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst)
 {
 	uint32_t i;

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -1896,8 +1896,8 @@ extern "C"
     uint16_t fftLen;                 /**< length of the FFT. */
     uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
     uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q15_t *pTwiddle;                 /**< points to the Sin twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    const q15_t *pTwiddle;           /**< points to the Sin twiddle factor table. */
+    const uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
     uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
     uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix2_instance_q15;
@@ -1923,8 +1923,8 @@ extern "C"
     uint16_t fftLen;                 /**< length of the FFT. */
     uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
     uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q15_t *pTwiddle;                 /**< points to the twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    const q15_t *pTwiddle;           /**< points to the twiddle factor table. */
+    const uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
     uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
     uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix4_instance_q15;
@@ -1949,8 +1949,8 @@ extern "C"
     uint16_t fftLen;                 /**< length of the FFT. */
     uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
     uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q31_t *pTwiddle;                 /**< points to the Twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    const q31_t *pTwiddle;           /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
     uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
     uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix2_instance_q31;
@@ -1975,8 +1975,8 @@ extern "C"
     uint16_t fftLen;                 /**< length of the FFT. */
     uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
     uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q31_t *pTwiddle;                 /**< points to the twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    const q31_t *pTwiddle;           /**< points to the twiddle factor table. */
+    const uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
     uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
     uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix4_instance_q31;
@@ -2001,8 +2001,8 @@ extern "C"
     uint16_t fftLen;                   /**< length of the FFT. */
     uint8_t ifftFlag;                  /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
     uint8_t bitReverseFlag;            /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    float32_t *pTwiddle;               /**< points to the Twiddle factor table. */
-    uint16_t *pBitRevTable;            /**< points to the bit reversal table. */
+    const float32_t *pTwiddle;         /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
     uint16_t twidCoefModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
     uint16_t bitRevFactor;             /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
     float32_t onebyfftLen;             /**< value of 1/fftLen. */
@@ -2028,8 +2028,8 @@ extern "C"
     uint16_t fftLen;                   /**< length of the FFT. */
     uint8_t ifftFlag;                  /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
     uint8_t bitReverseFlag;            /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    float32_t *pTwiddle;               /**< points to the Twiddle factor table. */
-    uint16_t *pBitRevTable;            /**< points to the bit reversal table. */
+    const float32_t *pTwiddle;         /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
     uint16_t twidCoefModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
     uint16_t bitRevFactor;             /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
     float32_t onebyfftLen;             /**< value of 1/fftLen. */
@@ -2107,8 +2107,8 @@ void arm_cfft_q31(
     uint8_t ifftFlagR;                        /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
     uint8_t bitReverseFlagR;                  /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
     uint32_t twidCoefRModifier;               /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    q15_t *pTwiddleAReal;                     /**< points to the real twiddle factor table. */
-    q15_t *pTwiddleBReal;                     /**< points to the imag twiddle factor table. */
+    const q15_t *pTwiddleAReal;               /**< points to the real twiddle factor table. */
+    const q15_t *pTwiddleBReal;               /**< points to the imag twiddle factor table. */
     const arm_cfft_instance_q15 *pCfft;       /**< points to the complex FFT instance. */
   } arm_rfft_instance_q15;
 
@@ -2132,8 +2132,8 @@ void arm_cfft_q31(
     uint8_t ifftFlagR;                          /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
     uint8_t bitReverseFlagR;                    /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
     uint32_t twidCoefRModifier;                 /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    q31_t *pTwiddleAReal;                       /**< points to the real twiddle factor table. */
-    q31_t *pTwiddleBReal;                       /**< points to the imag twiddle factor table. */
+    const q31_t *pTwiddleAReal;                 /**< points to the real twiddle factor table. */
+    const q31_t *pTwiddleBReal;                 /**< points to the imag twiddle factor table. */
     const arm_cfft_instance_q31 *pCfft;         /**< points to the complex FFT instance. */
   } arm_rfft_instance_q31;
 
@@ -2157,9 +2157,9 @@ void arm_cfft_q31(
     uint16_t fftLenBy2;                         /**< length of the complex FFT. */
     uint8_t ifftFlagR;                          /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
     uint8_t bitReverseFlagR;                    /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
-    uint32_t twidCoefRModifier;                     /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    float32_t *pTwiddleAReal;                   /**< points to the real twiddle factor table. */
-    float32_t *pTwiddleBReal;                   /**< points to the imag twiddle factor table. */
+    uint32_t twidCoefRModifier;                 /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    const float32_t *pTwiddleAReal;             /**< points to the real twiddle factor table. */
+    const float32_t *pTwiddleBReal;             /**< points to the imag twiddle factor table. */
     arm_cfft_radix4_instance_f32 *pCfft;        /**< points to the complex FFT instance. */
   } arm_rfft_instance_f32;
 
@@ -2219,8 +2219,8 @@ void arm_rfft_fast_f32(
     uint16_t N;                          /**< length of the DCT4. */
     uint16_t Nby2;                       /**< half of the length of the DCT4. */
     float32_t normalize;                 /**< normalizing factor. */
-    float32_t *pTwiddle;                 /**< points to the twiddle factor table. */
-    float32_t *pCosFactor;               /**< points to the cosFactor table. */
+    const float32_t *pTwiddle;           /**< points to the twiddle factor table. */
+    const float32_t *pCosFactor;         /**< points to the cosFactor table. */
     arm_rfft_instance_f32 *pRfft;        /**< points to the real FFT instance. */
     arm_cfft_radix4_instance_f32 *pCfft; /**< points to the complex FFT instance. */
   } arm_dct4_instance_f32;
@@ -2265,8 +2265,8 @@ void arm_rfft_fast_f32(
     uint16_t N;                          /**< length of the DCT4. */
     uint16_t Nby2;                       /**< half of the length of the DCT4. */
     q31_t normalize;                     /**< normalizing factor. */
-    q31_t *pTwiddle;                     /**< points to the twiddle factor table. */
-    q31_t *pCosFactor;                   /**< points to the cosFactor table. */
+    const q31_t *pTwiddle;               /**< points to the twiddle factor table. */
+    const q31_t *pCosFactor;             /**< points to the cosFactor table. */
     arm_rfft_instance_q31 *pRfft;        /**< points to the real FFT instance. */
     arm_cfft_radix4_instance_q31 *pCfft; /**< points to the complex FFT instance. */
   } arm_dct4_instance_q31;
@@ -2311,8 +2311,8 @@ void arm_rfft_fast_f32(
     uint16_t N;                          /**< length of the DCT4. */
     uint16_t Nby2;                       /**< half of the length of the DCT4. */
     q15_t normalize;                     /**< normalizing factor. */
-    q15_t *pTwiddle;                     /**< points to the twiddle factor table. */
-    q15_t *pCosFactor;                   /**< points to the cosFactor table. */
+    const q15_t *pTwiddle;               /**< points to the twiddle factor table. */
+    const q15_t *pCosFactor;             /**< points to the cosFactor table. */
     arm_rfft_instance_q15 *pRfft;        /**< points to the real FFT instance. */
     arm_cfft_radix4_instance_q15 *pCfft; /**< points to the complex FFT instance. */
   } arm_dct4_instance_q15;

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -1139,7 +1139,7 @@ extern "C"
    */
   void arm_fir_f32(
   const arm_fir_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -1290,7 +1290,7 @@ extern "C"
    */
   void arm_biquad_cascade_df1_f32(
   const arm_biquad_casd_df1_inst_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -1882,8 +1882,8 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -2018,7 +2018,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix2_f32(
   const arm_cfft_radix2_instance_f32 * S,
-  float32_t * pSrc);
+  const float32_t * pSrc);
 
   /**
    * @brief Instance structure for the floating-point CFFT/CIFFT function.
@@ -2045,7 +2045,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix4_f32(
   const arm_cfft_radix4_instance_f32 * S,
-  float32_t * pSrc);
+  const float32_t * pSrc);
 
   /**
    * @brief Instance structure for the fixed-point CFFT/CIFFT function.
@@ -2172,7 +2172,7 @@ void arm_cfft_q31(
 
   void arm_rfft_f32(
   const arm_rfft_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst);
 
   /**
@@ -2357,8 +2357,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -2413,8 +2413,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -2469,7 +2469,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_scale_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t scale,
   float32_t * pDst,
   uint32_t blockSize);
@@ -2542,7 +2542,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -2579,8 +2579,8 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   uint32_t blockSize,
   float32_t * result);
 
@@ -2677,7 +2677,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t offset,
   float32_t * pDst,
   uint32_t blockSize);
@@ -2732,7 +2732,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -2780,7 +2780,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -2878,9 +2878,9 @@ void arm_rfft_fast_f32(
  * @param[out] pDst     points to the location where the output result is written.  Length srcALen+srcBLen-1.
  */
   void arm_conv_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst);
 
@@ -3037,9 +3037,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst,
   uint32_t firstIndex,
@@ -3269,7 +3269,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_decimate_f32(
   const arm_fir_decimate_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -3500,7 +3500,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_interpolate_f32(
   const arm_fir_interpolate_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -3605,7 +3605,7 @@ void arm_rfft_fast_f32(
    */
   void arm_biquad_cascade_df2T_f32(
   const arm_biquad_cascade_df2T_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -3619,7 +3619,7 @@ void arm_rfft_fast_f32(
    */
   void arm_biquad_cascade_stereo_df2T_f32(
   const arm_biquad_cascade_stereo_df2T_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -3790,7 +3790,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_lattice_f32(
   const arm_fir_lattice_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -3838,7 +3838,7 @@ void arm_rfft_fast_f32(
    */
   void arm_iir_lattice_f32(
   const arm_iir_lattice_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -3948,7 +3948,7 @@ void arm_rfft_fast_f32(
    */
   void arm_lms_f32(
   const arm_lms_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pRef,
   float32_t * pOut,
   float32_t * pErr,
@@ -4100,7 +4100,7 @@ void arm_rfft_fast_f32(
    */
   void arm_lms_norm_f32(
   arm_lms_norm_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pRef,
   float32_t * pOut,
   float32_t * pErr,
@@ -4242,9 +4242,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst);
 
@@ -4450,7 +4450,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_sparse_f32(
   arm_fir_sparse_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   float32_t * pScratchIn,
   uint32_t blockSize);
@@ -4619,7 +4619,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_conj_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples);
 
@@ -4654,7 +4654,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_squared_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples);
 
@@ -6103,7 +6103,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult);
 
@@ -6175,7 +6175,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult);
 
@@ -6187,7 +6187,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_var_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult);
 
@@ -6223,7 +6223,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_rms_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult);
 
@@ -6259,7 +6259,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_std_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult);
 
@@ -6295,7 +6295,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples);
 
@@ -6365,8 +6365,8 @@ void arm_rfft_fast_f32(
    * @param[out] imagResult  imaginary part of the result returned here
    */
   void arm_cmplx_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   uint32_t numSamples,
   float32_t * realResult,
   float32_t * imagResult);
@@ -6408,8 +6408,8 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of samples in each vector
    */
   void arm_cmplx_mult_real_f32(
-  float32_t * pSrcCmplx,
-  float32_t * pSrcReal,
+  const float32_t * pSrcCmplx,
+  const float32_t * pSrcReal,
   float32_t * pCmplxDst,
   uint32_t numSamples);
 
@@ -6464,7 +6464,7 @@ void arm_rfft_fast_f32(
    * @param[out] pIndex     is the array index of the minimum value in the input buffer.
    */
   void arm_min_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult,
   uint32_t * pIndex);
@@ -6520,7 +6520,7 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult,
   uint32_t * pIndex);
@@ -6562,8 +6562,8 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_mult_cmplx_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t numSamples);
 
@@ -6575,7 +6575,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  length of the input vector
    */
   void arm_float_to_q31(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -6587,7 +6587,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  length of the input vector
    */
   void arm_float_to_q15(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -6599,7 +6599,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  length of the input vector
    */
   void arm_float_to_q7(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize);
 

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -976,7 +976,7 @@ extern "C"
   {
     uint16_t numTaps;        /**< number of filter coefficients in the filter. */
     q7_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q7_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+    const q7_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
   } arm_fir_instance_q7;
 
   /**
@@ -986,7 +986,7 @@ extern "C"
   {
     uint16_t numTaps;         /**< number of filter coefficients in the filter. */
     q15_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q15_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+    const q15_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
   } arm_fir_instance_q15;
 
   /**
@@ -996,7 +996,7 @@ extern "C"
   {
     uint16_t numTaps;         /**< number of filter coefficients in the filter. */
     q31_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q31_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps. */
+    const q31_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps. */
   } arm_fir_instance_q31;
 
   /**
@@ -1006,7 +1006,7 @@ extern "C"
   {
     uint16_t numTaps;     /**< number of filter coefficients in the filter. */
     float32_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
+    const float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
   } arm_fir_instance_f32;
 
 
@@ -1035,7 +1035,7 @@ extern "C"
   void arm_fir_init_q7(
   arm_fir_instance_q7 * S,
   uint16_t numTaps,
-  q7_t * pCoeffs,
+  const q7_t * pCoeffs,
   q7_t * pState,
   uint32_t blockSize);
 
@@ -1081,7 +1081,7 @@ extern "C"
   arm_status arm_fir_init_q15(
   arm_fir_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   uint32_t blockSize);
 
@@ -1125,7 +1125,7 @@ extern "C"
   void arm_fir_init_q31(
   arm_fir_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   uint32_t blockSize);
 
@@ -1155,7 +1155,7 @@ extern "C"
   void arm_fir_init_f32(
   arm_fir_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   uint32_t blockSize);
 
@@ -1167,7 +1167,7 @@ extern "C"
   {
     int8_t numStages;        /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
     q15_t *pState;           /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
-    q15_t *pCoeffs;          /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    const q15_t *pCoeffs;          /**< Points to the array of coefficients.  The array is of length 5*numStages. */
     int8_t postShift;        /**< Additional shift, in bits, applied to each output sample. */
   } arm_biquad_casd_df1_inst_q15;
 
@@ -1178,7 +1178,7 @@ extern "C"
   {
     uint32_t numStages;      /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
     q31_t *pState;           /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
-    q31_t *pCoeffs;          /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    const q31_t *pCoeffs;          /**< Points to the array of coefficients.  The array is of length 5*numStages. */
     uint8_t postShift;       /**< Additional shift, in bits, applied to each output sample. */
   } arm_biquad_casd_df1_inst_q31;
 
@@ -1189,7 +1189,7 @@ extern "C"
   {
     uint32_t numStages;      /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
     float32_t *pState;       /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
-    float32_t *pCoeffs;      /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    const float32_t *pCoeffs;      /**< Points to the array of coefficients.  The array is of length 5*numStages. */
   } arm_biquad_casd_df1_inst_f32;
 
 
@@ -1218,7 +1218,7 @@ extern "C"
   void arm_biquad_cascade_df1_init_q15(
   arm_biquad_casd_df1_inst_q15 * S,
   uint8_t numStages,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   int8_t postShift);
 
@@ -1276,7 +1276,7 @@ extern "C"
   void arm_biquad_cascade_df1_init_q31(
   arm_biquad_casd_df1_inst_q31 * S,
   uint8_t numStages,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   int8_t postShift);
 
@@ -1305,7 +1305,7 @@ extern "C"
   void arm_biquad_cascade_df1_init_f32(
   arm_biquad_casd_df1_inst_f32 * S,
   uint8_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState);
 
 
@@ -1912,7 +1912,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix2_q15(
   const arm_cfft_radix2_instance_q15 * S,
-  const q15_t * pSrc);
+  q15_t * pSrc);
 
 
   /**
@@ -1939,7 +1939,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix4_q15(
   const arm_cfft_radix4_instance_q15 * S,
-  const q15_t * pSrc);
+  q15_t * pSrc);
 
   /**
    * @brief Instance structure for the Radix-2 Q31 CFFT/CIFFT function.
@@ -1965,7 +1965,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix2_q31(
   const arm_cfft_radix2_instance_q31 * S,
-  const q31_t * pSrc);
+  q31_t * pSrc);
 
   /**
    * @brief Instance structure for the Q31 CFFT/CIFFT function.
@@ -1984,7 +1984,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix4_q31(
   const arm_cfft_radix4_instance_q31 * S,
-  const q31_t * pSrc);
+  q31_t * pSrc);
 
 /* Deprecated */
   arm_status arm_cfft_radix4_init_q31(
@@ -2018,7 +2018,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix2_f32(
   const arm_cfft_radix2_instance_f32 * S,
-  const float32_t * pSrc);
+  float32_t * pSrc);
 
   /**
    * @brief Instance structure for the floating-point CFFT/CIFFT function.
@@ -2045,7 +2045,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix4_f32(
   const arm_cfft_radix4_instance_f32 * S,
-  const float32_t * pSrc);
+  float32_t * pSrc);
 
   /**
    * @brief Instance structure for the fixed-point CFFT/CIFFT function.
@@ -3233,7 +3233,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t M;                  /**< decimation factor. */
     uint16_t numTaps;           /**< number of coefficients in the filter. */
-    q15_t *pCoeffs;             /**< points to the coefficient array. The array is of length numTaps.*/
+    const q15_t *pCoeffs;             /**< points to the coefficient array. The array is of length numTaps.*/
     q15_t *pState;              /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
   } arm_fir_decimate_instance_q15;
 
@@ -3244,7 +3244,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t M;                  /**< decimation factor. */
     uint16_t numTaps;           /**< number of coefficients in the filter. */
-    q31_t *pCoeffs;             /**< points to the coefficient array. The array is of length numTaps.*/
+    const q31_t *pCoeffs;             /**< points to the coefficient array. The array is of length numTaps.*/
     q31_t *pState;              /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
   } arm_fir_decimate_instance_q31;
 
@@ -3255,7 +3255,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t M;                  /**< decimation factor. */
     uint16_t numTaps;           /**< number of coefficients in the filter. */
-    float32_t *pCoeffs;         /**< points to the coefficient array. The array is of length numTaps.*/
+    const float32_t *pCoeffs;         /**< points to the coefficient array. The array is of length numTaps.*/
     float32_t *pState;          /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
   } arm_fir_decimate_instance_f32;
 
@@ -3289,7 +3289,7 @@ void arm_rfft_fast_f32(
   arm_fir_decimate_instance_f32 * S,
   uint16_t numTaps,
   uint8_t M,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   uint32_t blockSize);
 
@@ -3337,7 +3337,7 @@ void arm_rfft_fast_f32(
   arm_fir_decimate_instance_q15 * S,
   uint16_t numTaps,
   uint8_t M,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   uint32_t blockSize);
 
@@ -3384,7 +3384,7 @@ void arm_rfft_fast_f32(
   arm_fir_decimate_instance_q31 * S,
   uint16_t numTaps,
   uint8_t M,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   uint32_t blockSize);
 
@@ -3396,7 +3396,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t L;                      /**< upsample factor. */
     uint16_t phaseLength;           /**< length of each polyphase filter component. */
-    q15_t *pCoeffs;                 /**< points to the coefficient array. The array is of length L*phaseLength. */
+    const q15_t *pCoeffs;                 /**< points to the coefficient array. The array is of length L*phaseLength. */
     q15_t *pState;                  /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
   } arm_fir_interpolate_instance_q15;
 
@@ -3407,7 +3407,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t L;                      /**< upsample factor. */
     uint16_t phaseLength;           /**< length of each polyphase filter component. */
-    q31_t *pCoeffs;                 /**< points to the coefficient array. The array is of length L*phaseLength. */
+    const q31_t *pCoeffs;                 /**< points to the coefficient array. The array is of length L*phaseLength. */
     q31_t *pState;                  /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
   } arm_fir_interpolate_instance_q31;
 
@@ -3418,7 +3418,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t L;                     /**< upsample factor. */
     uint16_t phaseLength;          /**< length of each polyphase filter component. */
-    float32_t *pCoeffs;            /**< points to the coefficient array. The array is of length L*phaseLength. */
+    const float32_t *pCoeffs;      /**< points to the coefficient array. The array is of length L*phaseLength. */
     float32_t *pState;             /**< points to the state variable array. The array is of length phaseLength+numTaps-1. */
   } arm_fir_interpolate_instance_f32;
 
@@ -3452,7 +3452,7 @@ void arm_rfft_fast_f32(
   arm_fir_interpolate_instance_q15 * S,
   uint8_t L,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   uint32_t blockSize);
 
@@ -3486,7 +3486,7 @@ void arm_rfft_fast_f32(
   arm_fir_interpolate_instance_q31 * S,
   uint8_t L,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   uint32_t blockSize);
 
@@ -3520,7 +3520,7 @@ void arm_rfft_fast_f32(
   arm_fir_interpolate_instance_f32 * S,
   uint8_t L,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   uint32_t blockSize);
 
@@ -3532,7 +3532,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t numStages;       /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
     q63_t *pState;           /**< points to the array of state coefficients.  The array is of length 4*numStages. */
-    q31_t *pCoeffs;          /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    const q31_t *pCoeffs;          /**< points to the array of coefficients.  The array is of length 5*numStages. */
     uint8_t postShift;       /**< additional shift, in bits, applied to each output sample. */
   } arm_biquad_cas_df1_32x64_ins_q31;
 
@@ -3560,7 +3560,7 @@ void arm_rfft_fast_f32(
   void arm_biquad_cas_df1_32x64_init_q31(
   arm_biquad_cas_df1_32x64_ins_q31 * S,
   uint8_t numStages,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q63_t * pState,
   uint8_t postShift);
 
@@ -3572,7 +3572,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
     float32_t *pState;         /**< points to the array of state coefficients.  The array is of length 2*numStages. */
-    float32_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    const float32_t *pCoeffs;  /**< points to the array of coefficients.  The array is of length 5*numStages. */
   } arm_biquad_cascade_df2T_instance_f32;
 
   /**
@@ -3582,7 +3582,7 @@ void arm_rfft_fast_f32(
   {
     uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
     float32_t *pState;         /**< points to the array of state coefficients.  The array is of length 4*numStages. */
-    float32_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    const float32_t *pCoeffs;  /**< points to the array of coefficients.  The array is of length 5*numStages. */
   } arm_biquad_cascade_stereo_df2T_instance_f32;
 
   /**
@@ -3648,7 +3648,7 @@ void arm_rfft_fast_f32(
   void arm_biquad_cascade_df2T_init_f32(
   arm_biquad_cascade_df2T_instance_f32 * S,
   uint8_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState);
 
 
@@ -3662,7 +3662,7 @@ void arm_rfft_fast_f32(
   void arm_biquad_cascade_stereo_df2T_init_f32(
   arm_biquad_cascade_stereo_df2T_instance_f32 * S,
   uint8_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState);
 
 
@@ -3687,7 +3687,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numStages;                  /**< number of filter stages. */
     q15_t *pState;                       /**< points to the state variable array. The array is of length numStages. */
-    q15_t *pCoeffs;                      /**< points to the coefficient array. The array is of length numStages. */
+    const q15_t *pCoeffs;                      /**< points to the coefficient array. The array is of length numStages. */
   } arm_fir_lattice_instance_q15;
 
   /**
@@ -3697,7 +3697,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numStages;                  /**< number of filter stages. */
     q31_t *pState;                       /**< points to the state variable array. The array is of length numStages. */
-    q31_t *pCoeffs;                      /**< points to the coefficient array. The array is of length numStages. */
+    const q31_t *pCoeffs;                      /**< points to the coefficient array. The array is of length numStages. */
   } arm_fir_lattice_instance_q31;
 
   /**
@@ -3707,7 +3707,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numStages;                  /**< number of filter stages. */
     float32_t *pState;                   /**< points to the state variable array. The array is of length numStages. */
-    float32_t *pCoeffs;                  /**< points to the coefficient array. The array is of length numStages. */
+    const float32_t *pCoeffs;            /**< points to the coefficient array. The array is of length numStages. */
   } arm_fir_lattice_instance_f32;
 
 
@@ -3721,7 +3721,7 @@ void arm_rfft_fast_f32(
   void arm_fir_lattice_init_q15(
   arm_fir_lattice_instance_q15 * S,
   uint16_t numStages,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState);
 
 
@@ -3749,7 +3749,7 @@ void arm_rfft_fast_f32(
   void arm_fir_lattice_init_q31(
   arm_fir_lattice_instance_q31 * S,
   uint16_t numStages,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState);
 
 
@@ -3777,7 +3777,7 @@ void arm_rfft_fast_f32(
   void arm_fir_lattice_init_f32(
   arm_fir_lattice_instance_f32 * S,
   uint16_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState);
 
 
@@ -3932,7 +3932,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numTaps;    /**< number of coefficients in the filter. */
     float32_t *pState;   /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    float32_t *pCoeffs;  /**< points to the coefficient array. The array is of length numTaps. */
+    const float32_t *pCoeffs;  /**< points to the coefficient array. The array is of length numTaps. */
     float32_t mu;        /**< step size that controls filter coefficient updates. */
   } arm_lms_instance_f32;
 
@@ -3967,7 +3967,7 @@ void arm_rfft_fast_f32(
   void arm_lms_init_f32(
   arm_lms_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   float32_t mu,
   uint32_t blockSize);
@@ -3980,7 +3980,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numTaps;    /**< number of coefficients in the filter. */
     q15_t *pState;       /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q15_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
+    const q15_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
     q15_t mu;            /**< step size that controls filter coefficient updates. */
     uint32_t postShift;  /**< bit shift applied to coefficients. */
   } arm_lms_instance_q15;
@@ -3999,7 +3999,7 @@ void arm_rfft_fast_f32(
   void arm_lms_init_q15(
   arm_lms_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   q15_t mu,
   uint32_t blockSize,
@@ -4031,7 +4031,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numTaps;    /**< number of coefficients in the filter. */
     q31_t *pState;       /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q31_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
+    const q31_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
     q31_t mu;            /**< step size that controls filter coefficient updates. */
     uint32_t postShift;  /**< bit shift applied to coefficients. */
   } arm_lms_instance_q31;
@@ -4068,7 +4068,7 @@ void arm_rfft_fast_f32(
   void arm_lms_init_q31(
   arm_lms_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   q31_t mu,
   uint32_t blockSize,
@@ -4082,7 +4082,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numTaps;     /**< number of coefficients in the filter. */
     float32_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
+    const float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
     float32_t mu;         /**< step size that control filter coefficient updates. */
     float32_t energy;     /**< saves previous frame energy. */
     float32_t x0;         /**< saves previous input sample. */
@@ -4119,7 +4119,7 @@ void arm_rfft_fast_f32(
   void arm_lms_norm_init_f32(
   arm_lms_norm_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   float32_t mu,
   uint32_t blockSize);
@@ -4132,7 +4132,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numTaps;     /**< number of coefficients in the filter. */
     q31_t *pState;        /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q31_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
+    const q31_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
     q31_t mu;             /**< step size that controls filter coefficient updates. */
     uint8_t postShift;    /**< bit shift applied to coefficients. */
     q31_t *recipTable;    /**< points to the reciprocal initial value table. */
@@ -4172,7 +4172,7 @@ void arm_rfft_fast_f32(
   void arm_lms_norm_init_q31(
   arm_lms_norm_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   q31_t mu,
   uint32_t blockSize,
@@ -4186,7 +4186,7 @@ void arm_rfft_fast_f32(
   {
     uint16_t numTaps;     /**< Number of coefficients in the filter. */
     q15_t *pState;        /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q15_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
+    const q15_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
     q15_t mu;             /**< step size that controls filter coefficient updates. */
     uint8_t postShift;    /**< bit shift applied to coefficients. */
     q15_t *recipTable;    /**< Points to the reciprocal initial value table. */
@@ -4226,7 +4226,7 @@ void arm_rfft_fast_f32(
   void arm_lms_norm_init_q15(
   arm_lms_norm_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   q15_t mu,
   uint32_t blockSize,
@@ -4395,7 +4395,7 @@ void arm_rfft_fast_f32(
     uint16_t numTaps;             /**< number of coefficients in the filter. */
     uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
     float32_t *pState;            /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    float32_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+    const float32_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
     uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
     int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_f32;
@@ -4408,7 +4408,7 @@ void arm_rfft_fast_f32(
     uint16_t numTaps;             /**< number of coefficients in the filter. */
     uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
     q31_t *pState;                /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    q31_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
+    const q31_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
     uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
     int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_q31;
@@ -4421,7 +4421,7 @@ void arm_rfft_fast_f32(
     uint16_t numTaps;             /**< number of coefficients in the filter. */
     uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
     q15_t *pState;                /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    q15_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
+    const q15_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
     uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
     int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_q15;
@@ -4434,7 +4434,7 @@ void arm_rfft_fast_f32(
     uint16_t numTaps;             /**< number of coefficients in the filter. */
     uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
     q7_t *pState;                 /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    q7_t *pCoeffs;                /**< points to the coefficient array. The array is of length numTaps.*/
+    const q7_t *pCoeffs;                /**< points to the coefficient array. The array is of length numTaps.*/
     uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
     int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_q7;
@@ -4469,7 +4469,7 @@ void arm_rfft_fast_f32(
   void arm_fir_sparse_init_f32(
   arm_fir_sparse_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,
@@ -4505,7 +4505,7 @@ void arm_rfft_fast_f32(
   void arm_fir_sparse_init_q31(
   arm_fir_sparse_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,
@@ -4543,7 +4543,7 @@ void arm_rfft_fast_f32(
   void arm_fir_sparse_init_q15(
   arm_fir_sparse_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,
@@ -4581,7 +4581,7 @@ void arm_rfft_fast_f32(
   void arm_fir_sparse_init_q7(
   arm_fir_sparse_instance_q7 * S,
   uint16_t numTaps,
-  q7_t * pCoeffs,
+  const q7_t * pCoeffs,
   q7_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -2120,7 +2120,7 @@ void arm_cfft_q31(
 
   void arm_rfft_q15(
   const arm_rfft_instance_q15 * S,
-  const q15_t * pSrc,
+  q15_t * pSrc,
   q15_t * pDst);
 
   /**
@@ -2145,7 +2145,7 @@ void arm_cfft_q31(
 
   void arm_rfft_q31(
   const arm_rfft_instance_q31 * S,
-  const q31_t * pSrc,
+  q31_t * pSrc,
   q31_t * pDst);
 
   /**
@@ -2172,7 +2172,7 @@ void arm_cfft_q31(
 
   void arm_rfft_f32(
   const arm_rfft_instance_f32 * S,
-  const float32_t * pSrc,
+  float32_t * pSrc,
   float32_t * pDst);
 
   /**

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -1019,7 +1019,7 @@ extern "C"
    */
   void arm_fir_q7(
   const arm_fir_instance_q7 * S,
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -1049,7 +1049,7 @@ extern "C"
    */
   void arm_fir_q15(
   const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -1063,7 +1063,7 @@ extern "C"
    */
   void arm_fir_fast_q15(
   const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -1095,7 +1095,7 @@ extern "C"
    */
   void arm_fir_q31(
   const arm_fir_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -1109,7 +1109,7 @@ extern "C"
    */
   void arm_fir_fast_q31(
   const arm_fir_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -1202,7 +1202,7 @@ extern "C"
    */
   void arm_biquad_cascade_df1_q15(
   const arm_biquad_casd_df1_inst_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -1232,7 +1232,7 @@ extern "C"
    */
   void arm_biquad_cascade_df1_fast_q15(
   const arm_biquad_casd_df1_inst_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -1246,7 +1246,7 @@ extern "C"
    */
   void arm_biquad_cascade_df1_q31(
   const arm_biquad_casd_df1_inst_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -1260,7 +1260,7 @@ extern "C"
    */
   void arm_biquad_cascade_df1_fast_q31(
   const arm_biquad_casd_df1_inst_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -1840,8 +1840,8 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -1854,8 +1854,8 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -1868,8 +1868,8 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -1912,7 +1912,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix2_q15(
   const arm_cfft_radix2_instance_q15 * S,
-  q15_t * pSrc);
+  const q15_t * pSrc);
 
 
   /**
@@ -1939,7 +1939,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix4_q15(
   const arm_cfft_radix4_instance_q15 * S,
-  q15_t * pSrc);
+  const q15_t * pSrc);
 
   /**
    * @brief Instance structure for the Radix-2 Q31 CFFT/CIFFT function.
@@ -1965,7 +1965,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix2_q31(
   const arm_cfft_radix2_instance_q31 * S,
-  q31_t * pSrc);
+  const q31_t * pSrc);
 
   /**
    * @brief Instance structure for the Q31 CFFT/CIFFT function.
@@ -1984,7 +1984,7 @@ extern "C"
 /* Deprecated */
   void arm_cfft_radix4_q31(
   const arm_cfft_radix4_instance_q31 * S,
-  q31_t * pSrc);
+  const q31_t * pSrc);
 
 /* Deprecated */
   arm_status arm_cfft_radix4_init_q31(
@@ -2120,7 +2120,7 @@ void arm_cfft_q31(
 
   void arm_rfft_q15(
   const arm_rfft_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst);
 
   /**
@@ -2145,7 +2145,7 @@ void arm_cfft_q31(
 
   void arm_rfft_q31(
   const arm_rfft_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst);
 
   /**
@@ -2371,8 +2371,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -2385,8 +2385,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -2399,8 +2399,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -2427,8 +2427,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -2441,8 +2441,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -2455,8 +2455,8 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -2484,7 +2484,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of samples in the vector
    */
   void arm_scale_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t scaleFract,
   int8_t shift,
   q7_t * pDst,
@@ -2500,7 +2500,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of samples in the vector
    */
   void arm_scale_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t scaleFract,
   int8_t shift,
   q15_t * pDst,
@@ -2516,7 +2516,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of samples in the vector
    */
   void arm_scale_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t scaleFract,
   int8_t shift,
   q31_t * pDst,
@@ -2530,7 +2530,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -2554,7 +2554,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -2566,7 +2566,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -2593,8 +2593,8 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   uint32_t blockSize,
   q31_t * result);
 
@@ -2607,8 +2607,8 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   uint32_t blockSize,
   q63_t * result);
 
@@ -2621,8 +2621,8 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   uint32_t blockSize,
   q63_t * result);
 
@@ -2635,7 +2635,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_shift_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   int8_t shiftBits,
   q7_t * pDst,
   uint32_t blockSize);
@@ -2649,7 +2649,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_shift_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   int8_t shiftBits,
   q15_t * pDst,
   uint32_t blockSize);
@@ -2663,7 +2663,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_shift_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   int8_t shiftBits,
   q31_t * pDst,
   uint32_t blockSize);
@@ -2691,7 +2691,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t offset,
   q7_t * pDst,
   uint32_t blockSize);
@@ -2705,7 +2705,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t offset,
   q15_t * pDst,
   uint32_t blockSize);
@@ -2719,7 +2719,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t offset,
   q31_t * pDst,
   uint32_t blockSize);
@@ -2744,7 +2744,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -2756,7 +2756,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -2768,7 +2768,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -2792,7 +2792,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -2804,7 +2804,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -2816,7 +2816,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -2896,9 +2896,9 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer of size min(srcALen, srcBLen).
    */
   void arm_conv_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch1,
@@ -2914,9 +2914,9 @@ void arm_rfft_fast_f32(
  * @param[out] pDst     points to the location where the output result is written.  Length srcALen+srcBLen-1.
  */
   void arm_conv_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst);
 
@@ -2930,9 +2930,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_fast_q15(
-          q15_t * pSrcA,
+          const q15_t * pSrcA,
           uint32_t srcALen,
-          q15_t * pSrcB,
+          const q15_t * pSrcB,
           uint32_t srcBLen,
           q15_t * pDst);
 
@@ -2948,9 +2948,9 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer of size min(srcALen, srcBLen).
    */
   void arm_conv_fast_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch1,
@@ -2966,9 +2966,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst);
 
@@ -2982,9 +2982,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_fast_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst);
 
@@ -3000,9 +3000,9 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer (of type q15_t) of size min(srcALen, srcBLen).
    */
   void arm_conv_opt_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   q15_t * pScratch1,
@@ -3018,9 +3018,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst);
 
@@ -3060,9 +3060,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -3083,9 +3083,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -3104,9 +3104,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_fast_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -3127,9 +3127,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_fast_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -3150,9 +3150,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst,
   uint32_t firstIndex,
@@ -3171,9 +3171,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_fast_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst,
   uint32_t firstIndex,
@@ -3194,9 +3194,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_opt_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   uint32_t firstIndex,
@@ -3217,9 +3217,9 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   uint32_t firstIndex,
@@ -3303,7 +3303,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_decimate_q15(
   const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -3317,7 +3317,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_decimate_fast_q15(
   const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -3351,7 +3351,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_decimate_q31(
   const arm_fir_decimate_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -3364,7 +3364,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_decimate_fast_q31(
   arm_fir_decimate_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -3432,7 +3432,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_interpolate_q15(
   const arm_fir_interpolate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -3466,7 +3466,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_interpolate_q31(
   const arm_fir_interpolate_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -3545,7 +3545,7 @@ void arm_rfft_fast_f32(
    */
   void arm_biquad_cas_df1_32x64_q31(
   const arm_biquad_cas_df1_32x64_ins_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -3734,7 +3734,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_lattice_q15(
   const arm_fir_lattice_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -3762,7 +3762,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_lattice_q31(
   const arm_fir_lattice_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -3870,7 +3870,7 @@ void arm_rfft_fast_f32(
    */
   void arm_iir_lattice_q31(
   const arm_iir_lattice_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -3902,7 +3902,7 @@ void arm_rfft_fast_f32(
    */
   void arm_iir_lattice_q15(
   const arm_iir_lattice_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -4017,7 +4017,7 @@ void arm_rfft_fast_f32(
    */
   void arm_lms_q15(
   const arm_lms_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pRef,
   q15_t * pOut,
   q15_t * pErr,
@@ -4048,7 +4048,7 @@ void arm_rfft_fast_f32(
    */
   void arm_lms_q31(
   const arm_lms_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pRef,
   q31_t * pOut,
   q31_t * pErr,
@@ -4152,7 +4152,7 @@ void arm_rfft_fast_f32(
    */
   void arm_lms_norm_q31(
   arm_lms_norm_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pRef,
   q31_t * pOut,
   q31_t * pErr,
@@ -4206,7 +4206,7 @@ void arm_rfft_fast_f32(
    */
   void arm_lms_norm_q15(
   arm_lms_norm_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pRef,
   q15_t * pOut,
   q15_t * pErr,
@@ -4259,9 +4259,9 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch  points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
    */
   void arm_correlate_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch);
@@ -4277,9 +4277,9 @@ void arm_rfft_fast_f32(
    */
 
   void arm_correlate_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst);
 
@@ -4294,9 +4294,9 @@ void arm_rfft_fast_f32(
    */
 
   void arm_correlate_fast_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst);
 
@@ -4311,9 +4311,9 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch  points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
    */
   void arm_correlate_fast_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch);
@@ -4328,9 +4328,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst);
 
@@ -4344,9 +4344,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_fast_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst);
 
@@ -4362,9 +4362,9 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer (of type q15_t) of size min(srcALen, srcBLen).
    */
   void arm_correlate_opt_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   q15_t * pScratch1,
@@ -4380,9 +4380,9 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst);
 
@@ -4486,7 +4486,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_sparse_q31(
   arm_fir_sparse_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   q31_t * pScratchIn,
   uint32_t blockSize);
@@ -4523,7 +4523,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_sparse_q15(
   arm_fir_sparse_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   q15_t * pScratchIn,
   q31_t * pScratchOut,
@@ -4561,7 +4561,7 @@ void arm_rfft_fast_f32(
    */
   void arm_fir_sparse_q7(
   arm_fir_sparse_instance_q7 * S,
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   q7_t * pScratchIn,
   q31_t * pScratchOut,
@@ -4630,7 +4630,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_conj_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t numSamples);
 
@@ -4642,7 +4642,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_conj_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t numSamples);
 
@@ -4666,7 +4666,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_squared_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t numSamples);
 
@@ -4678,7 +4678,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_squared_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t numSamples);
 
@@ -5006,7 +5006,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_q7_to_q31(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -5103,7 +5103,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_q7_to_q15(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -5227,7 +5227,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q7_to_float(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -5341,7 +5341,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q31_to_float(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -6091,7 +6091,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q63_t * pResult);
 
@@ -6115,7 +6115,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q63_t * pResult);
 
@@ -6127,7 +6127,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult);
 
@@ -6139,7 +6139,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q7_t * pResult);
 
@@ -6151,7 +6151,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult);
 
@@ -6163,7 +6163,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult);
 
@@ -6199,7 +6199,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_var_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult);
 
@@ -6211,7 +6211,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_var_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult);
 
@@ -6235,7 +6235,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_rms_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult);
 
@@ -6247,7 +6247,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_rms_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult);
 
@@ -6271,7 +6271,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_std_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult);
 
@@ -6283,7 +6283,7 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_std_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult);
 
@@ -6307,7 +6307,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t numSamples);
 
@@ -6319,7 +6319,7 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t numSamples);
 
@@ -6333,8 +6333,8 @@ void arm_rfft_fast_f32(
    * @param[out] imagResult  imaginary part of the result returned here
    */
   void arm_cmplx_dot_prod_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   uint32_t numSamples,
   q31_t * realResult,
   q31_t * imagResult);
@@ -6349,8 +6349,8 @@ void arm_rfft_fast_f32(
    * @param[out] imagResult  imaginary part of the result returned here
    */
   void arm_cmplx_dot_prod_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   uint32_t numSamples,
   q63_t * realResult,
   q63_t * imagResult);
@@ -6380,8 +6380,8 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of samples in each vector
    */
   void arm_cmplx_mult_real_q15(
-  q15_t * pSrcCmplx,
-  q15_t * pSrcReal,
+  const q15_t * pSrcCmplx,
+  const q15_t * pSrcReal,
   q15_t * pCmplxDst,
   uint32_t numSamples);
 
@@ -6394,8 +6394,8 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of samples in each vector
    */
   void arm_cmplx_mult_real_q31(
-  q31_t * pSrcCmplx,
-  q31_t * pSrcReal,
+  const q31_t * pSrcCmplx,
+  const q31_t * pSrcReal,
   q31_t * pCmplxDst,
   uint32_t numSamples);
 
@@ -6422,7 +6422,7 @@ void arm_rfft_fast_f32(
    * @param[in]  index      is the array index of the minimum value in the input buffer.
    */
   void arm_min_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q7_t * result,
   uint32_t * index);
@@ -6436,7 +6436,7 @@ void arm_rfft_fast_f32(
    * @param[in]  pIndex     is the array index of the minimum value in the input buffer.
    */
   void arm_min_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult,
   uint32_t * pIndex);
@@ -6450,7 +6450,7 @@ void arm_rfft_fast_f32(
    * @param[out] pIndex     is the array index of the minimum value in the input buffer.
    */
   void arm_min_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult,
   uint32_t * pIndex);
@@ -6478,7 +6478,7 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q7_t * pResult,
   uint32_t * pIndex);
@@ -6492,7 +6492,7 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult,
   uint32_t * pIndex);
@@ -6506,7 +6506,7 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult,
   uint32_t * pIndex);
@@ -6534,8 +6534,8 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_mult_cmplx_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t numSamples);
 
@@ -6548,8 +6548,8 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_mult_cmplx_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t numSamples);
 
@@ -6611,7 +6611,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q31_to_q15(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize);
 
@@ -6623,7 +6623,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q31_to_q7(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize);
 
@@ -6635,7 +6635,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q15_to_float(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize);
 
@@ -6647,7 +6647,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q15_to_q31(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize);
 
@@ -6659,7 +6659,7 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q15_to_q7(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize);
 

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_f32.c
@@ -61,7 +61,7 @@
  */
 
 void arm_abs_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_q15.c
@@ -51,7 +51,7 @@
  */
 
 void arm_abs_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_q31.c
@@ -52,7 +52,7 @@
  */
 
 void arm_abs_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_abs_q7.c
@@ -55,7 +55,7 @@
  */
 
 void arm_abs_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_add_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_add_f32.c
@@ -59,8 +59,8 @@
  */
 
 void arm_add_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q15.c
@@ -52,8 +52,8 @@
  */
 
 void arm_add_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q31.c
@@ -53,8 +53,8 @@
  */
 
 void arm_add_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q7.c
@@ -52,8 +52,8 @@
  */
 
 void arm_add_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
@@ -61,8 +61,8 @@
 
 
 void arm_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   uint32_t blockSize,
   float32_t * result)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_q15.c
@@ -55,8 +55,8 @@
  */
 
 void arm_dot_prod_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   uint32_t blockSize,
   q63_t * result)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_q31.c
@@ -56,8 +56,8 @@
  */
 
 void arm_dot_prod_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   uint32_t blockSize,
   q63_t * result)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_q7.c
@@ -55,8 +55,8 @@
  */
 
 void arm_dot_prod_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   uint32_t blockSize,
   q31_t * result)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_f32.c
@@ -59,8 +59,8 @@
  */
 
 void arm_mult_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_q15.c
@@ -53,8 +53,8 @@
  */
 
 void arm_mult_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_q31.c
@@ -52,8 +52,8 @@
  */
 
 void arm_mult_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_q7.c
@@ -52,8 +52,8 @@
  */
 
 void arm_mult_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_f32.c
@@ -60,7 +60,7 @@
  */
 
 void arm_negate_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_q15.c
@@ -55,7 +55,7 @@
  */
 
 void arm_negate_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_q31.c
@@ -51,7 +51,7 @@
  */
 
 void arm_negate_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_negate_q7.c
@@ -51,7 +51,7 @@
  */
 
 void arm_negate_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_f32.c
@@ -62,7 +62,7 @@
 
 
 void arm_offset_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t offset,
   float32_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q15.c
@@ -52,7 +52,7 @@
  */
 
 void arm_offset_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t offset,
   q15_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q31.c
@@ -52,7 +52,7 @@
  */
 
 void arm_offset_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t offset,
   q31_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q7.c
@@ -52,7 +52,7 @@
  */
 
 void arm_offset_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t offset,
   q7_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_f32.c
@@ -75,7 +75,7 @@
 
 
 void arm_scale_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t scale,
   float32_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_q15.c
@@ -54,7 +54,7 @@
 
 
 void arm_scale_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t scaleFract,
   int8_t shift,
   q15_t * pDst,

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_q31.c
@@ -53,7 +53,7 @@
  */
 
 void arm_scale_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t scaleFract,
   int8_t shift,
   q31_t * pDst,

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_q7.c
@@ -53,7 +53,7 @@
  */
 
 void arm_scale_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t scaleFract,
   int8_t shift,
   q7_t * pDst,

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_shift_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_shift_q15.c
@@ -52,7 +52,7 @@
  */
 
 void arm_shift_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   int8_t shiftBits,
   q15_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_shift_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_shift_q31.c
@@ -70,7 +70,7 @@
  */
 
 void arm_shift_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   int8_t shiftBits,
   q31_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_shift_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_shift_q7.c
@@ -57,7 +57,7 @@
  */
 
 void arm_shift_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   int8_t shiftBits,
   q7_t * pDst,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_f32.c
@@ -60,8 +60,8 @@
  */
 
 void arm_sub_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_q15.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_q15.c
@@ -52,8 +52,8 @@
  */
 
 void arm_sub_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_q31.c
@@ -52,8 +52,8 @@
  */
 
 void arm_sub_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_q7.c
@@ -52,8 +52,8 @@
  */
 
 void arm_sub_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
+  const q7_t * pSrcA,
+  const q7_t * pSrcB,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_conj_f32.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_conj_f32.c
@@ -69,7 +69,7 @@
  */
 
 void arm_cmplx_conj_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_conj_q15.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_conj_q15.c
@@ -51,7 +51,7 @@
  */
 
 void arm_cmplx_conj_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_conj_q31.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_conj_q31.c
@@ -51,7 +51,7 @@
  */
 
 void arm_cmplx_conj_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_dot_prod_f32.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_dot_prod_f32.c
@@ -74,8 +74,8 @@
  */
 
 void arm_cmplx_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   uint32_t numSamples,
   float32_t * realResult,
   float32_t * imagResult)

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_dot_prod_q15.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_dot_prod_q15.c
@@ -56,8 +56,8 @@
  */
 
 void arm_cmplx_dot_prod_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   uint32_t numSamples,
   q31_t * realResult,
   q31_t * imagResult)

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_dot_prod_q31.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_dot_prod_q31.c
@@ -57,8 +57,8 @@
  */
 
 void arm_cmplx_dot_prod_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   uint32_t numSamples,
   q63_t * realResult,
   q63_t * imagResult)

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_f32.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_f32.c
@@ -70,7 +70,7 @@
 
 
 void arm_cmplx_mag_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_q15.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_q15.c
@@ -51,7 +51,7 @@
  */
 
 void arm_cmplx_mag_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_q31.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_q31.c
@@ -51,7 +51,7 @@
  */
 
 void arm_cmplx_mag_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_squared_f32.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_squared_f32.c
@@ -71,7 +71,7 @@
  */
 
 void arm_cmplx_mag_squared_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_squared_q15.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_squared_q15.c
@@ -50,7 +50,7 @@
  */
 
 void arm_cmplx_mag_squared_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_squared_q31.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mag_squared_q31.c
@@ -52,7 +52,7 @@
  */
 
 void arm_cmplx_mag_squared_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_cmplx_f32.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_cmplx_f32.c
@@ -70,8 +70,8 @@
  */
 
 void arm_cmplx_mult_cmplx_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
+  const float32_t * pSrcA,
+  const float32_t * pSrcB,
   float32_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_cmplx_q15.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_cmplx_q15.c
@@ -51,8 +51,8 @@
  */
 
 void arm_cmplx_mult_cmplx_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
+  const q15_t * pSrcA,
+  const q15_t * pSrcB,
   q15_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_cmplx_q31.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_cmplx_q31.c
@@ -53,8 +53,8 @@
  */
 
 void arm_cmplx_mult_cmplx_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
+  const q31_t * pSrcA,
+  const q31_t * pSrcB,
   q31_t * pDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_real_f32.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_real_f32.c
@@ -71,8 +71,8 @@
  */
 
 void arm_cmplx_mult_real_f32(
-  float32_t * pSrcCmplx,
-  float32_t * pSrcReal,
+  const float32_t * pSrcCmplx,
+  const float32_t * pSrcReal,
   float32_t * pCmplxDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_real_q15.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_real_q15.c
@@ -53,8 +53,8 @@
  */
 
 void arm_cmplx_mult_real_q15(
-  q15_t * pSrcCmplx,
-  q15_t * pSrcReal,
+  const q15_t * pSrcCmplx,
+  const q15_t * pSrcReal,
   q15_t * pCmplxDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_real_q31.c
+++ b/CMSIS/DSP/Source/ComplexMathFunctions/arm_cmplx_mult_real_q31.c
@@ -53,8 +53,8 @@
  */
 
 void arm_cmplx_mult_real_q31(
-  q31_t * pSrcCmplx,
-  q31_t * pSrcReal,
+  const q31_t * pSrcCmplx,
+  const q31_t * pSrcReal,
   q31_t * pCmplxDst,
   uint32_t numSamples)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_init_q31.c
@@ -73,7 +73,7 @@
 void arm_biquad_cas_df1_32x64_init_q31(
   arm_biquad_cas_df1_32x64_ins_q31 * S,
   uint8_t numStages,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q63_t * pState,
   uint8_t postShift)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_q31.c
@@ -174,14 +174,14 @@
 
 void arm_biquad_cas_df1_32x64_q31(
   const arm_biquad_cas_df1_32x64_ins_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
-  q31_t *pIn = pSrc;                             /*  input pointer initialization  */
+  const q31_t *pIn = pSrc;                       /*  input pointer initialization  */
   q31_t *pOut = pDst;                            /*  output pointer initialization */
   q63_t *pState = S->pState;                     /*  state pointer initialization  */
-  q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
+  const q31_t *pCoeffs = S->pCoeffs;             /*  coeff pointer initialization  */
   q63_t acc;                                     /*  accumulator                   */
   q31_t Xn1, Xn2;                                /*  Input Filter state variables        */
   q63_t Yn1, Yn2;                                /*  Output Filter state variables        */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f32.c
@@ -164,14 +164,14 @@
 
 void arm_biquad_cascade_df1_f32(
   const arm_biquad_casd_df1_inst_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
-  float32_t *pIn = pSrc;                         /*  source pointer            */
+  const float32_t *pIn = pSrc;                   /*  source pointer            */
   float32_t *pOut = pDst;                        /*  destination pointer       */
   float32_t *pState = S->pState;                 /*  pState pointer            */
-  float32_t *pCoeffs = S->pCoeffs;               /*  coefficient pointer       */
+  const float32_t *pCoeffs = S->pCoeffs;         /*  coefficient pointer       */
   float32_t acc;                                 /*  Simulates the accumulator */
   float32_t b0, b1, b2, a1, a2;                  /*  Filter coefficients       */
   float32_t Xn1, Xn2, Yn1, Yn2;                  /*  Filter pState variables   */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_fast_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_fast_q15.c
@@ -61,11 +61,11 @@
 
 void arm_biquad_cascade_df1_fast_q15(
   const arm_biquad_casd_df1_inst_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
-  q15_t *pIn = pSrc;                             /*  Source pointer                               */
+  const q15_t *pIn = pSrc;                       /*  Source pointer                               */
   q15_t *pOut = pDst;                            /*  Destination pointer                          */
   q31_t in;                                      /*  Temporary variable to hold input value       */
   q31_t out;                                     /*  Temporary variable to hold output value      */
@@ -75,7 +75,7 @@ void arm_biquad_cascade_df1_fast_q15(
   q31_t acc;                                     /*  Accumulator                                  */
   int32_t shift = (int32_t) (15 - S->postShift); /*  Post shift                                   */
   q15_t *pState = S->pState;                     /*  State pointer                                */
-  q15_t *pCoeffs = S->pCoeffs;                   /*  Coefficient pointer                          */
+  const q15_t *pCoeffs = S->pCoeffs;                   /*  Coefficient pointer                          */
   uint32_t sample, stage = S->numStages;         /*  Stage loop counter                           */
 
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_fast_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_fast_q31.c
@@ -63,17 +63,17 @@
 
 void arm_biquad_cascade_df1_fast_q31(
   const arm_biquad_casd_df1_inst_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t acc = 0;                                 /*  accumulator                   */
   q31_t Xn1, Xn2, Yn1, Yn2;                      /*  Filter state variables        */
   q31_t b0, b1, b2, a1, a2;                      /*  Filter coefficients           */
-  q31_t *pIn = pSrc;                             /*  input pointer initialization  */
+  const q31_t *pIn = pSrc;                       /*  input pointer initialization  */
   q31_t *pOut = pDst;                            /*  output pointer initialization */
   q31_t *pState = S->pState;                     /*  pState pointer initialization */
-  q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
+  const q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
   q31_t Xn;                                      /*  temporary input               */
   int32_t shift = (int32_t) S->postShift + 1;    /*  Shift to be applied to the output */
   uint32_t sample, stage = S->numStages;         /*  loop counters                     */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_init_f32.c
@@ -76,7 +76,7 @@
 void arm_biquad_cascade_df1_init_f32(
   arm_biquad_casd_df1_inst_f32 * S,
   uint8_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState)
 {
   /* Assign filter stages */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_init_q15.c
@@ -74,7 +74,7 @@
 void arm_biquad_cascade_df1_init_q15(
   arm_biquad_casd_df1_inst_q15 * S,
   uint8_t numStages,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   int8_t postShift)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_init_q31.c
@@ -73,7 +73,7 @@
 void arm_biquad_cascade_df1_init_q31(
   arm_biquad_casd_df1_inst_q31 * S,
   uint8_t numStages,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   int8_t postShift)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q15.c
@@ -61,7 +61,7 @@
 
 void arm_biquad_cascade_df1_q15(
   const arm_biquad_casd_df1_inst_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
@@ -71,7 +71,7 @@ void arm_biquad_cascade_df1_q15(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q15_t *pIn = pSrc;                             /*  Source pointer                               */
+  const q15_t *pIn = pSrc;                             /*  Source pointer                               */
   q15_t *pOut = pDst;                            /*  Destination pointer                          */
   q31_t in;                                      /*  Temporary variable to hold input value       */
   q31_t out;                                     /*  Temporary variable to hold output value      */
@@ -82,7 +82,7 @@ void arm_biquad_cascade_df1_q15(
   q63_t acc;                                     /*  Accumulator                                  */
   int32_t lShift = (15 - (int32_t) S->postShift);       /*  Post shift                                   */
   q15_t *pState = S->pState;                     /*  State pointer                                */
-  q15_t *pCoeffs = S->pCoeffs;                   /*  Coefficient pointer                          */
+  const q15_t *pCoeffs = S->pCoeffs;                   /*  Coefficient pointer                          */
   uint32_t sample, stage = (uint32_t) S->numStages;     /*  Stage loop counter                           */
   int32_t uShift = (32 - lShift);
 
@@ -309,7 +309,7 @@ void arm_biquad_cascade_df1_q15(
   q63_t acc;                                     /*  Accumulator                                  */
   int32_t shift = (15 - (int32_t) S->postShift); /*  Post shift                                   */
   q15_t *pState = S->pState;                     /*  State pointer                                */
-  q15_t *pCoeffs = S->pCoeffs;                   /*  Coefficient pointer                          */
+  const q15_t *pCoeffs = S->pCoeffs;                   /*  Coefficient pointer                          */
   uint32_t sample, stage = (uint32_t) S->numStages;     /*  Stage loop counter                           */
 
   do

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q15.c
@@ -301,16 +301,16 @@ void arm_biquad_cascade_df1_q15(
 
   /* Run the below code for Cortex-M0 */
 
-  q15_t *pIn = pSrc;                             /*  Source pointer                               */
-  q15_t *pOut = pDst;                            /*  Destination pointer                          */
-  q15_t b0, b1, b2, a1, a2;                      /*  Filter coefficients           */
-  q15_t Xn1, Xn2, Yn1, Yn2;                      /*  Filter state variables        */
-  q15_t Xn;                                      /*  temporary input               */
-  q63_t acc;                                     /*  Accumulator                                  */
-  int32_t shift = (15 - (int32_t) S->postShift); /*  Post shift                                   */
-  q15_t *pState = S->pState;                     /*  State pointer                                */
-  const q15_t *pCoeffs = S->pCoeffs;                   /*  Coefficient pointer                          */
-  uint32_t sample, stage = (uint32_t) S->numStages;     /*  Stage loop counter                           */
+  const q15_t *pIn = pSrc;                           /*  Source pointer          */
+  q15_t *pOut = pDst;                                /*  Destination pointer     */
+  q15_t b0, b1, b2, a1, a2;                          /*  Filter coefficients     */
+  q15_t Xn1, Xn2, Yn1, Yn2;                          /*  Filter state variables  */
+  q15_t Xn;                                          /*  temporary input         */
+  q63_t acc;                                         /*  Accumulator             */
+  int32_t shift = (15 - (int32_t) S->postShift);     /*  Post shift              */
+  q15_t *pState = S->pState;                         /*  State pointer           */
+  const q15_t *pCoeffs = S->pCoeffs;                 /*  Coefficient pointer     */
+  uint32_t sample, stage = (uint32_t) S->numStages;  /*  Stage loop counter      */
 
   do
   {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q31.c
@@ -60,17 +60,17 @@
 
 void arm_biquad_cascade_df1_q31(
   const arm_biquad_casd_df1_inst_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q63_t acc;                                     /*  accumulator                   */
   uint32_t uShift = ((uint32_t) S->postShift + 1U);
   uint32_t lShift = 32U - uShift;                /*  Shift to be applied to the output */
-  q31_t *pIn = pSrc;                             /*  input pointer initialization  */
+  const q31_t *pIn = pSrc;                       /*  input pointer initialization  */
   q31_t *pOut = pDst;                            /*  output pointer initialization */
   q31_t *pState = S->pState;                     /*  pState pointer initialization */
-  q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
+  const q31_t *pCoeffs = S->pCoeffs;                   /*  coeff pointer initialization  */
   q31_t Xn1, Xn2, Yn1, Yn2;                      /*  Filter state variables        */
   q31_t b0, b1, b2, a1, a2;                      /*  Filter coefficients           */
   q31_t Xn;                                      /*  temporary input               */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df2T_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df2T_f32.c
@@ -141,15 +141,15 @@
 LOW_OPTIMIZATION_ENTER
 void arm_biquad_cascade_df2T_f32(
 const arm_biquad_cascade_df2T_instance_f32 * S,
-float32_t * pSrc,
+const float32_t * pSrc,
 float32_t * pDst,
 uint32_t blockSize)
 {
 
-   float32_t *pIn = pSrc;                         /*  source pointer            */
+   const float32_t *pIn = pSrc;                   /*  source pointer            */
    float32_t *pOut = pDst;                        /*  destination pointer       */
    float32_t *pState = S->pState;                 /*  State pointer             */
-   float32_t *pCoeffs = S->pCoeffs;               /*  coefficient pointer       */
+   const float32_t *pCoeffs = S->pCoeffs;         /*  coefficient pointer       */
    float32_t acc1;                                /*  accumulator               */
    float32_t b0, b1, b2, a1, a2;                  /*  Filter coefficients       */
    float32_t Xn1;                                 /*  temporary input           */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df2T_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df2T_init_f32.c
@@ -68,7 +68,7 @@
 void arm_biquad_cascade_df2T_init_f32(
   arm_biquad_cascade_df2T_instance_f32 * S,
   uint8_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState)
 {
   /* Assign filter stages */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f32.c
@@ -141,15 +141,15 @@
 LOW_OPTIMIZATION_ENTER
 void arm_biquad_cascade_stereo_df2T_f32(
 const arm_biquad_cascade_stereo_df2T_instance_f32 * S,
-float32_t * pSrc,
+const float32_t * pSrc,
 float32_t * pDst,
 uint32_t blockSize)
 {
 
-    float32_t *pIn = pSrc;                         /*  source pointer            */
+    const float32_t *pIn = pSrc;                   /*  source pointer            */
     float32_t *pOut = pDst;                        /*  destination pointer       */
     float32_t *pState = S->pState;                 /*  State pointer             */
-    float32_t *pCoeffs = S->pCoeffs;               /*  coefficient pointer       */
+    const float32_t *pCoeffs = S->pCoeffs;         /*  coefficient pointer       */
     float32_t acc1a, acc1b;                        /*  accumulator               */
     float32_t b0, b1, b2, a1, a2;                  /*  Filter coefficients       */
     float32_t Xn1a, Xn1b;                          /*  temporary input           */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_init_f32.c
@@ -68,7 +68,7 @@
 void arm_biquad_cascade_stereo_df2T_init_f32(
   arm_biquad_cascade_stereo_df2T_instance_f32 * S,
   uint8_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState)
 {
   /* Assign filter stages */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_f32.c
@@ -110,9 +110,9 @@
  */
 
 void arm_conv_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst)
 {
@@ -122,12 +122,12 @@ void arm_conv_f32(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  float32_t *pIn1;                               /* inputA pointer */
-  float32_t *pIn2;                               /* inputB pointer */
+  const float32_t *pIn1;                               /* inputA pointer */
+  const float32_t *pIn2;                               /* inputB pointer */
   float32_t *pOut = pDst;                        /* output pointer */
-  float32_t *px;                                 /* Intermediate inputA pointer */
-  float32_t *py;                                 /* Intermediate inputB pointer */
-  float32_t *pSrc1, *pSrc2;                      /* Intermediate pointers */
+  const float32_t *px;                                 /* Intermediate inputA pointer */
+  const float32_t *py;                                 /* Intermediate inputB pointer */
+  const float32_t *pSrc1, *pSrc2;                      /* Intermediate pointers */
   float32_t sum, acc0, acc1, acc2, acc3;         /* Accumulator */
   float32_t x0, x1, x2, x3, c0;                  /* Temporary variables to hold state and coefficient values */
   uint32_t j, k, count, blkCnt, blockSize1, blockSize2, blockSize3;     /* loop counters */
@@ -601,8 +601,8 @@ void arm_conv_f32(
 
   /* Run the below code for Cortex-M0 */
 
-  float32_t *pIn1 = pSrcA;                       /* inputA pointer */
-  float32_t *pIn2 = pSrcB;                       /* inputB pointer */
+  const float32_t *pIn1 = pSrcA;                       /* inputA pointer */
+  const float32_t *pIn2 = pSrcB;                       /* inputB pointer */
   float32_t sum;                                 /* Accumulator */
   uint32_t i, j;                                 /* loop counters */
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_opt_q15.c
@@ -69,9 +69,9 @@
  */
 
 void arm_conv_fast_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch1,
@@ -83,10 +83,10 @@ void arm_conv_fast_opt_q15(
   q15_t *pOut = pDst;                            /* output pointer */
   q15_t *pScr1 = pScratch1;                      /* Temporary pointer for scratch1 */
   q15_t *pScr2 = pScratch2;                      /* Temporary pointer for scratch1 */
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pIn1;                             /* inputA pointer */
+  const q15_t *pIn2;                             /* inputB pointer */
+  const q15_t *px;                               /* Intermediate inputA pointer  */
+  const q15_t *py;                               /* Intermediate inputB pointer  */
   uint32_t j, k, blkCnt;                         /* loop counter */
   uint32_t tapCnt;                               /* loop count */
 #ifdef UNALIGNED_SUPPORT_DISABLE
@@ -158,7 +158,7 @@ void arm_conv_fast_opt_q15(
     k--;
   }
 
-  /* Initialze temporary scratch pointer */
+  /* Initialize temporary scratch pointer */
   pScr1 = pScratch1;
 
   /* Assuming scratch1 buffer is aligned by 32-bit */
@@ -270,10 +270,10 @@ void arm_conv_fast_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -296,7 +296,7 @@ void arm_conv_fast_opt_q15(
       y1 = _SIMD32_OFFSET(pIn2);
       y2 = _SIMD32_OFFSET(pIn2 + 2U);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x1, y1, acc0);
       acc2 = __SMLAD(x2, y1, acc2);
 
@@ -307,13 +307,13 @@ void arm_conv_fast_opt_q15(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLADX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
       x1 = _SIMD32_OFFSET(pScr1);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x2, y2, acc0);
       acc2 = __SMLAD(x1, y2, acc2);
 
@@ -429,7 +429,7 @@ void arm_conv_fast_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2);
       acc1 += (*pScr1++ * *pIn2);
       acc2 += (*pScr1++ * *pIn2);
@@ -480,10 +480,10 @@ void arm_conv_fast_opt_q15(
   /* Calculate convolution for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;
@@ -504,7 +504,7 @@ void arm_conv_fast_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2++);
 
       /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_q15.c
@@ -63,20 +63,20 @@
  */
 
 void arm_conv_fast_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst)
 {
 #ifndef UNALIGNED_SUPPORT_DISABLE
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
+  const q15_t *pIn1;                             /* inputA pointer */
+  const q15_t *pIn2;                             /* inputB pointer */
   q15_t *pOut = pDst;                            /* output pointer */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulator */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
   q31_t x0, x1, x2, x3, c0;                      /* Temporary variables to hold state and coefficient values */
   uint32_t blockSize1, blockSize2, blockSize3, j, k, count, blkCnt;     /* loop counter */
 
@@ -673,13 +673,13 @@ void arm_conv_fast_q15(
   }
 
 #else
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
+  const q15_t *pIn1;                                   /* inputA pointer */
+  const q15_t *pIn2;                                   /* inputB pointer */
   q15_t *pOut = pDst;                            /* output pointer */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulator */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
   q31_t x0, x1, x2, x3, c0;                      /* Temporary variables to hold state and coefficient values */
   uint32_t blockSize1, blockSize2, blockSize3, j, k, count, blkCnt;     /* loop counter */
   q15_t a, b;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_q31.c
@@ -65,18 +65,18 @@
  */
 
 void arm_conv_fast_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst)
 {
-  q31_t *pIn1;                                   /* inputA pointer */
-  q31_t *pIn2;                                   /* inputB pointer */
+  const q31_t *pIn1;                             /* inputA pointer */
+  const q31_t *pIn2;                             /* inputB pointer */
   q31_t *pOut = pDst;                            /* output pointer */
-  q31_t *px;                                     /* Intermediate inputA pointer  */
-  q31_t *py;                                     /* Intermediate inputB pointer  */
-  q31_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
+  const q31_t *px;                               /* Intermediate inputA pointer  */
+  const q31_t *py;                               /* Intermediate inputB pointer  */
+  const q31_t *pSrc1, *pSrc2;                    /* Intermediate pointers */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulator */
   q31_t x0, x1, x2, x3, c0;                      /* Temporary variables to hold state and coefficient values */
   uint32_t j, k, count, blkCnt, blockSize1, blockSize2, blockSize3;     /* loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q15.c
@@ -71,9 +71,9 @@
  */
 
 void arm_conv_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch1,
@@ -85,10 +85,10 @@ void arm_conv_opt_q15(
   q15_t *pOut = pDst;                            /* output pointer */
   q15_t *pScr1 = pScratch1;                      /* Temporary pointer for scratch1 */
   q15_t *pScr2 = pScratch2;                      /* Temporary pointer for scratch1 */
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pIn1;                             /* inputA pointer */
+  const q15_t *pIn2;                             /* inputB pointer */
+  const q15_t *px;                               /* Intermediate inputA pointer  */
+  const q15_t *py;                               /* Intermediate inputB pointer  */
   uint32_t j, k, blkCnt;                         /* loop counter */
   uint32_t tapCnt;                               /* loop count */
 #ifdef UNALIGNED_SUPPORT_DISABLE
@@ -160,7 +160,7 @@ void arm_conv_opt_q15(
     k--;
   }
 
-  /* Initialze temporary scratch pointer */
+  /* Initialize temporary scratch pointer */
   pScr1 = pScratch1;
 
   /* Assuming scratch1 buffer is aligned by 32-bit */
@@ -272,10 +272,10 @@ void arm_conv_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -298,7 +298,7 @@ void arm_conv_opt_q15(
       y1 = _SIMD32_OFFSET(pIn2);
       y2 = _SIMD32_OFFSET(pIn2 + 2U);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLALD(x1, y1, acc0);
       acc2 = __SMLALD(x2, y1, acc2);
 
@@ -309,13 +309,13 @@ void arm_conv_opt_q15(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLALDX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
       x1 = _SIMD32_OFFSET(pScr1);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLALD(x2, y2, acc0);
       acc2 = __SMLALD(x1, y2, acc2);
 
@@ -430,7 +430,7 @@ void arm_conv_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2);
       acc1 += (*pScr1++ * *pIn2);
       acc2 += (*pScr1++ * *pIn2);
@@ -479,10 +479,10 @@ void arm_conv_opt_q15(
   /* Calculate convolution for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;
@@ -504,7 +504,7 @@ void arm_conv_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2++);
 
       /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q7.c
@@ -65,9 +65,9 @@
  */
 
 void arm_conv_opt_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   q15_t * pScratch1,
@@ -76,9 +76,9 @@ void arm_conv_opt_q7(
 
   q15_t *pScr2, *pScr1;                          /* Intermediate pointers for scratch pointers */
   q15_t x4;                                      /* Temporary input variable */
-  q7_t *pIn1, *pIn2;                             /* inputA and inputB pointer */
+  const q7_t *pIn1, *pIn2;                             /* inputA and inputB pointer */
   uint32_t j, k, blkCnt, tapCnt;                 /* loop counter */
-  q7_t *px;                                      /* Temporary input1 pointer */
+  const q7_t *px;                                      /* Temporary input1 pointer */
   q15_t *py;                                     /* Temporary input2 pointer */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulator */
   q31_t x1, x2, x3, y1;                          /* Temporary input variables */
@@ -151,7 +151,7 @@ void arm_conv_opt_q7(
     k--;
   }
 
-  /* Initialze temporary scratch pointer */
+  /* Initialize temporary scratch pointer */
   pScr1 = pScratch1;
 
   /* Fill (srcBLen - 1U) zeros in scratch buffer */
@@ -251,10 +251,10 @@ void arm_conv_opt_q7(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -274,7 +274,7 @@ void arm_conv_opt_q7(
       /* Read four samples from smaller buffer */
       y1 = _SIMD32_OFFSET(pScr2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x1, y1, acc0);
       acc2 = __SMLAD(x2, y1, acc2);
 
@@ -285,7 +285,7 @@ void arm_conv_opt_q7(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLADX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
@@ -338,7 +338,7 @@ void arm_conv_opt_q7(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2);
       acc1 += (*pScr1++ * *pScr2);
       acc2 += (*pScr1++ * *pScr2);
@@ -373,10 +373,10 @@ void arm_conv_opt_q7(
   /* Calculate convolution for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;
@@ -396,7 +396,7 @@ void arm_conv_opt_q7(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2++);
 
       /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_f32.c
@@ -96,7 +96,7 @@ arm_status arm_conv_partial_f32(
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
   const float32_t *pIn1 = pSrcA;                 /* inputA pointer */
-  const const float32_t *pIn2 = pSrcB;                 /* inputB pointer */
+  const float32_t *pIn2 = pSrcB;                 /* inputB pointer */
   float32_t *pOut = pDst;                        /* output pointer */
   const float32_t *px;                           /* Intermediate inputA pointer */
   const float32_t *py;                           /* Intermediate inputB pointer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_f32.c
@@ -81,9 +81,9 @@
  */
 
 arm_status arm_conv_partial_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst,
   uint32_t firstIndex,
@@ -95,12 +95,12 @@ arm_status arm_conv_partial_f32(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  float32_t *pIn1 = pSrcA;                       /* inputA pointer */
-  float32_t *pIn2 = pSrcB;                       /* inputB pointer */
+  const float32_t *pIn1 = pSrcA;                 /* inputA pointer */
+  const const float32_t *pIn2 = pSrcB;                 /* inputB pointer */
   float32_t *pOut = pDst;                        /* output pointer */
-  float32_t *px;                                 /* Intermediate inputA pointer */
-  float32_t *py;                                 /* Intermediate inputB pointer */
-  float32_t *pSrc1, *pSrc2;                      /* Intermediate pointers */
+  const float32_t *px;                           /* Intermediate inputA pointer */
+  const float32_t *py;                           /* Intermediate inputB pointer */
+  const float32_t *pSrc1, *pSrc2;                /* Intermediate pointers */
   float32_t sum, acc0, acc1, acc2, acc3;         /* Accumulator */
   float32_t x0, x1, x2, x3, c0;                  /* Temporary variables to hold state and coefficient values */
   uint32_t j, k, count = 0U, blkCnt, check;
@@ -611,8 +611,8 @@ arm_status arm_conv_partial_f32(
 
   /* Run the below code for Cortex-M0 */
 
-  float32_t *pIn1 = pSrcA;                       /* inputA pointer */
-  float32_t *pIn2 = pSrcB;                       /* inputB pointer */
+  const float32_t *pIn1 = pSrcA;                       /* inputA pointer */
+  const float32_t *pIn2 = pSrcB;                       /* inputB pointer */
   float32_t sum;                                 /* Accumulator */
   uint32_t i, j;                                 /* loop counters */
   arm_status status;                             /* status of Partial convolution */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_opt_q15.c
@@ -61,9 +61,9 @@
 #ifndef UNALIGNED_SUPPORT_DISABLE
 
 arm_status arm_conv_partial_fast_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -78,10 +78,10 @@ arm_status arm_conv_partial_fast_opt_q15(
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulator */
   q31_t x1, x2, x3;                              /* Temporary variables to hold state and coefficient values */
   q31_t y1, y2;                                  /* State variables */
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pIn1;                             /* inputA pointer */
+  const q15_t *pIn2;                             /* inputB pointer */
+  const q15_t *px;                               /* Intermediate inputA pointer  */
+  const q15_t *py;                               /* Intermediate inputB pointer  */
   uint32_t j, k, blkCnt;                         /* loop counter */
   arm_status status;
 
@@ -162,7 +162,7 @@ arm_status arm_conv_partial_fast_opt_q15(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Assuming scratch1 buffer is aligned by 32-bit */
@@ -201,10 +201,10 @@ arm_status arm_conv_partial_fast_opt_q15(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -225,7 +225,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         y1 = _SIMD32_OFFSET(pIn2);
         y2 = _SIMD32_OFFSET(pIn2 + 2U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLAD(x1, y1, acc0);
         acc2 = __SMLAD(x2, y1, acc2);
 
@@ -236,13 +236,13 @@ arm_status arm_conv_partial_fast_opt_q15(
         x3 = __PKHBT(x1, x2, 0);
 #endif
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 = __SMLADX(x3, y1, acc1);
 
         /* Read next two samples from scratch1 buffer */
         x1 = _SIMD32_OFFSET(pScr1);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLAD(x2, y2, acc0);
 
         acc2 = __SMLAD(x1, y2, acc2);
@@ -285,7 +285,7 @@ arm_status arm_conv_partial_fast_opt_q15(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2);
         acc1 += (*pScr1++ * *pIn2);
         acc2 += (*pScr1++ * *pIn2);
@@ -331,10 +331,10 @@ arm_status arm_conv_partial_fast_opt_q15(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;
@@ -360,7 +360,7 @@ arm_status arm_conv_partial_fast_opt_q15(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2++);
 
         /* Decrement the loop counter */
@@ -389,9 +389,9 @@ arm_status arm_conv_partial_fast_opt_q15(
 #else
 
 arm_status arm_conv_partial_fast_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -404,10 +404,10 @@ arm_status arm_conv_partial_fast_opt_q15(
   q15_t *pScr1 = pScratch1;                      /* Temporary pointer for scratch1 */
   q15_t *pScr2 = pScratch2;                      /* Temporary pointer for scratch1 */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulator */
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pIn1;                                   /* inputA pointer */
+  const q15_t *pIn2;                                   /* inputB pointer */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
   uint32_t j, k, blkCnt;                         /* loop counter */
   arm_status status;                             /* Status variable */
   uint32_t tapCnt;                               /* loop count */
@@ -488,7 +488,7 @@ arm_status arm_conv_partial_fast_opt_q15(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Fill (srcBLen - 1U) zeros in scratch buffer */
@@ -574,10 +574,10 @@ arm_status arm_conv_partial_fast_opt_q15(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -600,13 +600,13 @@ arm_status arm_conv_partial_fast_opt_q15(
         y10 = *pIn2;
         y11 = *(pIn2 + 1U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q31_t) x10 *y10;
         acc0 += (q31_t) x11 *y11;
         acc2 += (q31_t) x20 *y10;
         acc2 += (q31_t) x21 *y11;
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 += (q31_t) x11 *y10;
         acc1 += (q31_t) x20 *y11;
 
@@ -614,7 +614,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         x10 = *pScr1;
         x11 = *(pScr1 + 1U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc3 += (q31_t) x21 *y10;
         acc3 += (q31_t) x10 *y11;
 
@@ -622,7 +622,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         y10 = *(pIn2 + 2U);
         y11 = *(pIn2 + 3U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q31_t) x20 *y10;
         acc0 += (q31_t) x21 *y11;
         acc2 += (q31_t) x10 *y10;
@@ -634,7 +634,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         x20 = *(pScr1 + 2);
         x21 = *(pScr1 + 3);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc3 += (q31_t) x11 *y10;
         acc3 += (q31_t) x20 *y11;
 
@@ -654,7 +654,7 @@ arm_status arm_conv_partial_fast_opt_q15(
 
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2);
         acc1 += (*pScr1++ * *pIn2);
         acc2 += (*pScr1++ * *pIn2);
@@ -688,10 +688,10 @@ arm_status arm_conv_partial_fast_opt_q15(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;
@@ -707,7 +707,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         y10 = *pIn2++;
         y11 = *pIn2++;
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q31_t) x10 *y10;
         acc0 += (q31_t) x11 *y11;
 
@@ -721,7 +721,7 @@ arm_status arm_conv_partial_fast_opt_q15(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2++);
 
         /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_q15.c
@@ -53,9 +53,9 @@
 
 
 arm_status arm_conv_partial_fast_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -63,13 +63,13 @@ arm_status arm_conv_partial_fast_q15(
 {
 #ifndef UNALIGNED_SUPPORT_DISABLE
 
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q15_t *pOut = pDst;                            /* output pointer               */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulator                  */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
   q31_t x0, x1, x2, x3, c0;
   uint32_t j, k, count, check, blkCnt;
   int32_t blockSize1, blockSize2, blockSize3;    /* loop counters                 */
@@ -710,13 +710,13 @@ arm_status arm_conv_partial_fast_q15(
 
 #else
 
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q15_t *pOut = pDst;                            /* output pointer               */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulator                  */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
   q31_t x0, x1, x2, x3, c0;
   uint32_t j, k, count, check, blkCnt;
   int32_t blockSize1, blockSize2, blockSize3;    /* loop counters                 */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_q31.c
@@ -53,20 +53,20 @@
  */
 
 arm_status arm_conv_partial_fast_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst,
   uint32_t firstIndex,
   uint32_t numPoints)
 {
-  q31_t *pIn1;                                   /* inputA pointer               */
-  q31_t *pIn2;                                   /* inputB pointer               */
+  const q31_t *pIn1;                             /* inputA pointer               */
+  const q31_t *pIn2;                             /* inputB pointer               */
   q31_t *pOut = pDst;                            /* output pointer               */
-  q31_t *px;                                     /* Intermediate inputA pointer  */
-  q31_t *py;                                     /* Intermediate inputB pointer  */
-  q31_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
+  const q31_t *px;                               /* Intermediate inputA pointer  */
+  const q31_t *py;                               /* Intermediate inputB pointer  */
+  const q31_t *pSrc1, *pSrc2;                    /* Intermediate pointers        */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulators                  */
   q31_t x0, x1, x2, x3, c0;
   uint32_t j, k, count, check, blkCnt;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q15.c
@@ -62,9 +62,9 @@
 #ifndef UNALIGNED_SUPPORT_DISABLE
 
 arm_status arm_conv_partial_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -79,10 +79,10 @@ arm_status arm_conv_partial_opt_q15(
   q63_t acc0, acc1, acc2, acc3;                  /* Accumulator */
   q31_t x1, x2, x3;                              /* Temporary variables to hold state and coefficient values */
   q31_t y1, y2;                                  /* State variables */
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pIn1;                             /* inputA pointer */
+  const q15_t *pIn2;                             /* inputB pointer */
+  const q15_t *px;                               /* Intermediate inputA pointer  */
+  const q15_t *py;                               /* Intermediate inputB pointer  */
   uint32_t j, k, blkCnt;                         /* loop counter */
   arm_status status;                             /* Status variable */
   uint32_t tapCnt;                               /* loop count */
@@ -160,7 +160,7 @@ arm_status arm_conv_partial_opt_q15(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Fill (srcBLen - 1U) zeros in scratch buffer */
@@ -195,10 +195,10 @@ arm_status arm_conv_partial_opt_q15(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -219,7 +219,7 @@ arm_status arm_conv_partial_opt_q15(
         y1 = _SIMD32_OFFSET(pIn2);
         y2 = _SIMD32_OFFSET(pIn2 + 2U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLALD(x1, y1, acc0);
         acc2 = __SMLALD(x2, y1, acc2);
 
@@ -230,13 +230,13 @@ arm_status arm_conv_partial_opt_q15(
         x3 = __PKHBT(x1, x2, 0);
 #endif
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 = __SMLALDX(x3, y1, acc1);
 
         /* Read next two samples from scratch1 buffer */
         x1 = _SIMD32_OFFSET(pScr1);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLALD(x2, y2, acc0);
         acc2 = __SMLALD(x1, y2, acc2);
 
@@ -277,7 +277,7 @@ arm_status arm_conv_partial_opt_q15(
 
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2);
         acc1 += (*pScr1++ * *pIn2);
         acc2 += (*pScr1++ * *pIn2);
@@ -323,10 +323,10 @@ arm_status arm_conv_partial_opt_q15(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;
@@ -352,7 +352,7 @@ arm_status arm_conv_partial_opt_q15(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2++);
 
         /* Decrement the loop counter */
@@ -383,9 +383,9 @@ arm_status arm_conv_partial_opt_q15(
 #else
 
 arm_status arm_conv_partial_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -398,10 +398,10 @@ arm_status arm_conv_partial_opt_q15(
   q15_t *pScr1 = pScratch1;                      /* Temporary pointer for scratch1 */
   q15_t *pScr2 = pScratch2;                      /* Temporary pointer for scratch1 */
   q63_t acc0, acc1, acc2, acc3;                  /* Accumulator */
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pIn1;                                   /* inputA pointer */
+  const q15_t *pIn2;                                   /* inputB pointer */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
   uint32_t j, k, blkCnt;                         /* loop counter */
   arm_status status;                             /* Status variable */
   uint32_t tapCnt;                               /* loop count */
@@ -482,7 +482,7 @@ arm_status arm_conv_partial_opt_q15(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Fill (srcBLen - 1U) zeros in scratch buffer */
@@ -568,10 +568,10 @@ arm_status arm_conv_partial_opt_q15(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -594,13 +594,13 @@ arm_status arm_conv_partial_opt_q15(
         y10 = *pIn2;
         y11 = *(pIn2 + 1U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q63_t) x10 *y10;
         acc0 += (q63_t) x11 *y11;
         acc2 += (q63_t) x20 *y10;
         acc2 += (q63_t) x21 *y11;
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 += (q63_t) x11 *y10;
         acc1 += (q63_t) x20 *y11;
 
@@ -608,7 +608,7 @@ arm_status arm_conv_partial_opt_q15(
         x10 = *pScr1;
         x11 = *(pScr1 + 1U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc3 += (q63_t) x21 *y10;
         acc3 += (q63_t) x10 *y11;
 
@@ -616,7 +616,7 @@ arm_status arm_conv_partial_opt_q15(
         y10 = *(pIn2 + 2U);
         y11 = *(pIn2 + 3U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q63_t) x20 *y10;
         acc0 += (q63_t) x21 *y11;
         acc2 += (q63_t) x10 *y10;
@@ -628,7 +628,7 @@ arm_status arm_conv_partial_opt_q15(
         x20 = *(pScr1 + 2);
         x21 = *(pScr1 + 3);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc3 += (q63_t) x11 *y10;
         acc3 += (q63_t) x20 *y11;
 
@@ -648,7 +648,7 @@ arm_status arm_conv_partial_opt_q15(
 
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2);
         acc1 += (*pScr1++ * *pIn2);
         acc2 += (*pScr1++ * *pIn2);
@@ -683,10 +683,10 @@ arm_status arm_conv_partial_opt_q15(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;
@@ -702,7 +702,7 @@ arm_status arm_conv_partial_opt_q15(
         y10 = *pIn2++;
         y11 = *pIn2++;
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q63_t) x10 *y10;
         acc0 += (q63_t) x11 *y11;
 
@@ -716,7 +716,7 @@ arm_status arm_conv_partial_opt_q15(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2++);
 
         /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q7.c
@@ -62,9 +62,9 @@
 #ifndef UNALIGNED_SUPPORT_DISABLE
 
 arm_status arm_conv_partial_opt_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   uint32_t firstIndex,
@@ -73,11 +73,11 @@ arm_status arm_conv_partial_opt_q7(
   q15_t * pScratch2)
 {
 
-  q15_t *pScr2, *pScr1;                          /* Intermediate pointers for scratch pointers */
+  q15_t *pScr2, *pScr1;                    /* Intermediate pointers for scratch pointers */
   q15_t x4;                                      /* Temporary input variable */
-  q7_t *pIn1, *pIn2;                             /* inputA and inputB pointer */
+  const q7_t *pIn1, *pIn2;                       /* inputA and inputB pointer */
   uint32_t j, k, blkCnt, tapCnt;                 /* loop counter */
-  q7_t *px;                                      /* Temporary input1 pointer */
+  const q7_t *px;                                /* Temporary input1 pointer */
   q15_t *py;                                     /* Temporary input2 pointer */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulator */
   q31_t x1, x2, x3, y1;                          /* Temporary input variables */
@@ -160,7 +160,7 @@ arm_status arm_conv_partial_opt_q7(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Fill (srcBLen - 1U) zeros in scratch buffer */
@@ -230,10 +230,10 @@ arm_status arm_conv_partial_opt_q7(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -253,7 +253,7 @@ arm_status arm_conv_partial_opt_q7(
         /* Read four samples from smaller buffer */
         y1 = _SIMD32_OFFSET(pScr2);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLAD(x1, y1, acc0);
         acc2 = __SMLAD(x2, y1, acc2);
 
@@ -264,7 +264,7 @@ arm_status arm_conv_partial_opt_q7(
         x3 = __PKHBT(x1, x2, 0);
 #endif
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 = __SMLADX(x3, y1, acc1);
 
         /* Read next two samples from scratch1 buffer */
@@ -317,7 +317,7 @@ arm_status arm_conv_partial_opt_q7(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pScr2);
         acc1 += (*pScr1++ * *pScr2);
         acc2 += (*pScr1++ * *pScr2);
@@ -351,10 +351,10 @@ arm_status arm_conv_partial_opt_q7(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;
@@ -380,7 +380,7 @@ arm_status arm_conv_partial_opt_q7(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pScr2++);
 
         /* Decrement the loop counter */
@@ -412,9 +412,9 @@ arm_status arm_conv_partial_opt_q7(
 #else
 
 arm_status arm_conv_partial_opt_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   uint32_t firstIndex,
@@ -425,10 +425,10 @@ arm_status arm_conv_partial_opt_q7(
 
   q15_t *pScr2, *pScr1;                          /* Intermediate pointers for scratch pointers */
   q15_t x4;                                      /* Temporary input variable */
-  q7_t *pIn1, *pIn2;                             /* inputA and inputB pointer */
+  const q7_t *pIn1, *pIn2;                             /* inputA and inputB pointer */
   uint32_t j, k, blkCnt, tapCnt;                 /* loop counter */
-  q7_t *px;                                      /* Temporary input1 pointer */
-  q15_t *py;                                     /* Temporary input2 pointer */
+  const q7_t *px;                                      /* Temporary input1 pointer */
+  const q15_t *py;                                     /* Temporary input2 pointer */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulator */
   arm_status status;
   q7_t *pOut = pDst;                             /* output pointer */
@@ -510,7 +510,7 @@ arm_status arm_conv_partial_opt_q7(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Fill (srcBLen - 1U) zeros in scratch buffer */
@@ -604,10 +604,10 @@ arm_status arm_conv_partial_opt_q7(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -630,7 +630,7 @@ arm_status arm_conv_partial_opt_q7(
         y10 = *pScr2;
         y11 = *(pScr2 + 1U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q31_t) x10 *y10;
         acc0 += (q31_t) x11 *y11;
         acc2 += (q31_t) x20 *y10;
@@ -644,7 +644,7 @@ arm_status arm_conv_partial_opt_q7(
         x10 = *pScr1;
         x11 = *(pScr1 + 1U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc3 += (q31_t) x21 *y10;
         acc3 += (q31_t) x10 *y11;
 
@@ -652,7 +652,7 @@ arm_status arm_conv_partial_opt_q7(
         y10 = *(pScr2 + 2U);
         y11 = *(pScr2 + 3U);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q31_t) x20 *y10;
         acc0 += (q31_t) x21 *y11;
         acc2 += (q31_t) x10 *y10;
@@ -664,7 +664,7 @@ arm_status arm_conv_partial_opt_q7(
         x20 = *(pScr1 + 2);
         x21 = *(pScr1 + 3);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc3 += (q31_t) x11 *y10;
         acc3 += (q31_t) x20 *y11;
 
@@ -689,7 +689,7 @@ arm_status arm_conv_partial_opt_q7(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pScr2);
         acc1 += (*pScr1++ * *pScr2);
         acc2 += (*pScr1++ * *pScr2);
@@ -721,10 +721,10 @@ arm_status arm_conv_partial_opt_q7(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;
@@ -740,7 +740,7 @@ arm_status arm_conv_partial_opt_q7(
         y10 = *pScr2++;
         y11 = *pScr2++;
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 += (q31_t) x10 *y10;
         acc0 += (q31_t) x11 *y11;
 
@@ -754,7 +754,7 @@ arm_status arm_conv_partial_opt_q7(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pScr2++);
 
         /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q15.c
@@ -56,9 +56,9 @@
  */
 
 arm_status arm_conv_partial_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   uint32_t firstIndex,
@@ -70,13 +70,13 @@ arm_status arm_conv_partial_q15(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q15_t *pOut = pDst;                            /* output pointer               */
   q63_t sum, acc0, acc1, acc2, acc3;             /* Accumulator                  */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
   q31_t x0, x1, x2, x3, c0;                      /* Temporary input variables */
   uint32_t j, k, count, check, blkCnt;
   int32_t blockSize1, blockSize2, blockSize3;    /* loop counter                 */
@@ -727,8 +727,8 @@ arm_status arm_conv_partial_q15(
 
   /* Run the below code for Cortex-M0 */
 
-  q15_t *pIn1 = pSrcA;                           /* inputA pointer */
-  q15_t *pIn2 = pSrcB;                           /* inputB pointer */
+  const q15_t *pIn1 = pSrcA;                           /* inputA pointer */
+  const q15_t *pIn2 = pSrcB;                           /* inputB pointer */
   q63_t sum;                                     /* Accumulator */
   uint32_t i, j;                                 /* loop counters */
   arm_status status;                             /* status of Partial convolution */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q31.c
@@ -52,9 +52,9 @@
  */
 
 arm_status arm_conv_partial_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst,
   uint32_t firstIndex,
@@ -66,12 +66,12 @@ arm_status arm_conv_partial_q31(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q31_t *pIn1;                                   /* inputA pointer               */
-  q31_t *pIn2;                                   /* inputB pointer               */
+  const q31_t *pIn1;                                   /* inputA pointer               */
+  const q31_t *pIn2;                                   /* inputB pointer               */
   q31_t *pOut = pDst;                            /* output pointer               */
-  q31_t *px;                                     /* Intermediate inputA pointer  */
-  q31_t *py;                                     /* Intermediate inputB pointer  */
-  q31_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
+  const q31_t *px;                                     /* Intermediate inputA pointer  */
+  const q31_t *py;                                     /* Intermediate inputB pointer  */
+  const q31_t *pSrc1, *pSrc2;                          /* Intermediate pointers        */
   q63_t sum, acc0, acc1, acc2;                   /* Accumulator                  */
   q31_t x0, x1, x2, c0;
   uint32_t j, k, count, check, blkCnt;
@@ -548,8 +548,8 @@ arm_status arm_conv_partial_q31(
 
   /* Run the below code for Cortex-M0 */
 
-  q31_t *pIn1 = pSrcA;                           /* inputA pointer */
-  q31_t *pIn2 = pSrcB;                           /* inputB pointer */
+  const q31_t *pIn1 = pSrcA;                           /* inputA pointer */
+  const q31_t *pIn2 = pSrcB;                           /* inputB pointer */
   q63_t sum;                                     /* Accumulator */
   uint32_t i, j;                                 /* loop counters */
   arm_status status;                             /* status of Partial convolution */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q7.c
@@ -54,9 +54,9 @@
  */
 
 arm_status arm_conv_partial_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   uint32_t firstIndex,
@@ -68,12 +68,12 @@ arm_status arm_conv_partial_q7(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q7_t *pIn1;                                    /* inputA pointer */
-  q7_t *pIn2;                                    /* inputB pointer */
+  const q7_t *pIn1;                                    /* inputA pointer */
+  const q7_t *pIn2;                                    /* inputB pointer */
   q7_t *pOut = pDst;                             /* output pointer */
-  q7_t *px;                                      /* Intermediate inputA pointer */
-  q7_t *py;                                      /* Intermediate inputB pointer */
-  q7_t *pSrc1, *pSrc2;                           /* Intermediate pointers */
+  const q7_t *px;                                      /* Intermediate inputA pointer */
+  const q7_t *py;                                      /* Intermediate inputB pointer */
+  const q7_t *pSrc1, *pSrc2;                           /* Intermediate pointers */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulator */
   q31_t input1, input2;
   q15_t in1, in2;
@@ -682,8 +682,8 @@ arm_status arm_conv_partial_q7(
 
   /* Run the below code for Cortex-M0 */
 
-  q7_t *pIn1 = pSrcA;                            /* inputA pointer */
-  q7_t *pIn2 = pSrcB;                            /* inputB pointer */
+  const q7_t *pIn1 = pSrcA;                            /* inputA pointer */
+  const q7_t *pIn2 = pSrcB;                            /* inputB pointer */
   q31_t sum;                                     /* Accumulator */
   uint32_t i, j;                                 /* loop counters */
   arm_status status;                             /* status of Partial convolution */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_q15.c
@@ -65,9 +65,9 @@
  */
 
 void arm_conv_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst)
 {
@@ -76,13 +76,13 @@ void arm_conv_q15(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q15_t *pIn1;                                   /* inputA pointer */
-  q15_t *pIn2;                                   /* inputB pointer */
+  const q15_t *pIn1;                                   /* inputA pointer */
+  const q15_t *pIn2;                                   /* inputB pointer */
   q15_t *pOut = pDst;                            /* output pointer */
   q63_t sum, acc0, acc1, acc2, acc3;             /* Accumulator */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
   q31_t x0, x1, x2, x3, c0;                      /* Temporary variables to hold state and coefficient values */
   uint32_t blockSize1, blockSize2, blockSize3, j, k, count, blkCnt;     /* loop counter */
 
@@ -687,8 +687,8 @@ void arm_conv_q15(
 
 /* Run the below code for Cortex-M0 */
 
-  q15_t *pIn1 = pSrcA;                           /* input pointer */
-  q15_t *pIn2 = pSrcB;                           /* coefficient pointer */
+  const q15_t *pIn1 = pSrcA;                           /* input pointer */
+  const q15_t *pIn2 = pSrcB;                           /* coefficient pointer */
   q63_t sum;                                     /* Accumulator */
   uint32_t i, j;                                 /* loop counter */
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_q31.c
@@ -64,9 +64,9 @@
  */
 
 void arm_conv_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst)
 {
@@ -76,12 +76,12 @@ void arm_conv_q31(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q31_t *pIn1;                                   /* inputA pointer */
-  q31_t *pIn2;                                   /* inputB pointer */
+  const q31_t *pIn1;                                   /* inputA pointer */
+  const q31_t *pIn2;                                   /* inputB pointer */
   q31_t *pOut = pDst;                            /* output pointer */
-  q31_t *px;                                     /* Intermediate inputA pointer  */
-  q31_t *py;                                     /* Intermediate inputB pointer  */
-  q31_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
+  const q31_t *px;                                     /* Intermediate inputA pointer  */
+  const q31_t *py;                                     /* Intermediate inputB pointer  */
+  const q31_t *pSrc1, *pSrc2;                          /* Intermediate pointers */
   q63_t sum;                                     /* Accumulator */
   q63_t acc0, acc1, acc2;                        /* Accumulator */
   q31_t x0, x1, x2, c0;                          /* Temporary variables to hold state and coefficient values */
@@ -518,8 +518,8 @@ void arm_conv_q31(
 
   /* Run the below code for Cortex-M0 */
 
-  q31_t *pIn1 = pSrcA;                           /* input pointer */
-  q31_t *pIn2 = pSrcB;                           /* coefficient pointer */
+  const q31_t *pIn1 = pSrcA;                           /* input pointer */
+  const q31_t *pIn2 = pSrcB;                           /* coefficient pointer */
   q63_t sum;                                     /* Accumulator */
   uint32_t i, j;                                 /* loop counter */
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_q7.c
@@ -62,9 +62,9 @@
  */
 
 void arm_conv_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst)
 {
@@ -74,12 +74,12 @@ void arm_conv_q7(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q7_t *pIn1;                                    /* inputA pointer */
-  q7_t *pIn2;                                    /* inputB pointer */
+  const q7_t *pIn1;                                    /* inputA pointer */
+  const q7_t *pIn2;                                    /* inputB pointer */
   q7_t *pOut = pDst;                             /* output pointer */
-  q7_t *px;                                      /* Intermediate inputA pointer */
-  q7_t *py;                                      /* Intermediate inputB pointer */
-  q7_t *pSrc1, *pSrc2;                           /* Intermediate pointers */
+  const q7_t *px;                                      /* Intermediate inputA pointer */
+  const q7_t *py;                                      /* Intermediate inputB pointer */
+  const q7_t *pSrc1, *pSrc2;                           /* Intermediate pointers */
   q7_t x0, x1, x2, x3, c0, c1;                   /* Temporary variables to hold state and coefficient values */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulator */
   q31_t input1, input2;                          /* Temporary input variables */
@@ -643,8 +643,8 @@ void arm_conv_q7(
 
   /* Run the below code for Cortex-M0 */
 
-  q7_t *pIn1 = pSrcA;                            /* input pointer */
-  q7_t *pIn2 = pSrcB;                            /* coefficient pointer */
+  const q7_t *pIn1 = pSrcA;                            /* input pointer */
+  const q7_t *pIn2 = pSrcB;                            /* coefficient pointer */
   q31_t sum;                                     /* Accumulator */
   uint32_t i, j;                                 /* loop counter */
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f32.c
@@ -102,9 +102,9 @@
  */
 
 void arm_correlate_f32(
-  float32_t * pSrcA,
+  const float32_t * pSrcA,
   uint32_t srcALen,
-  float32_t * pSrcB,
+  const float32_t * pSrcB,
   uint32_t srcBLen,
   float32_t * pDst)
 {
@@ -114,12 +114,12 @@ void arm_correlate_f32(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  float32_t *pIn1;                               /* inputA pointer */
-  float32_t *pIn2;                               /* inputB pointer */
+  const float32_t *pIn1;                               /* inputA pointer */
+  const float32_t *pIn2;                               /* inputB pointer */
   float32_t *pOut = pDst;                        /* output pointer */
-  float32_t *px;                                 /* Intermediate inputA pointer */
-  float32_t *py;                                 /* Intermediate inputB pointer */
-  float32_t *pSrc1;                              /* Intermediate pointers */
+  const float32_t *px;                                 /* Intermediate inputA pointer */
+  const float32_t *py;                                 /* Intermediate inputB pointer */
+  const float32_t *pSrc1;                              /* Intermediate pointers */
   float32_t sum, acc0, acc1, acc2, acc3;         /* Accumulators */
   float32_t x0, x1, x2, x3, c0;                  /* temporary variables for holding input and coefficient values */
   uint32_t j, k = 0U, count, blkCnt, outBlockSize, blockSize1, blockSize2, blockSize3;  /* loop counters */
@@ -639,8 +639,8 @@ void arm_correlate_f32(
 
   /* Run the below code for Cortex-M0 */
 
-  float32_t *pIn1 = pSrcA;                       /* inputA pointer */
-  float32_t *pIn2 = pSrcB + (srcBLen - 1U);      /* inputB pointer */
+  const float32_t *pIn1 = pSrcA;                       /* inputA pointer */
+  const float32_t *pIn2 = pSrcB + (srcBLen - 1U);      /* inputB pointer */
   float32_t sum;                                 /* Accumulator */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_opt_q15.c
@@ -70,17 +70,17 @@
  */
 
 void arm_correlate_fast_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch)
 {
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulators                  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
   q31_t x1, x2, x3;                              /* temporary variables for holding input and coefficient values */
   uint32_t j, blkCnt, outBlockSize;              /* loop counter                 */
   int32_t inc = 1;                               /* Destination address modifier */
@@ -251,10 +251,10 @@ void arm_correlate_fast_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -409,7 +409,7 @@ void arm_correlate_fast_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr++ * *pIn2);
       acc1 += (*pScr++ * *pIn2);
       acc2 += (*pScr++ * *pIn2);
@@ -448,10 +448,10 @@ void arm_correlate_fast_opt_q15(
   /* Calculate correlation for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;
@@ -472,7 +472,7 @@ void arm_correlate_fast_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr++ * *pIn2++);
 
       /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_q15.c
@@ -63,21 +63,21 @@
  */
 
 void arm_correlate_fast_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst)
 {
 #ifndef UNALIGNED_SUPPORT_DISABLE
 
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q15_t *pOut = pDst;                            /* output pointer               */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulators                  */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1;                                  /* Intermediate pointers        */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1;                                  /* Intermediate pointers        */
   q31_t x0, x1, x2, x3, c0;                      /* temporary variables for holding input and coefficient values */
   uint32_t j, k = 0U, count, blkCnt, outBlockSize, blockSize1, blockSize2, blockSize3;  /* loop counter                 */
   int32_t inc = 1;                               /* Destination address modifier */
@@ -616,13 +616,13 @@ void arm_correlate_fast_q15(
 
 #else
 
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q15_t *pOut = pDst;                            /* output pointer               */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulators                  */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1;                                  /* Intermediate pointers        */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1;                                  /* Intermediate pointers        */
   q31_t x0, x1, x2, x3, c0;                      /* temporary variables for holding input and coefficient values */
   uint32_t j, k = 0U, count, blkCnt, outBlockSize, blockSize1, blockSize2, blockSize3;  /* loop counter                 */
   int32_t inc = 1;                               /* Destination address modifier */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_q31.c
@@ -67,18 +67,18 @@
  */
 
 void arm_correlate_fast_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst)
 {
-  q31_t *pIn1;                                   /* inputA pointer               */
-  q31_t *pIn2;                                   /* inputB pointer               */
+  const q31_t *pIn1;                                   /* inputA pointer               */
+  const q31_t *pIn2;                                   /* inputB pointer               */
   q31_t *pOut = pDst;                            /* output pointer               */
-  q31_t *px;                                     /* Intermediate inputA pointer  */
-  q31_t *py;                                     /* Intermediate inputB pointer  */
-  q31_t *pSrc1;                                  /* Intermediate pointers        */
+  const q31_t *px;                                     /* Intermediate inputA pointer  */
+  const q31_t *py;                                     /* Intermediate inputB pointer  */
+  const q31_t *pSrc1;                                  /* Intermediate pointers        */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulators                  */
   q31_t x0, x1, x2, x3, c0;                      /* temporary variables for holding input and coefficient values */
   uint32_t j, k = 0U, count, blkCnt, outBlockSize, blockSize1, blockSize2, blockSize3;  /* loop counter                 */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q15.c
@@ -69,17 +69,17 @@
 
 
 void arm_correlate_opt_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst,
   q15_t * pScratch)
 {
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q63_t acc0, acc1, acc2, acc3;                  /* Accumulators                  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
   q31_t x1, x2, x3;                              /* temporary variables for holding input1 and input2 values */
   uint32_t j, blkCnt, outBlockSize;              /* loop counter                 */
   int32_t inc = 1;                               /* output pointer increment     */
@@ -251,10 +251,10 @@ void arm_correlate_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -410,7 +410,7 @@ void arm_correlate_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr++ * *pIn2);
       acc1 += (*pScr++ * *pIn2);
       acc2 += (*pScr++ * *pIn2);
@@ -448,10 +448,10 @@ void arm_correlate_opt_q15(
   /* Calculate correlation for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;
@@ -472,7 +472,7 @@ void arm_correlate_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr++ * *pIn2++);
 
       /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q7.c
@@ -69,9 +69,9 @@
 
 
 void arm_correlate_opt_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst,
   q15_t * pScratch1,
@@ -80,8 +80,8 @@ void arm_correlate_opt_q7(
   q7_t *pOut = pDst;                             /* output pointer                */
   q15_t *pScr1 = pScratch1;                      /* Temporary pointer for scratch */
   q15_t *pScr2 = pScratch2;                      /* Temporary pointer for scratch */
-  q7_t *pIn1;                                    /* inputA pointer                */
-  q7_t *pIn2;                                    /* inputB pointer                */
+  const q7_t *pIn1;                              /* inputA pointer                */
+  const q7_t *pIn2;                              /* inputB pointer                */
   q15_t *py;                                     /* Intermediate inputB pointer   */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulators                  */
   uint32_t j, k = 0U, blkCnt;                    /* loop counter                  */
@@ -277,10 +277,10 @@ void arm_correlate_opt_q7(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -300,7 +300,7 @@ void arm_correlate_opt_q7(
       /* Read four samples from smaller buffer */
       y1 = _SIMD32_OFFSET(pScr2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x1, y1, acc0);
       acc2 = __SMLAD(x2, y1, acc2);
 
@@ -311,7 +311,7 @@ void arm_correlate_opt_q7(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLADX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
@@ -364,7 +364,7 @@ void arm_correlate_opt_q7(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2);
       acc1 += (*pScr1++ * *pScr2);
       acc2 += (*pScr1++ * *pScr2);
@@ -401,10 +401,10 @@ void arm_correlate_opt_q7(
   /* Calculate correlation for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;
@@ -424,7 +424,7 @@ void arm_correlate_opt_q7(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2++);
 
       /* Decrement the loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q15.c
@@ -65,9 +65,9 @@
  */
 
 void arm_correlate_q15(
-  q15_t * pSrcA,
+  const q15_t * pSrcA,
   uint32_t srcALen,
-  q15_t * pSrcB,
+  const q15_t * pSrcB,
   uint32_t srcBLen,
   q15_t * pDst)
 {
@@ -76,13 +76,13 @@ void arm_correlate_q15(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q15_t *pIn1;                                   /* inputA pointer               */
-  q15_t *pIn2;                                   /* inputB pointer               */
+  const q15_t *pIn1;                                   /* inputA pointer               */
+  const q15_t *pIn2;                                   /* inputB pointer               */
   q15_t *pOut = pDst;                            /* output pointer               */
   q63_t sum, acc0, acc1, acc2, acc3;             /* Accumulators                  */
-  q15_t *px;                                     /* Intermediate inputA pointer  */
-  q15_t *py;                                     /* Intermediate inputB pointer  */
-  q15_t *pSrc1;                                  /* Intermediate pointers        */
+  const q15_t *px;                                     /* Intermediate inputA pointer  */
+  const q15_t *py;                                     /* Intermediate inputB pointer  */
+  const q15_t *pSrc1;                                  /* Intermediate pointers        */
   q31_t x0, x1, x2, x3, c0;                      /* temporary variables for holding input and coefficient values */
   uint32_t j, k = 0U, count, blkCnt, outBlockSize, blockSize1, blockSize2, blockSize3;  /* loop counter                 */
   int32_t inc = 1;                               /* Destination address modifier */
@@ -619,8 +619,8 @@ void arm_correlate_q15(
 
 /* Run the below code for Cortex-M0 */
 
-  q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
-  q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
+  const q15_t *pIn1 = pSrcA;                           /* inputA pointer               */
+  const q15_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
   q63_t sum;                                     /* Accumulators                  */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q31.c
@@ -64,9 +64,9 @@
  */
 
 void arm_correlate_q31(
-  q31_t * pSrcA,
+  const q31_t * pSrcA,
   uint32_t srcALen,
-  q31_t * pSrcB,
+  const q31_t * pSrcB,
   uint32_t srcBLen,
   q31_t * pDst)
 {
@@ -75,12 +75,12 @@ void arm_correlate_q31(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q31_t *pIn1;                                   /* inputA pointer               */
-  q31_t *pIn2;                                   /* inputB pointer               */
+  const q31_t *pIn1;                                   /* inputA pointer               */
+  const q31_t *pIn2;                                   /* inputB pointer               */
   q31_t *pOut = pDst;                            /* output pointer               */
-  q31_t *px;                                     /* Intermediate inputA pointer  */
-  q31_t *py;                                     /* Intermediate inputB pointer  */
-  q31_t *pSrc1;                                  /* Intermediate pointers        */
+  const q31_t *px;                                     /* Intermediate inputA pointer  */
+  const q31_t *py;                                     /* Intermediate inputB pointer  */
+  const q31_t *pSrc1;                                  /* Intermediate pointers        */
   q63_t sum, acc0, acc1, acc2;                   /* Accumulators                  */
   q31_t x0, x1, x2, c0;                          /* temporary variables for holding input and coefficient values */
   uint32_t j, k = 0U, count, blkCnt, outBlockSize, blockSize1, blockSize2, blockSize3;  /* loop counter                 */
@@ -565,8 +565,8 @@ void arm_correlate_q31(
 
   /* Run the below code for Cortex-M0 */
 
-  q31_t *pIn1 = pSrcA;                           /* inputA pointer               */
-  q31_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
+  const q31_t *pIn1 = pSrcA;                           /* inputA pointer               */
+  const q31_t *pIn2 = pSrcB + (srcBLen - 1U);          /* inputB pointer               */
   q63_t sum;                                     /* Accumulators                  */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q7.c
@@ -62,9 +62,9 @@
  */
 
 void arm_correlate_q7(
-  q7_t * pSrcA,
+  const q7_t * pSrcA,
   uint32_t srcALen,
-  q7_t * pSrcB,
+  const q7_t * pSrcB,
   uint32_t srcBLen,
   q7_t * pDst)
 {
@@ -74,12 +74,12 @@ void arm_correlate_q7(
 
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
-  q7_t *pIn1;                                    /* inputA pointer               */
-  q7_t *pIn2;                                    /* inputB pointer               */
+  const q7_t *pIn1;                                    /* inputA pointer               */
+  const q7_t *pIn2;                                    /* inputB pointer               */
   q7_t *pOut = pDst;                             /* output pointer               */
-  q7_t *px;                                      /* Intermediate inputA pointer  */
-  q7_t *py;                                      /* Intermediate inputB pointer  */
-  q7_t *pSrc1;                                   /* Intermediate pointers        */
+  const q7_t *px;                                      /* Intermediate inputA pointer  */
+  const q7_t *py;                                      /* Intermediate inputB pointer  */
+  const q7_t *pSrc1;                                   /* Intermediate pointers        */
   q31_t sum, acc0, acc1, acc2, acc3;             /* Accumulators                  */
   q31_t input1, input2;                          /* temporary variables */
   q15_t in1, in2;                                /* temporary variables */
@@ -690,8 +690,8 @@ void arm_correlate_q7(
 
 /* Run the below code for Cortex-M0 */
 
-  q7_t *pIn1 = pSrcA;                            /* inputA pointer */
-  q7_t *pIn2 = pSrcB + (srcBLen - 1U);           /* inputB pointer */
+  const q7_t *pIn1 = pSrcA;                            /* inputA pointer */
+  const q7_t *pIn2 = pSrcB + (srcBLen - 1U);           /* inputB pointer */
   q31_t sum;                                     /* Accumulator */
   uint32_t i = 0U, j;                            /* loop counters */
   uint32_t inv = 0U;                             /* Reverse order flag */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_f32.c
@@ -128,14 +128,14 @@
 
 void arm_fir_decimate_f32(
   const arm_fir_decimate_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
   float32_t *pState = S->pState;                 /* State pointer */
-  float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
   float32_t *pStateCurnt;                        /* Points to the current sample of the state */
-  float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
+  const float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
   float32_t sum0;                                /* Accumulator */
   float32_t x0, c0;                              /* Temporary variables to hold state and coefficient values */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
@@ -144,7 +144,7 @@ void arm_fir_decimate_f32(
 #if defined (ARM_MATH_DSP)
 
   uint32_t blkCntN4;
-  float32_t *px0, *px1, *px2, *px3;
+  const float32_t *px0, *px1, *px2, *px3;
   float32_t acc0, acc1, acc2, acc3;
   float32_t x1, x2, x3;
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_fast_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_fast_q15.c
@@ -67,19 +67,19 @@
 
 void arm_fir_decimate_fast_q15(
   const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;             /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q15_t *px;                                     /* Temporary pointer for state buffer */
-  q15_t *pb;                                     /* Temporary pointer coefficient buffer */
+  const const q15_t *pb;                               /* Temporary pointer coefficient buffer */
   q31_t x0, x1, c0, c1;                          /* Temporary variables to hold state and coefficient values */
   q31_t sum0;                                    /* Accumulators */
   q31_t acc0, acc1;
-  q15_t *px0, *px1;
+  const q15_t *px0, *px1;
   uint32_t blkCntN3;
   uint32_t numTaps = S->numTaps;                 /* Number of taps */
   uint32_t i, blkCnt, tapCnt, outBlockSize = blockSize / S->M;  /* Loop counters */
@@ -307,19 +307,19 @@ void arm_fir_decimate_fast_q15(
 
 void arm_fir_decimate_fast_q15(
   const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q15_t *px;                                     /* Temporary pointer for state buffer */
-  q15_t *pb;                                     /* Temporary pointer coefficient buffer */
+  const q15_t *px;                                     /* Temporary pointer for state buffer */
+  const q15_t *pb;                                     /* Temporary pointer coefficient buffer */
   q15_t x0, x1, c0;                              /* Temporary variables to hold state and coefficient values */
   q31_t sum0;                                    /* Accumulators */
   q31_t acc0, acc1;
-  q15_t *px0, *px1;
+  const q15_t *px0, *px1;
   uint32_t blkCntN3;
   uint32_t numTaps = S->numTaps;                 /* Number of taps */
   uint32_t i, blkCnt, tapCnt, outBlockSize = blockSize / S->M;  /* Loop counters */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_fast_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_fast_q15.c
@@ -75,7 +75,7 @@ void arm_fir_decimate_fast_q15(
   const q15_t *pCoeffs = S->pCoeffs;             /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q15_t *px;                                     /* Temporary pointer for state buffer */
-  const const q15_t *pb;                               /* Temporary pointer coefficient buffer */
+  const q15_t *pb;                               /* Temporary pointer coefficient buffer */
   q31_t x0, x1, c0, c1;                          /* Temporary variables to hold state and coefficient values */
   q31_t sum0;                                    /* Accumulators */
   q31_t acc0, acc1;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_fast_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_fast_q31.c
@@ -63,23 +63,23 @@
 
 void arm_fir_decimate_fast_q31(
   arm_fir_decimate_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
-  q31_t *px;                                     /* Temporary pointers for state buffer */
-  q31_t *pb;                                     /* Temporary pointers for coefficient buffer */
+  const q31_t *px;                                     /* Temporary pointers for state buffer */
+  const q31_t *pb;                                     /* Temporary pointers for coefficient buffer */
   q31_t sum0;                                    /* Accumulator */
   uint32_t numTaps = S->numTaps;                 /* Number of taps */
   uint32_t i, tapCnt, blkCnt, outBlockSize = blockSize / S->M;  /* Loop counters */
   uint32_t blkCntN2;
   q31_t x1;
   q31_t acc0, acc1;
-  q31_t *px0, *px1;
+  const q31_t *px0, *px1;
 
   /* S->pState buffer contains previous frame (numTaps - 1) samples */
   /* pStateCurnt points to the location where the new input data should be written */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_init_f32.c
@@ -64,7 +64,7 @@ arm_status arm_fir_decimate_init_f32(
   arm_fir_decimate_instance_f32 * S,
   uint16_t numTaps,
   uint8_t M,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_init_q15.c
@@ -65,7 +65,7 @@ arm_status arm_fir_decimate_init_q15(
   arm_fir_decimate_instance_q15 * S,
   uint16_t numTaps,
   uint8_t M,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_init_q31.c
@@ -64,7 +64,7 @@ arm_status arm_fir_decimate_init_q31(
   arm_fir_decimate_instance_q31 * S,
   uint16_t numTaps,
   uint8_t M,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_q15.c
@@ -64,19 +64,19 @@
 
 void arm_fir_decimate_q15(
   const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q15_t *px;                                     /* Temporary pointer for state buffer */
-  q15_t *pb;                                     /* Temporary pointer coefficient buffer */
+  const q15_t *px;                                     /* Temporary pointer for state buffer */
+  const q15_t *pb;                                     /* Temporary pointer coefficient buffer */
   q31_t x0, x1, c0, c1;                          /* Temporary variables to hold state and coefficient values */
   q63_t sum0;                                    /* Accumulators */
   q63_t acc0, acc1;
-  q15_t *px0, *px1;
+  const q15_t *px0, *px1;
   uint32_t blkCntN3;
   uint32_t numTaps = S->numTaps;                 /* Number of taps */
   uint32_t i, blkCnt, tapCnt, outBlockSize = blockSize / S->M;  /* Loop counters */
@@ -304,19 +304,19 @@ void arm_fir_decimate_q15(
 
 void arm_fir_decimate_q15(
   const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q15_t *px;                                     /* Temporary pointer for state buffer */
-  q15_t *pb;                                     /* Temporary pointer coefficient buffer */
+  const q15_t *px;                                     /* Temporary pointer for state buffer */
+  const q15_t *pb;                                     /* Temporary pointer coefficient buffer */
   q15_t x0, x1, c0;                              /* Temporary variables to hold state and coefficient values */
   q63_t sum0;                                    /* Accumulators */
   q63_t acc0, acc1;
-  q15_t *px0, *px1;
+  const q15_t *px0, *px1;
   uint32_t blkCntN3;
   uint32_t numTaps = S->numTaps;                 /* Number of taps */
   uint32_t i, blkCnt, tapCnt, outBlockSize = blockSize / S->M;  /* Loop counters */
@@ -582,15 +582,15 @@ void arm_fir_decimate_q15(
 
 void arm_fir_decimate_q15(
   const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q15_t *px;                                     /* Temporary pointer for state buffer */
-  q15_t *pb;                                     /* Temporary pointer coefficient buffer */
+  const q15_t *px;                                     /* Temporary pointer for state buffer */
+  const q15_t *pb;                                     /* Temporary pointer coefficient buffer */
   q31_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
   q63_t sum0;                                    /* Accumulators */
   uint32_t numTaps = S->numTaps;                 /* Number of taps */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_q31.c
@@ -59,16 +59,16 @@
 
 void arm_fir_decimate_q31(
   const arm_fir_decimate_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
-  q31_t *px;                                     /* Temporary pointers for state buffer */
-  q31_t *pb;                                     /* Temporary pointers for coefficient buffer */
+  const q31_t *px;                                     /* Temporary pointers for state buffer */
+  const q31_t *pb;                                     /* Temporary pointers for coefficient buffer */
   q63_t sum0;                                    /* Accumulator */
   uint32_t numTaps = S->numTaps;                 /* Number of taps */
   uint32_t i, tapCnt, blkCnt, outBlockSize = blockSize / S->M;  /* Loop counters */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_f32.c
@@ -123,14 +123,14 @@
 
 void arm_fir_f32(
 const arm_fir_instance_f32 * S,
-float32_t * pSrc,
+const float32_t * pSrc,
 float32_t * pDst,
 uint32_t blockSize)
 {
    float32_t *pState = S->pState;                 /* State pointer */
-   float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+   const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
    float32_t *pStateCurnt;                        /* Points to the current sample of the state */
-   float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
+   const float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
    uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
    uint32_t i, tapCnt, blkCnt;                    /* Loop counters */
 
@@ -204,14 +204,14 @@ uint32_t blockSize)
 
 void arm_fir_f32(
 const arm_fir_instance_f32 * S,
-float32_t * pSrc,
+const float32_t * pSrc,
 float32_t * pDst,
 uint32_t blockSize)
 {
    float32_t *pState = S->pState;                 /* State pointer */
-   float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+   const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
    float32_t *pStateCurnt;                        /* Points to the current sample of the state */
-   float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
+   const float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
    float32_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;     /* Accumulators */
    float32_t x0, x1, x2, x3, x4, x5, x6, x7, c0;  /* Temporary variables to hold state and coefficient values */
    uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_fast_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_fast_q15.c
@@ -59,16 +59,16 @@
 
 void arm_fir_fast_q15(
   const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulators */
-  q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
-  q15_t *px;                                     /* Temporary q31 pointer for SIMD state buffer accesses */
+  const q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
+  const q15_t *px;                                     /* Temporary q31 pointer for SIMD state buffer accesses */
   q31_t x0, x1, x2, c0;                          /* Temporary variables to hold SIMD state and coefficient values */
   uint32_t numTaps = S->numTaps;                 /* Number of taps in the filter */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_fast_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_fast_q31.c
@@ -62,17 +62,17 @@
 IAR_ONLY_LOW_OPTIMIZATION_ENTER
 void arm_fir_fast_q31(
   const arm_fir_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t x0, x1, x2, x3;                          /* Temporary variables to hold state */
   q31_t c0;                                      /* Temporary variable to hold coefficient value */
-  q31_t *px;                                     /* Temporary pointer for state */
-  q31_t *pb;                                     /* Temporary pointer for coefficient buffer */
+  const q31_t *px;                                     /* Temporary pointer for state */
+  const q31_t *pb;                                     /* Temporary pointer for coefficient buffer */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulators */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
   uint32_t i, tapCnt, blkCnt;                    /* Loop counters */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_f32.c
@@ -61,7 +61,7 @@
 void arm_fir_init_f32(
   arm_fir_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_q15.c
@@ -78,7 +78,7 @@
 arm_status arm_fir_init_q15(
   arm_fir_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_q31.c
@@ -61,7 +61,7 @@
 void arm_fir_init_q31(
   arm_fir_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_init_q7.c
@@ -58,7 +58,7 @@
 void arm_fir_init_q7(
   arm_fir_instance_q7 * S,
   uint16_t numTaps,
-  q7_t * pCoeffs,
+  const q7_t * pCoeffs,
   q7_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_f32.c
@@ -476,7 +476,7 @@ void arm_fir_interpolate_f32(
   float32_t *pState = S->pState;                 /* State pointer */
   const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
   float32_t *pStateCurnt;                        /* Points to the current sample of the state */
-  float32_t *ptr1, *ptr2;                        /* Temporary pointers for state and coefficient buffers */
+  const float32_t *ptr1, *ptr2;                  /* Temporary pointers for state and coefficient buffers */
 
 
   float32_t sum;                                 /* Accumulator */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_f32.c
@@ -135,14 +135,14 @@
 
 void arm_fir_interpolate_f32(
   const arm_fir_interpolate_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
   float32_t *pState = S->pState;                 /* State pointer */
-  float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *pCoeffs = S->pCoeffs;         /* Coefficient pointer */
   float32_t *pStateCurnt;                        /* Points to the current sample of the state */
-  float32_t *ptr1, *ptr2;                        /* Temporary pointers for state and coefficient buffers */
+  const float32_t *ptr1, *ptr2;                  /* Temporary pointers for state and coefficient buffers */
   float32_t sum0;                                /* Accumulators */
   float32_t x0, c0;                              /* Temporary variables to hold state and coefficient values */
   uint32_t i, blkCnt, j;                         /* Loop counters */
@@ -469,12 +469,12 @@ void arm_fir_interpolate_f32(
 
 void arm_fir_interpolate_f32(
   const arm_fir_interpolate_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
   float32_t *pState = S->pState;                 /* State pointer */
-  float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
   float32_t *pStateCurnt;                        /* Points to the current sample of the state */
   float32_t *ptr1, *ptr2;                        /* Temporary pointers for state and coefficient buffers */
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_init_f32.c
@@ -65,7 +65,7 @@ arm_status arm_fir_interpolate_init_f32(
   arm_fir_interpolate_instance_f32 * S,
   uint8_t L,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_init_q15.c
@@ -65,7 +65,7 @@ arm_status arm_fir_interpolate_init_q15(
   arm_fir_interpolate_instance_q15 * S,
   uint8_t L,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_init_q31.c
@@ -66,7 +66,7 @@ arm_status arm_fir_interpolate_init_q31(
   arm_fir_interpolate_instance_q31 * S,
   uint8_t L,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q15.c
@@ -61,14 +61,14 @@
 
 void arm_fir_interpolate_q15(
   const arm_fir_interpolate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer                                            */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer                                      */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer                                      */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state                */
-  q15_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers     */
+  const q15_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers     */
   q63_t sum0;                                    /* Accumulators                                             */
   q15_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
   uint32_t i, blkCnt, j, tapCnt;                 /* Loop counters                                            */
@@ -392,12 +392,12 @@ void arm_fir_interpolate_q15(
 
 void arm_fir_interpolate_q15(
   const arm_fir_interpolate_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer                                            */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer                                      */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer                                      */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state                */
   q15_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers     */
   q63_t sum;                                     /* Accumulator */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q15.c
@@ -431,7 +431,7 @@ void arm_fir_interpolate_q15(
       ptr1 = pState;
 
       /* Initialize coefficient pointer */
-      ptr2 = pCoeffs + (i - 1U);
+      ptr2 = (q15_t*) pCoeffs + (i - 1U);
 
       /* Loop over the polyPhase length */
       tapCnt = (uint32_t) phaseLen;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q31.c
@@ -61,14 +61,14 @@
 
 void arm_fir_interpolate_q31(
   const arm_fir_interpolate_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q31_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers */
+  const q31_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers */
   q63_t sum0;                                    /* Accumulators */
   q31_t x0, c0;                                  /* Temporary variables to hold state and coefficient values */
   uint32_t i, blkCnt, j;                         /* Loop counters */
@@ -386,12 +386,12 @@ void arm_fir_interpolate_q31(
 
 void arm_fir_interpolate_q31(
   const arm_fir_interpolate_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t *ptr1, *ptr2;                            /* Temporary pointers for state and coefficient buffers */
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_interpolate_q31.c
@@ -428,7 +428,7 @@ void arm_fir_interpolate_q31(
       ptr1 = pState;
 
       /* Initialize coefficient pointer */
-      ptr2 = pCoeffs + (i - 1U);
+      ptr2 = (q31_t*) pCoeffs + (i - 1U);
 
       tapCnt = phaseLen;
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_f32.c
@@ -118,14 +118,14 @@
 
 void arm_fir_lattice_f32(
   const arm_fir_lattice_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
   float32_t *pState;                             /* State pointer */
-  float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
   float32_t *px;                                 /* temporary state pointer */
-  float32_t *pk;                                 /* temporary coefficient pointer */
+  const float32_t *pk;                                 /* temporary coefficient pointer */
 
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_init_f32.c
@@ -49,7 +49,7 @@
 void arm_fir_lattice_init_f32(
   arm_fir_lattice_instance_f32 * S,
   uint16_t numStages,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState)
 {
   /* Assign filter taps */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_init_q15.c
@@ -49,7 +49,7 @@
 void arm_fir_lattice_init_q15(
   arm_fir_lattice_instance_q15 * S,
   uint16_t numStages,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState)
 {
   /* Assign filter taps */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_init_q31.c
@@ -49,7 +49,7 @@
 void arm_fir_lattice_init_q31(
   arm_fir_lattice_instance_q31 * S,
   uint16_t numStages,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState)
 {
   /* Assign filter taps */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_q15.c
@@ -49,14 +49,14 @@
 
 void arm_fir_lattice_q15(
   const arm_fir_lattice_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState;                                 /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *px;                                     /* temporary state pointer */
-  q15_t *pk;                                     /* temporary coefficient pointer */
+  const q15_t *pk;                                     /* temporary coefficient pointer */
 
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_q31.c
@@ -57,14 +57,14 @@
 
 void arm_fir_lattice_q31(
   const arm_fir_lattice_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState;                                 /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *px;                                     /* temporary state pointer */
-  q31_t *pk;                                     /* temporary coefficient pointer */
+  const q31_t *pk;                                     /* temporary coefficient pointer */
   q31_t fcurr1, fnext1, gcurr1 = 0, gnext1;      /* temporary variables for first sample in loop unrolling */
   q31_t fcurr2, fnext2, gnext2;                  /* temporary variables for second sample in loop unrolling */
   uint32_t numStages = S->numStages;             /* Length of the filter */
@@ -257,13 +257,13 @@ void arm_fir_lattice_q31(
 
 void arm_fir_lattice_q31(
   const arm_fir_lattice_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState;                                 /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
-  q31_t *px;                                     /* temporary state pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *px;                                     /* temporary state pointer */
   q31_t *pk;                                     /* temporary coefficient pointer */
   q31_t fcurr, fnext, gcurr, gnext;              /* temporary variables */
   uint32_t numStages = S->numStages;             /* Length of the filter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_lattice_q31.c
@@ -262,9 +262,9 @@ void arm_fir_lattice_q31(
   uint32_t blockSize)
 {
   q31_t *pState;                                 /* State pointer */
-  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
-  const q31_t *px;                                     /* temporary state pointer */
-  q31_t *pk;                                     /* temporary coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;             /* Coefficient pointer */
+  q31_t *px;                               /* temporary state pointer */
+  const q31_t *pk;                               /* temporary coefficient pointer */
   q31_t fcurr, fnext, gcurr, gnext;              /* temporary variables */
   uint32_t numStages = S->numStages;             /* Length of the filter */
   uint32_t blkCnt, stageCnt;                     /* temporary variables for counts */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_q15.c
@@ -72,15 +72,15 @@
 
 void arm_fir_q15(
   const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
-  q15_t *px1;                                    /* Temporary q15 pointer for state buffer */
-  q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
+  const q15_t *px1;                                    /* Temporary q15 pointer for state buffer */
+  const q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
   q31_t x0, x1, x2, x3, c0;                      /* Temporary variables to hold SIMD state and coefficient values */
   q63_t acc0, acc1, acc2, acc3;                  /* Accumulators */
   uint32_t numTaps = S->numTaps;                 /* Number of taps in the filter */
@@ -315,16 +315,16 @@ void arm_fir_q15(
 
 void arm_fir_q15(
   const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q63_t acc0, acc1, acc2, acc3;                  /* Accumulators */
-  q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
-  q15_t *px;                                     /* Temporary q31 pointer for SIMD state buffer accesses */
+  const q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
+  const q15_t *px;                                     /* Temporary q31 pointer for SIMD state buffer accesses */
   q31_t x0, x1, x2, c0;                          /* Temporary variables to hold SIMD state and coefficient values */
   uint32_t numTaps = S->numTaps;                 /* Number of taps in the filter */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */
@@ -590,18 +590,18 @@ void arm_fir_q15(
 
 void arm_fir_q15(
   const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
 
 
 
-  q15_t *px;                                     /* Temporary pointer for state buffer */
-  q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
+  const q15_t *px;                                     /* Temporary pointer for state buffer */
+  const q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
   q63_t acc;                                     /* Accumulator */
   uint32_t numTaps = S->numTaps;                 /* Number of nTaps in the filter */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_q31.c
@@ -59,12 +59,12 @@
 
 void arm_fir_q31(
   const arm_fir_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
 
 
@@ -74,8 +74,8 @@ void arm_fir_q31(
 
   q31_t x0, x1, x2;                              /* Temporary variables to hold state */
   q31_t c0;                                      /* Temporary variable to hold coefficient value */
-  q31_t *px;                                     /* Temporary pointer for state */
-  q31_t *pb;                                     /* Temporary pointer for coefficient buffer */
+  const q31_t *px;                                     /* Temporary pointer for state */
+  const q31_t *pb;                                     /* Temporary pointer for coefficient buffer */
   q63_t acc0, acc1, acc2;                        /* Accumulators */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
   uint32_t i, tapCnt, blkCnt, tapCntN3;          /* Loop counters */
@@ -276,8 +276,8 @@ void arm_fir_q31(
 
 /* Run the below code for Cortex-M0 */
 
-  q31_t *px;                                     /* Temporary pointer for state */
-  q31_t *pb;                                     /* Temporary pointer for coefficient buffer */
+  const q31_t *px;                                     /* Temporary pointer for state */
+  const q31_t *pb;                                     /* Temporary pointer for coefficient buffer */
   q63_t acc;                                     /* Accumulator */
   uint32_t numTaps = S->numTaps;                 /* Length of the filter */
   uint32_t i, tapCnt, blkCnt;                    /* Loop counters */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_q7.c
@@ -56,7 +56,7 @@
 
 void arm_fir_q7(
   const arm_fir_instance_q7 * S,
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {
@@ -66,12 +66,12 @@ void arm_fir_q7(
   /* Run the below code for Cortex-M4 and Cortex-M3 */
 
   q7_t *pState = S->pState;                      /* State pointer */
-  q7_t *pCoeffs = S->pCoeffs;                    /* Coefficient pointer */
+  const q7_t *pCoeffs = S->pCoeffs;                    /* Coefficient pointer */
   q7_t *pStateCurnt;                             /* Points to the current sample of the state */
   q7_t x0, x1, x2, x3;                           /* Temporary variables to hold state */
   q7_t c0;                                       /* Temporary variable to hold coefficient value */
-  q7_t *px;                                      /* Temporary pointer for state */
-  q7_t *pb;                                      /* Temporary pointer for coefficient buffer */
+  const q7_t *px;                                      /* Temporary pointer for state */
+  const q7_t *pb;                                      /* Temporary pointer for coefficient buffer */
   q31_t acc0, acc1, acc2, acc3;                  /* Accumulators */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
   uint32_t i, tapCnt, blkCnt;                    /* Loop counters */
@@ -309,8 +309,8 @@ void arm_fir_q7(
   uint32_t numTaps = S->numTaps;                 /* Number of taps in the filter */
   uint32_t i, blkCnt;                            /* Loop counters */
   q7_t *pState = S->pState;                      /* State pointer */
-  q7_t *pCoeffs = S->pCoeffs;                    /* Coefficient pointer */
-  q7_t *px, *pb;                                 /* Temporary pointers to state and coeff */
+  const q7_t *pCoeffs = S->pCoeffs;                    /* Coefficient pointer */
+  const q7_t *px, *pb;                                 /* Temporary pointers to state and coeff */
   q31_t acc = 0;                                 /* Accumlator */
   q7_t *pStateCurnt;                             /* Points to the current sample of the state */
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_f32.c
@@ -111,16 +111,16 @@
 
 void arm_fir_sparse_f32(
   arm_fir_sparse_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   float32_t * pScratchIn,
   uint32_t blockSize)
 {
 
   float32_t *pState = S->pState;                 /* State pointer */
-  float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
-  float32_t *px;                                 /* Scratch buffer pointer */
-  float32_t *py = pState;                        /* Temporary pointers for state buffer */
+  const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *px;                                 /* Scratch buffer pointer */
+  const float32_t *py = pState;                        /* Temporary pointers for state buffer */
   float32_t *pb = pScratchIn;                    /* Temporary pointers for scratch buffer */
   float32_t *pOut;                               /* Destination pointer */
   int32_t *pTapDelay = S->pTapDelay;             /* Pointer to the array containing offset of the non-zero tap values. */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_f32.c
@@ -61,7 +61,7 @@
 void arm_fir_sparse_init_f32(
   arm_fir_sparse_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_q15.c
@@ -61,7 +61,7 @@
 void arm_fir_sparse_init_q15(
   arm_fir_sparse_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_q31.c
@@ -60,7 +60,7 @@
 void arm_fir_sparse_init_q31(
   arm_fir_sparse_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_init_q7.c
@@ -61,7 +61,7 @@
 void arm_fir_sparse_init_q7(
   arm_fir_sparse_instance_q7 * S,
   uint16_t numTaps,
-  q7_t * pCoeffs,
+  const q7_t * pCoeffs,
   q7_t * pState,
   int32_t * pTapDelay,
   uint16_t maxDelay,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_q15.c
@@ -56,7 +56,7 @@
 
 void arm_fir_sparse_q15(
   arm_fir_sparse_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   q15_t * pScratchIn,
   q31_t * pScratchOut,
@@ -64,9 +64,9 @@ void arm_fir_sparse_q15(
 {
 
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pIn = pSrc;                             /* Working pointer for input */
+  const q15_t *pIn = pSrc;                             /* Working pointer for input */
   q15_t *pOut = pDst;                            /* Working pointer for output */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *px;                                     /* Temporary pointers for scratch buffer */
   q15_t *pb = pScratchIn;                        /* Temporary pointers for scratch buffer */
   q15_t *py = pState;                            /* Temporary pointers for state buffer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_q31.c
@@ -54,16 +54,16 @@
 
 void arm_fir_sparse_q31(
   arm_fir_sparse_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   q31_t * pScratchIn,
   uint32_t blockSize)
 {
 
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
-  q31_t *px;                                     /* Scratch buffer pointer */
-  q31_t *py = pState;                            /* Temporary pointers for state buffer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *px;                                     /* Scratch buffer pointer */
+  const q31_t *py = pState;                            /* Temporary pointers for state buffer */
   q31_t *pb = pScratchIn;                        /* Temporary pointers for scratch buffer */
   q31_t *pOut;                                   /* Destination pointer */
   q63_t out;                                     /* Temporary output variable */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_sparse_q7.c
@@ -61,7 +61,7 @@
 
 void arm_fir_sparse_q7(
   arm_fir_sparse_instance_q7 * S,
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   q7_t * pScratchIn,
   q31_t * pScratchOut,
@@ -69,7 +69,7 @@ void arm_fir_sparse_q7(
 {
 
   q7_t *pState = S->pState;                      /* State pointer */
-  q7_t *pCoeffs = S->pCoeffs;                    /* Coefficient pointer */
+  const q7_t *pCoeffs = S->pCoeffs;              /* Coefficient pointer */
   q7_t *px;                                      /* Scratch buffer pointer */
   q7_t *py = pState;                             /* Temporary pointers for state buffer */
   q7_t *pb = pScratchIn;                         /* Temporary pointers for scratch buffer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_f32.c
@@ -121,7 +121,7 @@
 
 void arm_iir_lattice_f32(
   const arm_iir_lattice_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
@@ -335,14 +335,14 @@ void arm_iir_lattice_f32(
 
 void arm_iir_lattice_f32(
   const arm_iir_lattice_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {
   float32_t fcurr, fnext = 0, gcurr, gnext;      /* Temporary variables for lattice stages */
   float32_t acc;                                 /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* temporary variables for counts */
-  float32_t *px1, *px2, *pk, *pv;                /* temporary pointers for state and coef */
+  const float32_t *px1, *px2, *pk, *pv;                /* temporary pointers for state and coef */
   uint32_t numStages = S->numStages;             /* number of stages */
   float32_t *pState;                             /* State pointer */
   float32_t *pStateCurnt;                        /* State current pointer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_f32.c
@@ -342,7 +342,7 @@ void arm_iir_lattice_f32(
   float32_t fcurr, fnext = 0, gcurr, gnext;      /* Temporary variables for lattice stages */
   float32_t acc;                                 /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* temporary variables for counts */
-  const float32_t *px1, *px2, *pk, *pv;                /* temporary pointers for state and coef */
+  float32_t *px1, *px2, *pk, *pv;                /* temporary pointers for state and coef */
   uint32_t numStages = S->numStages;             /* number of stages */
   float32_t *pState;                             /* State pointer */
   float32_t *pStateCurnt;                        /* State current pointer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_q15.c
@@ -357,7 +357,7 @@ void arm_iir_lattice_q15(
   uint32_t stgCnt;                               /* Temporary variables for counts */
   q63_t acc;                                     /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* Temporary variables for counts */
-  const q15_t *px1, *px2, *pk, *pv;                    /* temporary pointers for state and coef */
+  q15_t *px1, *px2, *pk, *pv;                    /* temporary pointers for state and coef */
   uint32_t numStages = S->numStages;             /* number of stages */
   q15_t *pState;                                 /* State pointer */
   q15_t *pStateCurnt;                            /* State current pointer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_q15.c
@@ -58,7 +58,7 @@
 
 void arm_iir_lattice_q15(
   const arm_iir_lattice_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {
@@ -73,7 +73,8 @@ void arm_iir_lattice_q15(
   uint32_t stgCnt;                               /* Temporary variables for counts */
   q63_t acc;                                     /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* Temporary variables for counts */
-  q15_t *px1, *px2, *pk, *pv;                    /* temporary pointers for state and coef */
+  const q15_t *px1, *pk, *pv;                    /* temporary pointers for state and coef */
+  q15_t *px2;
   uint32_t numStages = S->numStages;             /* number of stages */
   q15_t *pState;                                 /* State pointer */
   q15_t *pStateCurnt;                            /* State current pointer */
@@ -356,7 +357,7 @@ void arm_iir_lattice_q15(
   uint32_t stgCnt;                               /* Temporary variables for counts */
   q63_t acc;                                     /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* Temporary variables for counts */
-  q15_t *px1, *px2, *pk, *pv;                    /* temporary pointers for state and coef */
+  const q15_t *px1, *px2, *pk, *pv;                    /* temporary pointers for state and coef */
   uint32_t numStages = S->numStages;             /* number of stages */
   q15_t *pState;                                 /* State pointer */
   q15_t *pStateCurnt;                            /* State current pointer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_iir_lattice_q31.c
@@ -57,14 +57,15 @@
 
 void arm_iir_lattice_q31(
   const arm_iir_lattice_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {
   q31_t fcurr, fnext = 0, gcurr = 0, gnext;      /* Temporary variables for lattice stages */
   q63_t acc;                                     /* Accumlator */
   uint32_t blkCnt, tapCnt;                       /* Temporary variables for counts */
-  q31_t *px1, *px2, *pk, *pv;                    /* Temporary pointers for state and coef */
+  const q31_t *px1, *pk, *pv;                    /* Temporary pointers for state and coef */
+  q31_t *px2;
   uint32_t numStages = S->numStages;             /* number of stages */
   q31_t *pState;                                 /* State pointer */
   q31_t *pStateCurnt;                            /* State current pointer */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_f32.c
@@ -175,7 +175,7 @@ void arm_lms_f32(
   uint32_t blockSize)
 {
   float32_t *pState = S->pState;                 /* State pointer */
-  const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *pCoeffs = S->pCoeffs;         /* Coefficient pointer */
   float32_t *pStateCurnt;                        /* Points to the current sample of the state */
   float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
   float32_t mu = S->mu;                          /* Adaptive factor */
@@ -347,7 +347,7 @@ void arm_lms_f32(
     px = pState;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (float32_t*) pCoeffs;
 
     /* Set the accumulator to zero */
     sum = 0.0f;
@@ -379,7 +379,7 @@ void arm_lms_f32(
     px = pState;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (float32_t *) pCoeffs;
 
     /* Loop over numTaps number of values */
     tapCnt = numTaps;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_f32.c
@@ -168,14 +168,14 @@
 
 void arm_lms_f32(
   const arm_lms_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pRef,
   float32_t * pOut,
   float32_t * pErr,
   uint32_t blockSize)
 {
   float32_t *pState = S->pState;                 /* State pointer */
-  float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
   float32_t *pStateCurnt;                        /* Points to the current sample of the state */
   float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
   float32_t mu = S->mu;                          /* Adaptive factor */
@@ -207,7 +207,7 @@ void arm_lms_f32(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (float32_t*) (pCoeffs);
 
     /* Set the accumulator to zero */
     sum = 0.0f;
@@ -254,7 +254,7 @@ void arm_lms_f32(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (float32_t*) (pCoeffs);
 
     /* Loop unrolling.  Process 4 taps at a time. */
     tapCnt = numTaps >> 2;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_init_f32.c
@@ -57,7 +57,7 @@
 void arm_lms_init_f32(
   arm_lms_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   float32_t mu,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_init_q15.c
@@ -62,7 +62,7 @@
 void arm_lms_init_q15(
   arm_lms_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   q15_t mu,
   uint32_t blockSize,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_init_q31.c
@@ -62,7 +62,7 @@
 void arm_lms_init_q31(
   arm_lms_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   q31_t mu,
   uint32_t blockSize,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_f32.c
@@ -160,14 +160,14 @@
 
 void arm_lms_norm_f32(
   arm_lms_norm_instance_f32 * S,
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pRef,
   float32_t * pOut,
   float32_t * pErr,
   uint32_t blockSize)
 {
   float32_t *pState = S->pState;                 /* State pointer */
-  float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
+  const float32_t *pCoeffs = S->pCoeffs;               /* Coefficient pointer */
   float32_t *pStateCurnt;                        /* Points to the current sample of the state */
   float32_t *px, *pb;                            /* Temporary pointers for state and coefficient buffers */
   float32_t mu = S->mu;                          /* Adaptive factor */
@@ -206,7 +206,7 @@ void arm_lms_norm_f32(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (float32_t*) (pCoeffs);
 
     /* Read the sample from input buffer */
     in = *pSrc++;
@@ -261,7 +261,7 @@ void arm_lms_norm_f32(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (float32_t*) (pCoeffs);
 
     /* Loop unrolling.  Process 4 taps at a time. */
     tapCnt = numTaps >> 2;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_f32.c
@@ -359,7 +359,7 @@ void arm_lms_norm_f32(
     px = pState;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (float32_t*) pCoeffs;
 
     /* Read the sample from input buffer */
     in = *pSrc++;
@@ -399,7 +399,7 @@ void arm_lms_norm_f32(
     px = pState;
 
     /* Initialize pCcoeffs pointer */
-    pb = pCoeffs;
+    pb = (float32_t*) pCoeffs;
 
     /* Loop over numTaps number of values */
     tapCnt = numTaps;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_init_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_init_f32.c
@@ -60,7 +60,7 @@
 void arm_lms_norm_init_f32(
   arm_lms_norm_instance_f32 * S,
   uint16_t numTaps,
-  float32_t * pCoeffs,
+  const float32_t * pCoeffs,
   float32_t * pState,
   float32_t mu,
   uint32_t blockSize)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_init_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_init_q15.c
@@ -60,7 +60,7 @@
 void arm_lms_norm_init_q15(
   arm_lms_norm_instance_q15 * S,
   uint16_t numTaps,
-  q15_t * pCoeffs,
+  const q15_t * pCoeffs,
   q15_t * pState,
   q15_t mu,
   uint32_t blockSize,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_init_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_init_q31.c
@@ -59,7 +59,7 @@
 void arm_lms_norm_init_q31(
   arm_lms_norm_instance_q31 * S,
   uint16_t numTaps,
-  q31_t * pCoeffs,
+  const q31_t * pCoeffs,
   q31_t * pState,
   q31_t mu,
   uint32_t blockSize,

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q15.c
@@ -87,7 +87,7 @@ void arm_lms_norm_q15(
   //uint32_t shift = (uint32_t) S->postShift + 1U; /* Shift to be applied to the output */
   q15_t errorXmu, oneByEnergy;                   /* Temporary variables to store error and mu product and reciprocal of energy */
   q15_t postShift;                               /* Post shift to be applied to weight after reciprocal calculation */
-  q31_t coef;                                    /* Teporary variable for coefficient */
+  q31_t coef;                                    /* Temporary variable for coefficient */
   q31_t acc_l, acc_h;
   int32_t lShift = (15 - (int32_t) S->postShift);       /*  Post shift  */
   int32_t uShift = (32 - lShift);

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q15.c
@@ -66,14 +66,14 @@
 
 void arm_lms_norm_q15(
   arm_lms_norm_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pRef,
   q15_t * pOut,
   q15_t * pErr,
   uint32_t blockSize)
 {
   q15_t *pState = S->pState;                     /* State pointer */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q15_t *px, *pb;                                /* Temporary pointers for state and coefficient buffers */
   q15_t mu = S->mu;                              /* Adaptive factor */
@@ -116,7 +116,7 @@ void arm_lms_norm_q15(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (q15_t*) (pCoeffs);
 
     /* Read the sample from input buffer */
     in = *pSrc++;
@@ -202,7 +202,7 @@ void arm_lms_norm_q15(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (q15_t*) (pCoeffs);
 
     /* Loop unrolling.  Process 4 taps at a time. */
     tapCnt = numTaps >> 2;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q15.c
@@ -306,7 +306,7 @@ void arm_lms_norm_q15(
     px = pState;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (q15_t *) pCoeffs;
 
     /* Read the sample from input buffer */
     in = *pSrc++;
@@ -370,7 +370,7 @@ void arm_lms_norm_q15(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (q15_t *) (pCoeffs);
 
     /* Loop over numTaps number of values */
     tapCnt = numTaps;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q31.c
@@ -67,14 +67,14 @@
 
 void arm_lms_norm_q31(
   arm_lms_norm_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pRef,
   q31_t * pOut,
   q31_t * pErr,
   uint32_t blockSize)
 {
   q31_t *pState = S->pState;                     /* State pointer */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t *px, *pb;                                /* Temporary pointers for state and coefficient buffers */
   q31_t mu = S->mu;                              /* Adaptive factor */
@@ -118,7 +118,7 @@ void arm_lms_norm_q31(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (q31_t*) (pCoeffs);
 
     /* Read the sample from input buffer */
     in = *pSrc++;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q31.c
@@ -298,7 +298,7 @@ void arm_lms_norm_q31(
     px = pState;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (q31_t *) pCoeffs;
 
     /* Read the sample from input buffer */
     in = *pSrc++;
@@ -358,7 +358,7 @@ void arm_lms_norm_q31(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (q31_t *) (pCoeffs);
 
     /* Loop over numTaps number of values */
     tapCnt = numTaps;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_norm_q31.c
@@ -189,7 +189,7 @@ void arm_lms_norm_q31(
     px = pState;
 
     /* Initialize coeff pointer */
-    pb = (pCoeffs);
+    pb = (q31_t*) (pCoeffs);
 
     /* Loop unrolling.  Process 4 taps at a time. */
     tapCnt = numTaps >> 2;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q15.c
@@ -275,7 +275,7 @@ void arm_lms_q15(
     px = pState;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (q15_t *) pCoeffs;
 
     /* Set the accumulator to zero */
     acc = 0;
@@ -320,7 +320,7 @@ void arm_lms_q15(
     px = pState++;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (q15_t *) pCoeffs;
 
     /* Loop over numTaps number of values */
     tapCnt = numTaps;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q15.c
@@ -61,7 +61,7 @@
 
 void arm_lms_q15(
   const arm_lms_instance_q15 * S,
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pRef,
   q15_t * pOut,
   q15_t * pErr,
@@ -69,10 +69,10 @@ void arm_lms_q15(
 {
   q15_t *pState = S->pState;                     /* State pointer */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
-  q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q15_t mu = S->mu;                              /* Adaptive factor */
-  q15_t *px;                                     /* Temporary pointer for state */
+  const q15_t *px;                                     /* Temporary pointer for state */
   q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */
   q63_t acc;                                     /* Accumulator */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q15.c
@@ -69,16 +69,16 @@ void arm_lms_q15(
 {
   q15_t *pState = S->pState;                     /* State pointer */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
-  const q15_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q15_t *pCoeffs = S->pCoeffs;             /* Coefficient pointer */
   q15_t *pStateCurnt;                            /* Points to the current sample of the state */
   q15_t mu = S->mu;                              /* Adaptive factor */
-  const q15_t *px;                                     /* Temporary pointer for state */
+  q15_t *px;                                     /* Temporary pointer for state */
   q15_t *pb;                                     /* Temporary pointer for coefficient buffer */
   uint32_t tapCnt, blkCnt;                       /* Loop counters */
   q63_t acc;                                     /* Accumulator */
   q15_t e = 0;                                   /* error of data sample */
   q15_t alpha;                                   /* Intermediate constant for taps update */
-  q31_t coef;                                    /* Teporary variable for coefficient */
+  q31_t coef;                                    /* Temporary variable for coefficient */
   q31_t acc_l, acc_h;
   int32_t lShift = (15 - (int32_t) S->postShift);       /*  Post shift  */
   int32_t uShift = (32 - lShift);
@@ -105,7 +105,7 @@ void arm_lms_q15(
     px = pState;
 
     /* Initialize coefficient pointer */
-    pb = pCoeffs;
+    pb = (q15_t*) pCoeffs;
 
     /* Set the accumulator to zero */
     acc = 0;
@@ -176,7 +176,7 @@ void arm_lms_q15(
     px = pState++;
 
     /* Initialize coefficient pointer */
-    pb = pCoeffs;
+    pb = (q15_t*) pCoeffs;
 
     /* Loop unrolling.  Process 4 taps at a time. */
     tapCnt = numTaps >> 2U;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q31.c
@@ -64,7 +64,7 @@
 
 void arm_lms_q31(
   const arm_lms_instance_q31 * S,
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pRef,
   q31_t * pOut,
   q31_t * pErr,
@@ -72,7 +72,7 @@ void arm_lms_q31(
 {
   q31_t *pState = S->pState;                     /* State pointer */
   uint32_t numTaps = S->numTaps;                 /* Number of filter coefficients in the filter */
-  q31_t *pCoeffs = S->pCoeffs;                   /* Coefficient pointer */
+  const q31_t *pCoeffs = S->pCoeffs;             /* Coefficient pointer */
   q31_t *pStateCurnt;                            /* Points to the current sample of the state */
   q31_t mu = S->mu;                              /* Adaptive factor */
   q31_t *px;                                     /* Temporary pointer for state */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q31.c
@@ -107,7 +107,7 @@ void arm_lms_q31(
     px = pState;
 
     /* Initialize coefficient pointer */
-    pb = pCoeffs;
+    pb = (q31_t*) pCoeffs;
 
     /* Set the accumulator to zero */
     acc = 0;
@@ -171,7 +171,7 @@ void arm_lms_q31(
     px = pState++;
 
     /* Initialize coefficient pointer */
-    pb = pCoeffs;
+    pb = (q31_t*) pCoeffs;
 
     /* Loop unrolling.  Process 4 taps at a time. */
     tapCnt = numTaps >> 2;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_lms_q31.c
@@ -267,7 +267,7 @@ void arm_lms_q31(
     px = pState;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (q31_t *) pCoeffs;
 
     /* Set the accumulator to zero */
     acc = 0;
@@ -309,7 +309,7 @@ void arm_lms_q31(
     px = pState++;
 
     /* Initialize pCoeffs pointer */
-    pb = pCoeffs;
+    pb = (q31_t *) pCoeffs;
 
     /* Loop over numTaps number of values */
     tapCnt = numTaps;

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_add_f32.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_add_f32.c
@@ -63,8 +63,8 @@ arm_status arm_mat_add_f32(
   const arm_matrix_instance_f32 * pSrcB,
   arm_matrix_instance_f32 * pDst)
 {
-  float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A  */
-  float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B  */
+  const float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A  */
+  const float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B  */
   float32_t *pOut = pDst->pData;                 /* output data matrix pointer   */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_add_q31.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_add_q31.c
@@ -56,8 +56,8 @@ arm_status arm_mat_add_q31(
   const arm_matrix_instance_q31 * pSrcB,
   arm_matrix_instance_q31 * pDst)
 {
-  q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
-  q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
+  const q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
+  const q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
   q31_t *pOut = pDst->pData;                     /* output data matrix pointer */
   q31_t inA1, inB1;                              /* temporary variables */
 

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_f32.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_f32.c
@@ -64,8 +64,8 @@ arm_status arm_mat_cmplx_mult_f32(
   const arm_matrix_instance_f32 * pSrcB,
   arm_matrix_instance_f32 * pDst)
 {
-  float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A */
-  float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B */
+  const float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A */
+  const float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B */
   float32_t *pInA = pSrcA->pData;                /* input data matrix pointer A  */
   float32_t *pOut = pDst->pData;                 /* output data matrix pointer */
   float32_t *px;                                 /* Temporary output data matrix pointer */

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_q15.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_q15.c
@@ -287,7 +287,7 @@ arm_status arm_mat_cmplx_mult_q15(
           c = *pInB;
           d = *(pInB + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal += (q31_t) a *c;
           sumImag += (q31_t) a *d;
           sumReal -= (q31_t) b *d;
@@ -303,7 +303,7 @@ arm_status arm_mat_cmplx_mult_q15(
           /* update pointer */
           pInA += 4U;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal += (q31_t) a *c;
           sumImag += (q31_t) a *d;
           sumReal -= (q31_t) b *d;
@@ -315,7 +315,7 @@ arm_status arm_mat_cmplx_mult_q15(
           pSourceA = *__SIMD32(pInA)++;
           pSourceB = *__SIMD32(pInB)++;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
 #ifdef ARM_MATH_BIG_ENDIAN
           prod1 = -__SMUSD(pSourceA, pSourceB);
 #else
@@ -329,7 +329,7 @@ arm_status arm_mat_cmplx_mult_q15(
           pSourceA = *__SIMD32(pInA)++;
           pSourceB = *__SIMD32(pInB)++;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
 #ifdef ARM_MATH_BIG_ENDIAN
           prod1 = -__SMUSD(pSourceA, pSourceB);
 #else
@@ -358,7 +358,7 @@ arm_status arm_mat_cmplx_mult_q15(
           c = *pInB++;
           d = *pInB++;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal += (q31_t) a *c;
           sumImag += (q31_t) a *d;
           sumReal -= (q31_t) b *d;
@@ -369,7 +369,7 @@ arm_status arm_mat_cmplx_mult_q15(
           pSourceA = *__SIMD32(pInA)++;
           pSourceB = *__SIMD32(pInB)++;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
 #ifdef ARM_MATH_BIG_ENDIAN
           prod1 = -__SMUSD(pSourceA, pSourceB);
 #else

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_q31.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_q31.c
@@ -66,8 +66,8 @@ arm_status arm_mat_cmplx_mult_q31(
   const arm_matrix_instance_q31 * pSrcB,
   arm_matrix_instance_q31 * pDst)
 {
-  q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
-  q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
+  const q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
+  const q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
   q31_t *pInA = pSrcA->pData;                    /* input data matrix pointer A  */
   q31_t *pOut = pDst->pData;                     /* output data matrix pointer */
   q31_t *px;                                     /* Temporary output data matrix pointer */
@@ -144,7 +144,7 @@ arm_status arm_mat_cmplx_mult_q31(
           /* Reading imaginary part of complex matrix B */
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 += (q63_t) a0 *c0;
           sumImag1 += (q63_t) b0 *c0;
 
@@ -152,7 +152,7 @@ arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 -= (q63_t) b0 *d0;
           sumImag1 += (q63_t) a0 *d0;
 
@@ -164,7 +164,7 @@ arm_status arm_mat_cmplx_mult_q31(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 += (q63_t) a1 *c1;
           sumImag1 += (q63_t) b1 *c1;
 
@@ -172,7 +172,7 @@ arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 -= (q63_t) b1 *d1;
           sumImag1 += (q63_t) a1 *d1;
 
@@ -182,7 +182,7 @@ arm_status arm_mat_cmplx_mult_q31(
           b0 = *(pIn1 + 1U);
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 += (q63_t) a0 *c0;
           sumImag1 += (q63_t) b0 *c0;
 
@@ -190,7 +190,7 @@ arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 -= (q63_t) b0 *d0;
           sumImag1 += (q63_t) a0 *d0;
 
@@ -202,7 +202,7 @@ arm_status arm_mat_cmplx_mult_q31(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 += (q63_t) a1 *c1;
           sumImag1 += (q63_t) b1 *c1;
 
@@ -210,7 +210,7 @@ arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 -= (q63_t) b1 *d1;
           sumImag1 += (q63_t) a1 *d1;
 
@@ -231,7 +231,7 @@ arm_status arm_mat_cmplx_mult_q31(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 += (q63_t) a1 *c1;
           sumImag1 += (q63_t) b1 *c1;
 
@@ -239,7 +239,7 @@ arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sumReal1 -= (q63_t) b1 *d1;
           sumImag1 += (q63_t) a1 *d1;
 

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_f32.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_f32.c
@@ -68,8 +68,8 @@ arm_status arm_mat_mult_f32(
   const arm_matrix_instance_f32 * pSrcB,
   arm_matrix_instance_f32 * pDst)
 {
-  float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A */
-  float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B */
+  const float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A */
+  const float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B */
   float32_t *pInA = pSrcA->pData;                /* input data matrix pointer A  */
   float32_t *pOut = pDst->pData;                 /* output data matrix pointer */
   float32_t *px;                                 /* Temporary output data matrix pointer */

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_q15.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_q15.c
@@ -297,7 +297,7 @@ arm_status arm_mat_mult_q15(
           pSourceA2 = *__SIMD32(pInA)++;
           pSourceB2 = *__SIMD32(pInB)++;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sum = __SMLALD(pSourceA1, pSourceB1, sum);
           sum = __SMLALD(pSourceA2, pSourceB2, sum);
 
@@ -306,18 +306,18 @@ arm_status arm_mat_mult_q15(
           inA1 = *pInA++;
           inB1 = *pInB++;
           inA2 = *pInA++;
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sum += inA1 * inB1;
           inB2 = *pInB++;
 
           inA1 = *pInA++;
           inB1 = *pInB++;
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sum += inA2 * inB2;
           inA2 = *pInA++;
           inB2 = *pInB++;
 
-          /* Multiply and Accumlates */
+          /* Multiply and accumulates */
           sum += inA1 * inB1;
           sum += inA2 * inB2;
 
@@ -359,12 +359,12 @@ arm_status arm_mat_mult_q15(
 
   /* Run the below code for Cortex-M0 */
 
-  q15_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
-  q15_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
+  const q15_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
+  const q15_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
   q15_t *pInA = pSrcA->pData;                    /* input data matrix pointer A of Q15 type */
   q15_t *pInB = pSrcB->pData;                    /* input data matrix pointer B of Q15 type */
   q15_t *pOut = pDst->pData;                     /* output data matrix pointer */
-  q15_t *px;                                     /* Temporary output data matrix pointer */
+  const q15_t *px;                                     /* Temporary output data matrix pointer */
   uint16_t numColsB = pSrcB->numCols;            /* number of columns of input matrix B */
   uint16_t numColsA = pSrcA->numCols;            /* number of columns of input matrix A */
   uint16_t numRowsA = pSrcA->numRows;            /* number of rows of input matrix A    */

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_q15.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_q15.c
@@ -359,12 +359,12 @@ arm_status arm_mat_mult_q15(
 
   /* Run the below code for Cortex-M0 */
 
-  const q15_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
-  const q15_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
+  const q15_t *pIn1 = pSrcA->pData;              /* input data matrix pointer A */
+  const q15_t *pIn2 = pSrcB->pData;              /* input data matrix pointer B */
   q15_t *pInA = pSrcA->pData;                    /* input data matrix pointer A of Q15 type */
   q15_t *pInB = pSrcB->pData;                    /* input data matrix pointer B of Q15 type */
   q15_t *pOut = pDst->pData;                     /* output data matrix pointer */
-  const q15_t *px;                                     /* Temporary output data matrix pointer */
+  q15_t *px;                                     /* Temporary output data matrix pointer */
   uint16_t numColsB = pSrcB->numCols;            /* number of columns of input matrix B */
   uint16_t numColsA = pSrcA->numCols;            /* number of columns of input matrix A */
   uint16_t numRowsA = pSrcA->numRows;            /* number of rows of input matrix A    */

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_q31.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_q31.c
@@ -68,8 +68,8 @@ arm_status arm_mat_mult_q31(
   const arm_matrix_instance_q31 * pSrcB,
   arm_matrix_instance_q31 * pDst)
 {
-  q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
-  q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
+  const q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
+  const q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
   q31_t *pInA = pSrcA->pData;                    /* input data matrix pointer A */
   q31_t *pOut = pDst->pData;                     /* output data matrix pointer */
   q31_t *px;                                     /* Temporary output data matrix pointer */

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_sub_f32.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_sub_f32.c
@@ -62,8 +62,8 @@ arm_status arm_mat_sub_f32(
   const arm_matrix_instance_f32 * pSrcB,
   arm_matrix_instance_f32 * pDst)
 {
-  float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A */
-  float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B */
+  const float32_t *pIn1 = pSrcA->pData;                /* input data matrix pointer A */
+  const float32_t *pIn2 = pSrcB->pData;                /* input data matrix pointer B */
   float32_t *pOut = pDst->pData;                 /* output data matrix pointer  */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_sub_q31.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_sub_q31.c
@@ -57,8 +57,8 @@ arm_status arm_mat_sub_q31(
   const arm_matrix_instance_q31 * pSrcB,
   arm_matrix_instance_q31 * pDst)
 {
-  q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
-  q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
+  const q31_t *pIn1 = pSrcA->pData;                    /* input data matrix pointer A */
+  const q31_t *pIn2 = pSrcB->pData;                    /* input data matrix pointer B */
   q31_t *pOut = pDst->pData;                     /* output data matrix pointer */
   q31_t inA1, inB1;                              /* temporary variables */
 

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_max_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_max_f32.c
@@ -56,7 +56,7 @@
  */
 
 void arm_max_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_max_q15.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_max_q15.c
@@ -48,7 +48,7 @@
  */
 
 void arm_max_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_max_q31.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_max_q31.c
@@ -48,7 +48,7 @@
  */
 
 void arm_max_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_max_q7.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_max_q7.c
@@ -48,7 +48,7 @@
  */
 
 void arm_max_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q7_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_f32.c
@@ -60,7 +60,7 @@
  */
 
 void arm_mean_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_q15.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_q15.c
@@ -58,7 +58,7 @@
  */
 
 void arm_mean_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_q31.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_q31.c
@@ -58,7 +58,7 @@
  */
 
 void arm_mean_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_q7.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_q7.c
@@ -58,7 +58,7 @@
  */
 
 void arm_mean_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q7_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_min_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_min_f32.c
@@ -56,7 +56,7 @@
  */
 
 void arm_min_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_min_q15.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_min_q15.c
@@ -49,7 +49,7 @@
  */
 
 void arm_min_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_min_q31.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_min_q31.c
@@ -49,7 +49,7 @@
  */
 
 void arm_min_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_min_q7.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_min_q7.c
@@ -49,7 +49,7 @@
  */
 
 void arm_min_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q7_t * pResult,
   uint32_t * pIndex)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_power_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_power_f32.c
@@ -62,7 +62,7 @@
 
 
 void arm_power_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_power_q15.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_power_q15.c
@@ -59,7 +59,7 @@
  */
 
 void arm_power_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q63_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_power_q31.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_power_q31.c
@@ -60,7 +60,7 @@
  */
 
 void arm_power_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q63_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_power_q7.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_power_q7.c
@@ -59,7 +59,7 @@
  */
 
 void arm_power_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_rms_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_rms_f32.c
@@ -62,7 +62,7 @@
  */
 
 void arm_rms_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_rms_q15.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_rms_q15.c
@@ -56,7 +56,7 @@
  */
 
 void arm_rms_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_rms_q31.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_rms_q31.c
@@ -59,7 +59,7 @@
  */
 
 void arm_rms_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_std_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_std_f32.c
@@ -64,7 +64,7 @@
  */
 
 void arm_std_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   uint32_t blockSize,
   float32_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_std_q15.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_std_q15.c
@@ -58,7 +58,7 @@
  */
 
 void arm_std_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_std_q31.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_std_q31.c
@@ -62,7 +62,7 @@
  */
 
 void arm_std_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_var_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_var_f32.c
@@ -63,7 +63,7 @@
  */
 
 void arm_var_f32(
-                 float32_t * pSrc,
+                 const float32_t * pSrc,
                  uint32_t blockSize,
                  float32_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_var_f32.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_var_f32.c
@@ -69,7 +69,7 @@ void arm_var_f32(
 {
     float32_t fMean, fValue;
     uint32_t blkCnt;            /* loop counter */
-    float32_t * pInput = pSrc;
+    const float32_t *pInput = pSrc;
     float32_t sum = 0.0f;
     float32_t fSum = 0.0f;
     #if defined(ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_var_q15.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_var_q15.c
@@ -58,7 +58,7 @@
  */
 
 void arm_var_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   uint32_t blockSize,
   q15_t * pResult)
 {

--- a/CMSIS/DSP/Source/StatisticsFunctions/arm_var_q31.c
+++ b/CMSIS/DSP/Source/StatisticsFunctions/arm_var_q31.c
@@ -62,7 +62,7 @@
  */
 
 void arm_var_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   uint32_t blockSize,
   q31_t * pResult)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_copy_f32.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_copy_f32.c
@@ -60,7 +60,7 @@
 
 
 void arm_copy_f32(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_copy_q15.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_copy_q15.c
@@ -46,7 +46,7 @@
  */
 
 void arm_copy_q15(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_copy_q31.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_copy_q31.c
@@ -47,7 +47,7 @@
  */
 
 void arm_copy_q31(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_copy_q7.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_copy_q7.c
@@ -47,7 +47,7 @@
  */
 
 void arm_copy_q7(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q15.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q15.c
@@ -66,7 +66,7 @@ void arm_float_to_q15(
   q15_t * pDst,
   uint32_t blockSize)
 {
-  float32_t *pIn = pSrc;                         /* Src pointer */
+  const float32_t *pIn = pSrc;                   /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #ifdef ARM_MATH_ROUNDING

--- a/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q15.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q15.c
@@ -62,7 +62,7 @@
 
 
 void arm_float_to_q15(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q31.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q31.c
@@ -70,7 +70,7 @@ void arm_float_to_q31(
   q31_t * pDst,
   uint32_t blockSize)
 {
-  float32_t *pIn = pSrc;                         /* Src pointer */
+  const float32_t *pIn = pSrc;                   /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #ifdef ARM_MATH_ROUNDING

--- a/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q31.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q31.c
@@ -66,7 +66,7 @@
 
 
 void arm_float_to_q31(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q7.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q7.c
@@ -65,7 +65,7 @@ void arm_float_to_q7(
   q7_t * pDst,
   uint32_t blockSize)
 {
-  float32_t *pIn = pSrc;                         /* Src pointer */
+  const float32_t *pIn = pSrc;                   /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #ifdef ARM_MATH_ROUNDING

--- a/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q7.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_float_to_q7.c
@@ -61,7 +61,7 @@
 
 
 void arm_float_to_q7(
-  float32_t * pSrc,
+  const float32_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_float.c
@@ -67,7 +67,7 @@ void arm_q15_to_float(
   float32_t * pDst,
   uint32_t blockSize)
 {
-  q15_t *pIn = pSrc;                             /* Src pointer */
+  const q15_t *pIn = pSrc;                        /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_float.c
@@ -63,7 +63,7 @@
 
 
 void arm_q15_to_float(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q31.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q31.c
@@ -60,7 +60,7 @@ void arm_q15_to_q31(
   q31_t * pDst,
   uint32_t blockSize)
 {
-  q15_t *pIn = pSrc;                             /* Src pointer */
+  const q15_t *pIn = pSrc;                       /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q31.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q31.c
@@ -56,7 +56,7 @@
 
 
 void arm_q15_to_q31(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q7.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q7.c
@@ -61,7 +61,7 @@ void arm_q15_to_q7(
   q7_t * pDst,
   uint32_t blockSize)
 {
-  q15_t *pIn = pSrc;                             /* Src pointer */
+  const q15_t *pIn = pSrc;                       /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q7.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_q7.c
@@ -57,7 +57,7 @@
 
 
 void arm_q15_to_q7(
-  q15_t * pSrc,
+  const q15_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_float.c
@@ -64,7 +64,7 @@ void arm_q31_to_float(
   float32_t * pDst,
   uint32_t blockSize)
 {
-  q31_t *pIn = pSrc;                             /* Src pointer */
+  const q31_t *pIn = pSrc;                       /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_float.c
@@ -60,7 +60,7 @@
 
 
 void arm_q31_to_float(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q15.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q15.c
@@ -60,7 +60,7 @@ void arm_q31_to_q15(
   q15_t * pDst,
   uint32_t blockSize)
 {
-  q31_t *pIn = pSrc;                             /* Src pointer */
+  const q31_t *pIn = pSrc;                       /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q15.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q15.c
@@ -56,7 +56,7 @@
 
 
 void arm_q31_to_q15(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q7.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q7.c
@@ -56,7 +56,7 @@
 
 
 void arm_q31_to_q7(
-  q31_t * pSrc,
+  const q31_t * pSrc,
   q7_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q7.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q31_to_q7.c
@@ -60,7 +60,7 @@ void arm_q31_to_q7(
   q7_t * pDst,
   uint32_t blockSize)
 {
-  q31_t *pIn = pSrc;                             /* Src pointer */
+  const q31_t *pIn = pSrc;                       /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_float.c
@@ -64,7 +64,7 @@ void arm_q7_to_float(
   float32_t * pDst,
   uint32_t blockSize)
 {
-  q7_t *pIn = pSrc;                              /* Src pointer */
+  const q7_t *pIn = pSrc;                        /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_float.c
@@ -60,7 +60,7 @@
 
 
 void arm_q7_to_float(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   float32_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q15.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q15.c
@@ -63,7 +63,7 @@ void arm_q7_to_q15(
   q15_t * pDst,
   uint32_t blockSize)
 {
-  q7_t *pIn = pSrc;                              /* Src pointer */
+  const q7_t *pIn = pSrc;                        /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q15.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q15.c
@@ -59,7 +59,7 @@
 
 
 void arm_q7_to_q15(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q15_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q31.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q31.c
@@ -56,7 +56,7 @@
 
 
 void arm_q7_to_q31(
-  q7_t * pSrc,
+  const q7_t * pSrc,
   q31_t * pDst,
   uint32_t blockSize)
 {

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q31.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_q31.c
@@ -60,7 +60,7 @@ void arm_q7_to_q31(
   q31_t * pDst,
   uint32_t blockSize)
 {
-  q7_t *pIn = pSrc;                              /* Src pointer */
+  const q7_t *pIn = pSrc;                        /* Src pointer */
   uint32_t blkCnt;                               /* loop counter */
 
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/TransformFunctions/arm_bitreversal.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_bitreversal.c
@@ -42,7 +42,7 @@ void arm_bitreversal_f32(
 float32_t * pSrc,
 uint16_t fftSize,
 uint16_t bitRevFactor,
-uint16_t * pBitRevTab)
+const uint16_t * pBitRevTab)
 {
    uint16_t fftLenBy2, fftLenBy2p1;
    uint16_t i, j;
@@ -114,7 +114,7 @@ void arm_bitreversal_q31(
 q31_t * pSrc,
 uint32_t fftLen,
 uint16_t bitRevFactor,
-uint16_t * pBitRevTable)
+const uint16_t * pBitRevTable)
 {
    uint32_t fftLenBy2, fftLenBy2p1, i, j;
    q31_t in;
@@ -185,7 +185,7 @@ void arm_bitreversal_q15(
 q15_t * pSrc16,
 uint32_t fftLen,
 uint16_t bitRevFactor,
-uint16_t * pBitRevTab)
+const uint16_t * pBitRevTab)
 {
    q31_t *pSrc = (q31_t *) pSrc16;
    q31_t in;

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_f32.c
@@ -37,7 +37,7 @@ extern void arm_radix8_butterfly_f32(
 
 extern void arm_bitreversal_32(
     uint32_t * pSrc,
-    const uint16_t bitRevLen,
+    uint16_t bitRevLen,
     const uint16_t * pBitRevTable);
 
 /**

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
@@ -42,7 +42,7 @@ extern void arm_radix4_butterfly_inverse_q15(
 
 extern void arm_bitreversal_16(
     uint16_t * pSrc,
-    const uint16_t bitRevLen,
+    uint16_t bitRevLen,
     const uint16_t * pBitRevTable);
 
 void arm_cfft_radix4by2_q15(

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q31.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q31.c
@@ -42,7 +42,7 @@ extern void arm_radix4_butterfly_inverse_q31(
 
 extern void arm_bitreversal_32(
     uint32_t * pSrc,
-    const uint16_t bitRevLen,
+    uint16_t bitRevLen,
     const uint16_t * pBitRevTable);
 
 void arm_cfft_radix4by2_q31(

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_f32.c
@@ -31,13 +31,13 @@
 void arm_radix2_butterfly_f32(
   float32_t * pSrc,
   uint32_t fftLen,
-  float32_t * pCoef,
+  const float32_t * pCoef,
   uint16_t twidCoefModifier);
 
 void arm_radix2_butterfly_inverse_f32(
   float32_t * pSrc,
   uint32_t fftLen,
-  float32_t * pCoef,
+  const float32_t * pCoef,
   uint16_t twidCoefModifier,
   float32_t onebyfftLen);
 
@@ -115,7 +115,7 @@ float32_t * pSrc)
 void arm_radix2_butterfly_f32(
 float32_t * pSrc,
 uint32_t fftLen,
-float32_t * pCoef,
+const float32_t * pCoef,
 uint16_t twidCoefModifier)
 {
 
@@ -283,7 +283,7 @@ uint16_t twidCoefModifier)
 void arm_radix2_butterfly_inverse_f32(
 float32_t * pSrc,
 uint32_t fftLen,
-float32_t * pCoef,
+const float32_t * pCoef,
 uint16_t twidCoefModifier,
 float32_t onebyfftLen)
 {

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_f32.c
@@ -45,7 +45,7 @@ extern void arm_bitreversal_f32(
     float32_t * pSrc,
     uint16_t fftSize,
     uint16_t bitRevFactor,
-    uint16_t * pBitRevTab);
+    const uint16_t * pBitRevTab);
 
 /**
 * @ingroup groupTransforms

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_q15.c
@@ -31,20 +31,20 @@
 void arm_radix2_butterfly_q15(
   q15_t * pSrc,
   uint32_t fftLen,
-  q15_t * pCoef,
+  const q15_t * pCoef,
   uint16_t twidCoefModifier);
 
 void arm_radix2_butterfly_inverse_q15(
   q15_t * pSrc,
   uint32_t fftLen,
-  q15_t * pCoef,
+  const q15_t * pCoef,
   uint16_t twidCoefModifier);
 
 void arm_bitreversal_q15(
   q15_t * pSrc,
   uint32_t fftLen,
   uint16_t bitRevFactor,
-  uint16_t * pBitRevTab);
+  const uint16_t * pBitRevTab);
 
 /**
  * @ingroup groupTransforms
@@ -90,7 +90,7 @@ void arm_cfft_radix2_q15(
 void arm_radix2_butterfly_q15(
   q15_t * pSrc,
   uint32_t fftLen,
-  q15_t * pCoef,
+  const q15_t * pCoef,
   uint16_t twidCoefModifier)
 {
 #if defined (ARM_MATH_DSP)
@@ -419,7 +419,7 @@ void arm_radix2_butterfly_q15(
 void arm_radix2_butterfly_inverse_q15(
   q15_t * pSrc,
   uint32_t fftLen,
-  q15_t * pCoef,
+  const q15_t * pCoef,
   uint16_t twidCoefModifier)
 {
 #if defined (ARM_MATH_DSP)

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_q31.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix2_q31.c
@@ -31,20 +31,20 @@
 void arm_radix2_butterfly_q31(
   q31_t * pSrc,
   uint32_t fftLen,
-  q31_t * pCoef,
+  const q31_t * pCoef,
   uint16_t twidCoefModifier);
 
 void arm_radix2_butterfly_inverse_q31(
   q31_t * pSrc,
   uint32_t fftLen,
-  q31_t * pCoef,
+  const q31_t * pCoef,
   uint16_t twidCoefModifier);
 
 void arm_bitreversal_q31(
   q31_t * pSrc,
   uint32_t fftLen,
   uint16_t bitRevFactor,
-  uint16_t * pBitRevTab);
+  const uint16_t * pBitRevTab);
 
 /**
 * @ingroup groupTransforms
@@ -90,7 +90,7 @@ q31_t * pSrc)
 void arm_radix2_butterfly_q31(
 q31_t * pSrc,
 uint32_t fftLen,
-q31_t * pCoef,
+const q31_t * pCoef,
 uint16_t twidCoefModifier)
 {
 
@@ -218,7 +218,7 @@ uint16_t twidCoefModifier)
 void arm_radix2_butterfly_inverse_q31(
 q31_t * pSrc,
 uint32_t fftLen,
-q31_t * pCoef,
+const q31_t * pCoef,
 uint16_t twidCoefModifier)
 {
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_f32.c
@@ -32,18 +32,18 @@ extern void arm_bitreversal_f32(
 float32_t * pSrc,
 uint16_t fftSize,
 uint16_t bitRevFactor,
-uint16_t * pBitRevTab);
+const uint16_t * pBitRevTab);
 
 void arm_radix4_butterfly_f32(
 float32_t * pSrc,
 uint16_t fftLen,
-float32_t * pCoef,
+const float32_t * pCoef,
 uint16_t twidCoefModifier);
 
 void arm_radix4_butterfly_inverse_f32(
 float32_t * pSrc,
 uint16_t fftLen,
-float32_t * pCoef,
+const float32_t * pCoef,
 uint16_t twidCoefModifier,
 float32_t onebyfftLen);
 
@@ -110,7 +110,7 @@ void arm_cfft_radix4_f32(
 void arm_radix4_butterfly_f32(
 float32_t * pSrc,
 uint16_t fftLen,
-float32_t * pCoef,
+const float32_t * pCoef,
 uint16_t twidCoefModifier)
 {
 
@@ -614,7 +614,7 @@ uint16_t twidCoefModifier)
 void arm_radix4_butterfly_inverse_f32(
 float32_t * pSrc,
 uint16_t fftLen,
-float32_t * pCoef,
+const float32_t * pCoef,
 uint16_t twidCoefModifier,
 float32_t onebyfftLen)
 {

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q15.c
@@ -46,7 +46,7 @@ void arm_bitreversal_q15(
   q15_t * pSrc,
   uint32_t fftLen,
   uint16_t bitRevFactor,
-  const int16_t * pBitRevTab);
+  const uint16_t * pBitRevTab);
 
 /**
  * @ingroup groupTransforms

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q15.c
@@ -33,20 +33,20 @@
 void arm_radix4_butterfly_q15(
   q15_t * pSrc16,
   uint32_t fftLen,
-  q15_t * pCoef16,
+  const q15_t * pCoef16,
   uint32_t twidCoefModifier);
 
 void arm_radix4_butterfly_inverse_q15(
   q15_t * pSrc16,
   uint32_t fftLen,
-  q15_t * pCoef16,
+  const q15_t * pCoef16,
   uint32_t twidCoefModifier);
 
 void arm_bitreversal_q15(
   q15_t * pSrc,
   uint32_t fftLen,
   uint16_t bitRevFactor,
-  uint16_t * pBitRevTab);
+  const int16_t * pBitRevTab);
 
 /**
  * @ingroup groupTransforms
@@ -149,7 +149,7 @@ void arm_cfft_radix4_q15(
 void arm_radix4_butterfly_q15(
   q15_t * pSrc16,
   uint32_t fftLen,
-  q15_t * pCoef16,
+  const q15_t * pCoef16,
   uint32_t twidCoefModifier)
 {
 
@@ -1066,7 +1066,7 @@ void arm_radix4_butterfly_q15(
 void arm_radix4_butterfly_inverse_q15(
   q15_t * pSrc16,
   uint32_t fftLen,
-  q15_t * pCoef16,
+  const q15_t * pCoef16,
   uint32_t twidCoefModifier)
 {
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q31.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q31.c
@@ -32,20 +32,20 @@
 void arm_radix4_butterfly_inverse_q31(
 q31_t * pSrc,
 uint32_t fftLen,
-q31_t * pCoef,
+const q31_t * pCoef,
 uint32_t twidCoefModifier);
 
 void arm_radix4_butterfly_q31(
 q31_t * pSrc,
 uint32_t fftLen,
-q31_t * pCoef,
+const q31_t * pCoef,
 uint32_t twidCoefModifier);
 
 void arm_bitreversal_q31(
 q31_t * pSrc,
 uint32_t fftLen,
 uint16_t bitRevFactor,
-uint16_t * pBitRevTab);
+const uint16_t * pBitRevTab);
 
 /**
  * @ingroup groupTransforms
@@ -148,7 +148,7 @@ void arm_cfft_radix4_q31(
 void arm_radix4_butterfly_q31(
   q31_t * pSrc,
   uint32_t fftLen,
-  q31_t * pCoef,
+  const q31_t * pCoef,
   uint32_t twidCoefModifier)
 {
   uint32_t n1, n2, ia1, ia2, ia3, i0, i1, i2, i3, j, k;
@@ -553,7 +553,7 @@ void arm_radix4_butterfly_q31(
 void arm_radix4_butterfly_inverse_q31(
   q31_t * pSrc,
   uint32_t fftLen,
-  q31_t * pCoef,
+  const q31_t * pCoef,
   uint32_t twidCoefModifier)
 {
   uint32_t n1, n2, ia1, ia2, ia3, i0, i1, i2, i3, j, k;

--- a/CMSIS/DSP/Source/TransformFunctions/arm_dct4_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_dct4_f32.c
@@ -128,8 +128,8 @@ void arm_dct4_f32(
   float32_t * pInlineBuffer)
 {
   uint32_t i;                                    /* Loop counter */
-  float32_t *weights = S->pTwiddle;              /* Pointer to the Weights table */
-  float32_t *cosFact = S->pCosFactor;            /* Pointer to the cos factors table */
+  const float32_t *weights = S->pTwiddle;        /* Pointer to the Weights table */
+  const float32_t *cosFact = S->pCosFactor;      /* Pointer to the cos factors table */
   float32_t *pS1, *pS2, *pbuff;                  /* Temporary pointers for input buffer and pState buffer */
   float32_t in;                                  /* Temporary variable */
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_dct4_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_dct4_q15.c
@@ -54,8 +54,8 @@ void arm_dct4_q15(
   q15_t * pInlineBuffer)
 {
   uint32_t i;                                    /* Loop counter */
-  q15_t *weights = S->pTwiddle;                  /* Pointer to the Weights table */
-  q15_t *cosFact = S->pCosFactor;                /* Pointer to the cos factors table */
+  const q15_t *weights = S->pTwiddle;                  /* Pointer to the Weights table */
+  const q15_t *cosFact = S->pCosFactor;                /* Pointer to the cos factors table */
   q15_t *pS1, *pS2, *pbuff;                      /* Temporary pointers for input buffer and pState buffer */
   q15_t in;                                      /* Temporary variable */
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_dct4_q31.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_dct4_q31.c
@@ -55,8 +55,8 @@ void arm_dct4_q31(
   q31_t * pInlineBuffer)
 {
   uint16_t i;                                    /* Loop counter */
-  q31_t *weights = S->pTwiddle;                  /* Pointer to the Weights table */
-  q31_t *cosFact = S->pCosFactor;                /* Pointer to the cos factors table */
+  const q31_t *weights = S->pTwiddle;            /* Pointer to the Weights table */
+  const q31_t *cosFact = S->pCosFactor;          /* Pointer to the cos factors table */
   q31_t *pS1, *pS2, *pbuff;                      /* Temporary pointers for input buffer and pState buffer */
   q31_t in;                                      /* Temporary variable */
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_rfft_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_rfft_f32.c
@@ -35,13 +35,13 @@
 extern void arm_radix4_butterfly_f32(
     float32_t * pSrc,
     uint16_t fftLen,
-    float32_t * pCoef,
+    const float32_t * pCoef,
     uint16_t twidCoefModifier);
 
 extern void arm_radix4_butterfly_inverse_f32(
     float32_t * pSrc,
     uint16_t fftLen,
-    float32_t * pCoef,
+    const float32_t * pCoef,
     uint16_t twidCoefModifier,
     float32_t onebyfftLen);
 
@@ -49,21 +49,21 @@ extern void arm_bitreversal_f32(
     float32_t * pSrc,
     uint16_t fftSize,
     uint16_t bitRevFactor,
-    uint16_t * pBitRevTab);
+    const uint16_t * pBitRevTab);
 
 void arm_split_rfft_f32(
   float32_t * pSrc,
   uint32_t fftLen,
-  float32_t * pATable,
-  float32_t * pBTable,
+  const float32_t * pATable,
+  const float32_t * pBTable,
   float32_t * pDst,
   uint32_t modifier);
 
 void arm_split_rifft_f32(
   float32_t * pSrc,
   uint32_t fftLen,
-  float32_t * pATable,
-  float32_t * pBTable,
+  const float32_t * pATable,
+  const float32_t * pBTable,
   float32_t * pDst,
   uint32_t modifier);
 
@@ -157,14 +157,14 @@ void arm_rfft_f32(
 void arm_split_rfft_f32(
   float32_t * pSrc,
   uint32_t fftLen,
-  float32_t * pATable,
-  float32_t * pBTable,
+  const float32_t * pATable,
+  const float32_t * pBTable,
   float32_t * pDst,
   uint32_t modifier)
 {
   uint32_t i;                                    /* Loop Counter */
   float32_t outR, outI;                          /* Temporary variables for output */
-  float32_t *pCoefA, *pCoefB;                    /* Temporary pointers for twiddle factors */
+  const float32_t *pCoefA, *pCoefB;              /* Temporary pointers for twiddle factors */
   float32_t CoefA1, CoefA2, CoefB1;              /* Temporary variables for twiddle coefficients */
   float32_t *pDst1 = &pDst[2], *pDst2 = &pDst[(4U * fftLen) - 1U];      /* temp pointers for output buffer */
   float32_t *pSrc1 = &pSrc[2], *pSrc2 = &pSrc[(2U * fftLen) - 1U];      /* temp pointers for input buffer */
@@ -251,13 +251,13 @@ void arm_split_rfft_f32(
 void arm_split_rifft_f32(
   float32_t * pSrc,
   uint32_t fftLen,
-  float32_t * pATable,
-  float32_t * pBTable,
+  const float32_t * pATable,
+  const float32_t * pBTable,
   float32_t * pDst,
   uint32_t modifier)
 {
   float32_t outR, outI;                          /* Temporary variables for output */
-  float32_t *pCoefA, *pCoefB;                    /* Temporary pointers for twiddle factors */
+  const float32_t *pCoefA, *pCoefB;              /* Temporary pointers for twiddle factors */
   float32_t CoefA1, CoefA2, CoefB1;              /* Temporary variables for twiddle coefficients */
   float32_t *pSrc1 = &pSrc[0], *pSrc2 = &pSrc[(2U * fftLen) + 1U];
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_rfft_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_rfft_q15.c
@@ -35,16 +35,16 @@
 void arm_split_rfft_q15(
     q15_t * pSrc,
     uint32_t fftLen,
-    q15_t * pATable,
-    q15_t * pBTable,
+    const q15_t * pATable,
+    const q15_t * pBTable,
     q15_t * pDst,
     uint32_t modifier);
 
 void arm_split_rifft_q15(
     q15_t * pSrc,
     uint32_t fftLen,
-    q15_t * pATable,
-    q15_t * pBTable,
+    const q15_t * pATable,
+    const q15_t * pBTable,
     q15_t * pDst,
     uint32_t modifier);
 
@@ -127,14 +127,14 @@ void arm_rfft_q15(
 void arm_split_rfft_q15(
     q15_t * pSrc,
     uint32_t fftLen,
-    q15_t * pATable,
-    q15_t * pBTable,
+    const q15_t * pATable,
+    const q15_t * pBTable,
     q15_t * pDst,
     uint32_t modifier)
 {
     uint32_t i;                                    /* Loop Counter */
     q31_t outR, outI;                              /* Temporary variables for output */
-    q15_t *pCoefA, *pCoefB;                        /* Temporary pointers for twiddle factors */
+    const q15_t *pCoefA, *pCoefB;                  /* Temporary pointers for twiddle factors */
     q15_t *pSrc1, *pSrc2;
 #if defined (ARM_MATH_DSP)
     q15_t *pD1, *pD2;
@@ -282,7 +282,7 @@ void arm_split_rfft_q15(
 /**
 * @brief  Core Real IFFT process
 * @param[in]   *pSrc 				points to the input buffer.
-* @param[in]   fftLen  		    length of FFT.
+* @param[in]   fftLen  		        length of FFT.
 * @param[in]   *pATable 			points to the twiddle Coef A buffer.
 * @param[in]   *pBTable 			points to the twiddle Coef B buffer.
 * @param[out]  *pDst 				points to the output buffer.
@@ -293,14 +293,14 @@ void arm_split_rfft_q15(
 void arm_split_rifft_q15(
     q15_t * pSrc,
     uint32_t fftLen,
-    q15_t * pATable,
-    q15_t * pBTable,
+    const q15_t * pATable,
+    const q15_t * pBTable,
     q15_t * pDst,
     uint32_t modifier)
 {
     uint32_t i;                                    /* Loop Counter */
     q31_t outR, outI;                              /* Temporary variables for output */
-    q15_t *pCoefA, *pCoefB;                        /* Temporary pointers for twiddle factors */
+    const q15_t *pCoefA, *pCoefB;                  /* Temporary pointers for twiddle factors */
     q15_t *pSrc1, *pSrc2;
     q15_t *pDst1 = &pDst[0];
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_rfft_q31.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_rfft_q31.c
@@ -35,16 +35,16 @@
 void arm_split_rfft_q31(
     q31_t * pSrc,
     uint32_t fftLen,
-    q31_t * pATable,
-    q31_t * pBTable,
+    const q31_t * pATable,
+    const q31_t * pBTable,
     q31_t * pDst,
     uint32_t modifier);
 
 void arm_split_rifft_q31(
     q31_t * pSrc,
     uint32_t fftLen,
-    q31_t * pATable,
-    q31_t * pBTable,
+    const q31_t * pATable,
+    const q31_t * pBTable,
     q31_t * pDst,
     uint32_t modifier);
 
@@ -125,14 +125,14 @@ void arm_rfft_q31(
 void arm_split_rfft_q31(
     q31_t * pSrc,
     uint32_t fftLen,
-    q31_t * pATable,
-    q31_t * pBTable,
+    const q31_t * pATable,
+    const q31_t * pBTable,
     q31_t * pDst,
     uint32_t modifier)
 {
     uint32_t i;                                    /* Loop Counter */
     q31_t outR, outI;                              /* Temporary variables for output */
-    q31_t *pCoefA, *pCoefB;                        /* Temporary pointers for twiddle factors */
+    const q31_t *pCoefA, *pCoefB;                  /* Temporary pointers for twiddle factors */
     q31_t CoefA1, CoefA2, CoefB1;                  /* Temporary variables for twiddle coefficients */
     q31_t *pOut1 = &pDst[2], *pOut2 = &pDst[(4U * fftLen) - 1U];
     q31_t *pIn1 = &pSrc[2], *pIn2 = &pSrc[(2U * fftLen) - 1U];
@@ -217,13 +217,13 @@ void arm_split_rfft_q31(
 void arm_split_rifft_q31(
     q31_t * pSrc,
     uint32_t fftLen,
-    q31_t * pATable,
-    q31_t * pBTable,
+    const q31_t * pATable,
+    const q31_t * pBTable,
     q31_t * pDst,
     uint32_t modifier)
 {
     q31_t outR, outI;                              /* Temporary variables for output */
-    q31_t *pCoefA, *pCoefB;                        /* Temporary pointers for twiddle factors */
+    const q31_t *pCoefA, *pCoefB;                  /* Temporary pointers for twiddle factors */
     q31_t CoefA1, CoefA2, CoefB1;                  /* Temporary variables for twiddle coefficients */
     q31_t *pIn1 = &pSrc[0], *pIn2 = &pSrc[(2U * fftLen) + 1U];
 


### PR DESCRIPTION
This PR closes #349. The lack of const-correctness has been bugging me lately as I've been writing a C++ wrapper around the CMSIS-DSP library, and my C++ linter and compiler are quite strict in requiring const correctness. 

I've also fixed a couple of recurring typos. Adding `const` might in some cases help the compiler optimize further as well, but this has not been verified. 

In some source files, a pointer has been reused to point to both a `const` and non-`const` field. In these cases, I've elected to do a cast from `const` to non-`const`, otherwise I'd be introducing a second temporary pointer. 