### PR TITLE
RTX5: Have osThreadJoin mark thread non-joinable

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_thread.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_thread.c
@@ -1184,6 +1184,7 @@ static osStatus_t svcRtxThreadJoin (osThreadId_t thread_id) {
     // Suspend current Thread
     if (osRtxThreadWaitEnter(osRtxThreadWaitingJoin, osWaitForever)) {
       thread->thread_join = osRtxThreadGetRunning();
+      thread->attr &= ~osThreadJoinable;
       EvrRtxThreadJoinPending(thread);
     } else {
       EvrRtxThreadError(thread, (int32_t)osErrorResource);
@@ -1223,7 +1224,7 @@ static void svcRtxThreadExit (void) {
   osRtxThreadSwitch(osRtxThreadListGet(&osRtxInfo.thread.ready));
   osRtxThreadSetRunning(NULL);
 
-  if (((thread->attr & osThreadJoinable) == 0U) || (thread->thread_join != NULL)) {
+  if ((thread->attr & osThreadJoinable) == 0U) {
     osRtxThreadFree(thread);
   } else {
     // Update Thread State and put it into Terminate Thread list
@@ -1299,7 +1300,7 @@ static osStatus_t svcRtxThreadTerminate (osThreadId_t thread_id) {
       osRtxThreadDispatch(NULL);
     }
 
-    if (((thread->attr & osThreadJoinable) == 0U) || (thread->thread_join != NULL)) {
+    if ((thread->attr & osThreadJoinable) == 0U) {
       osRtxThreadFree(thread);
     } else {
       // Update Thread State and put it into Terminate Thread list


### PR DESCRIPTION
By inspection, this will have the following effects:

* A second call to osThreadJoin while the first is still waiting will now
  return with osErrorResource, rather than starting a join on this thread
  and leaving the first thread to never wake - we trap and avoid this
  application-caused deadlock.
* A call to osThreadDetach while an osThreadJoin is still waiting will
  now return with osErrorResource; this previously would have cleared
  the joinable flag and returned osOK.
* svcRtxThreadExit and svcRtxThreadTerminate implementations can be
  slightly simplified, as they only need to check the Joinable flag to
  decide whether to immediately free.