### PR TITLE
Added register save to "__FPU_Enable()"

### DIFF
--- a/CMSIS/Core_A/Include/cmsis_armcc.h
+++ b/CMSIS/Core_A/Include/cmsis_armcc.h
@@ -481,6 +481,8 @@ __STATIC_INLINE __ASM void __FPU_Enable(void)
 {
         ARM
 
+        PUSH    {R1-R3}
+
         //Permit access to VFP/NEON, registers by modifying CPACR
         MRC     p15,0,R1,c1,c0,2
         ORR     R1,R1,#0x00F00000
@@ -540,6 +542,8 @@ __STATIC_INLINE __ASM void __FPU_Enable(void)
         LDR     R3,=0x00086060 //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
         AND     R2,R2,R3
         VMSR    FPSCR,R2
+
+        POP     {R1-R3}
 
         BX      LR
 }

--- a/CMSIS/Core_A/Include/cmsis_armclang.h
+++ b/CMSIS/Core_A/Include/cmsis_armclang.h
@@ -519,6 +519,8 @@ __STATIC_FORCEINLINE void __set_FPEXC(uint32_t fpexc)
 __STATIC_INLINE void __FPU_Enable(void)
 {
   __ASM volatile(
+    "        PUSH    {R1-R3}           \n"
+
     //Permit access to VFP/NEON, registers by modifying CPACR
     "        MRC     p15,0,R1,c1,c0,2  \n"
     "        ORR     R1,R1,#0x00F00000 \n"
@@ -577,7 +579,9 @@ __STATIC_INLINE void __FPU_Enable(void)
     "        VMRS    R2,FPSCR          \n"
     "        LDR     R3,=0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
     "        AND     R2,R2,R3          \n"
-    "        VMSR    FPSCR,R2            "
+    "        VMSR    FPSCR,R2          \n"
+
+    "        POP     {R1-R3}             "
   );
 }
 

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -746,6 +746,8 @@ __STATIC_FORCEINLINE void __set_FPEXC(uint32_t fpexc)
 __STATIC_INLINE void __FPU_Enable(void)
 {
   __ASM volatile(
+    "        PUSH    {R1-R3}           \n"
+
     //Permit access to VFP/NEON, registers by modifying CPACR
     "        MRC     p15,0,R1,c1,c0,2  \n"
     "        ORR     R1,R1,#0x00F00000 \n"
@@ -804,7 +806,9 @@ __STATIC_INLINE void __FPU_Enable(void)
     "        VMRS    R2,FPSCR          \n"
     "        LDR     R3,=0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
     "        AND     R2,R2,R3          \n"
-    "        VMSR    FPSCR,R2            "
+    "        VMSR    FPSCR,R2          \n"
+
+    "        POP     {R1-R3}             "
   );
 }
 

--- a/CMSIS/Core_A/Include/cmsis_iccarm.h
+++ b/CMSIS/Core_A/Include/cmsis_iccarm.h
@@ -496,6 +496,8 @@ __STATIC_INLINE
 void __FPU_Enable(void)
 {
   __ASM volatile(
+    "        PUSH    {R1-R3}           \n"
+
     //Permit access to VFP/NEON, registers by modifying CPACR
     "        MRC     p15,0,R1,c1,c0,2  \n"
     "        ORR     R1,R1,#0x00F00000 \n"
@@ -554,7 +556,10 @@ void __FPU_Enable(void)
     "        VMRS    R2,FPSCR          \n"
     "        MOV32   R3,#0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
     "        AND     R2,R2,R3          \n"
-    "        VMSR    FPSCR,R2          \n");
+    "        VMSR    FPSCR,R2          \n"
+
+    "        POP     {R1-R3}             "
+   );
 }
 
 


### PR DESCRIPTION
Fixed the values of registers R1 to R3 may be destroyed when inline expansion.
The problem was confirmed when the optimization was set to "-Os" in ARMC6.
The ARMC5 __ASM function automatically adds register saving even when inline expansion, but explicitly adds push and pop to match the processing with other compilers.
