### PR TITLE
NVIC_SetVector: Add DSB to newer cores

### DIFF
--- a/CMSIS/Core/Include/core_armv81mml.h
+++ b/CMSIS/Core/Include/core_armv81mml.h
@@ -2480,6 +2480,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t *vectors = (uint32_t *)SCB->VTOR;
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
 }
 
 

--- a/CMSIS/Core/Include/core_armv8mbl.h
+++ b/CMSIS/Core/Include/core_armv8mbl.h
@@ -1552,6 +1552,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
   uint32_t *vectors = (uint32_t *)0x0U;
 #endif
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
 }
 
 

--- a/CMSIS/Core/Include/core_armv8mml.h
+++ b/CMSIS/Core/Include/core_armv8mml.h
@@ -2345,6 +2345,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t *vectors = (uint32_t *)SCB->VTOR;
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
 }
 
 

--- a/CMSIS/Core/Include/core_cm0.h
+++ b/CMSIS/Core/Include/core_cm0.h
@@ -831,6 +831,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t vectors = 0x0U;
   (* (int *) (vectors + ((int32_t)IRQn + NVIC_USER_IRQ_OFFSET) * 4)) = vector;
+  /* ARM Application Note 321 states that the M0 does not require the architectural barrier */
 }
 
 

--- a/CMSIS/Core/Include/core_cm0plus.h
+++ b/CMSIS/Core/Include/core_cm0plus.h
@@ -953,6 +953,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
   uint32_t vectors = 0x0U;
 #endif
   (* (int *) (vectors + ((int32_t)IRQn + NVIC_USER_IRQ_OFFSET) * 4)) = vector;
+  /* ARM Application Note 321 states that the M0+ does not require the architectural barrier */
 }
 
 

--- a/CMSIS/Core/Include/core_cm1.h
+++ b/CMSIS/Core/Include/core_cm1.h
@@ -858,6 +858,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t *vectors = (uint32_t *)0x0U;
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M1 does not require the architectural barrier */
 }
 
 

--- a/CMSIS/Core/Include/core_cm23.h
+++ b/CMSIS/Core/Include/core_cm23.h
@@ -1627,6 +1627,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
   uint32_t *vectors = (uint32_t *)0x0U;
 #endif
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
 }
 
 

--- a/CMSIS/Core/Include/core_cm3.h
+++ b/CMSIS/Core/Include/core_cm3.h
@@ -1729,6 +1729,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t vectors = (uint32_t )SCB->VTOR;
   (* (int *) (vectors + ((int32_t)IRQn + NVIC_USER_IRQ_OFFSET) * 4)) = vector;
+  /* ARM Application Note 321 states that the M3 does not require the architectural barrier */
 }
 
 

--- a/CMSIS/Core/Include/core_cm33.h
+++ b/CMSIS/Core/Include/core_cm33.h
@@ -2420,6 +2420,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t *vectors = (uint32_t *)SCB->VTOR;
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
 }
 
 

--- a/CMSIS/Core/Include/core_cm35p.h
+++ b/CMSIS/Core/Include/core_cm35p.h
@@ -2420,6 +2420,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t *vectors = (uint32_t *)SCB->VTOR;
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
 }
 
 

--- a/CMSIS/Core/Include/core_cm4.h
+++ b/CMSIS/Core/Include/core_cm4.h
@@ -1905,6 +1905,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t vectors = (uint32_t )SCB->VTOR;
   (* (int *) (vectors + ((int32_t)IRQn + NVIC_USER_IRQ_OFFSET) * 4)) = vector;
+  /* ARM Application Note 321 states that the M4 does not require the architectural barrier */
 }
 
 

--- a/CMSIS/Core/Include/core_cm7.h
+++ b/CMSIS/Core/Include/core_cm7.h
@@ -2128,6 +2128,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t vectors = (uint32_t )SCB->VTOR;
   (* (int *) (vectors + ((int32_t)IRQn + NVIC_USER_IRQ_OFFSET) * 4)) = vector;
+  __DSB();
 }
 
 

--- a/CMSIS/Core/Include/core_sc000.h
+++ b/CMSIS/Core/Include/core_sc000.h
@@ -904,6 +904,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t *vectors = (uint32_t *)SCB->VTOR;
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M0 and M0+ do not require the architectural barrier - assume SC000 is the same */
 }
 
 

--- a/CMSIS/Core/Include/core_sc300.h
+++ b/CMSIS/Core/Include/core_sc300.h
@@ -1718,6 +1718,7 @@ __STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
   uint32_t *vectors = (uint32_t *)SCB->VTOR;
   vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M3 does not require the architectural barrier - assume SC300 is the same */
 }
 
 


### PR DESCRIPTION
Architecturally, a barrier is required after a vector table change to ensure that the newly-written entry is used by an immediately-occurring exception.

Without a barrier, the following sequences could fail:

    NVIC_SetVector(irq, irq_handler);
    NVIC_EnableIRQ(irq);

or

    NVIC_SetVector(SVCall_IRQn, svc_handler);
    __SVC(0);

A DSB at the end of `NVIC_SetVector` covers both cases.

A failure due to lack of barrier in the first case has been observed on Cortex-M7.

For earlier Cortex-M cores, ARM Application Note 321 ("ARM Cortex-M Programming Guide to Memory Barrier Instructions") states:

    ARM recommends that the architectural requirements are adopted.

    ... architecturally a memory barrier instruction is
    required after the vector table entry is updated, and if the
    exception is to be activated immediately.

    ...

    In the Cortex-M processors, omission of the DSB or DMB instructions
    does not cause any issue in vector entry modifications.

We take this last statement to apply to the M0, M0+, M1, M3 and M4 that the document covers, assuming further that it applies to all revisions beyond those listed, and also to the SC000 and SC300 (as variants of the M0 and M3).

ARM has not published similar implementation specifications for later cores, so a DSB is added to M7, M23, M33, M35P, and the generic ARMv8-M variants.

Fixes #576.
