### PR TITLE
`arm_nn_tables.h`: removed duplicated declaration

### DIFF
--- a/CMSIS/NN/Include/arm_nn_tables.h
+++ b/CMSIS/NN/Include/arm_nn_tables.h
@@ -53,7 +53,4 @@ extern const q15_t tanhTable_q15[256];
 extern const q15_t sigmoidHTable_q15[192];
 extern const q15_t sigmoidLTable_q15[128];
 
-extern const q15_t sigmoidLTable_q15[128];
-extern const q15_t sigmoidHTable_q15[192];
-
 #endif                          /*  ARM_NN_TABLES_H */


### PR DESCRIPTION
Fixed duplicated declaration of `sigmoidHTable_q15`, `sigmoidLTable_q15`.