### PR TITLE
Newlib allocates stack size biger than 0x400 by default

### DIFF
--- a/Device/ARM/ARMCM0/Source/GCC/startup_ARMCM0.c
+++ b/Device/ARM/ARMCM0/Source/GCC/startup_ARMCM0.c
@@ -70,7 +70,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM0plus/Source/GCC/startup_ARMCM0plus.c
+++ b/Device/ARM/ARMCM0plus/Source/GCC/startup_ARMCM0plus.c
@@ -70,7 +70,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM1/Source/GCC/startup_ARMCM1.c
+++ b/Device/ARM/ARMCM1/Source/GCC/startup_ARMCM1.c
@@ -70,7 +70,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM23/Source/GCC/startup_ARMCM23.c
+++ b/Device/ARM/ARMCM23/Source/GCC/startup_ARMCM23.c
@@ -76,7 +76,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM3/Source/GCC/startup_ARMCM3.c
+++ b/Device/ARM/ARMCM3/Source/GCC/startup_ARMCM3.c
@@ -70,7 +70,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM33/Source/GCC/startup_ARMCM33.c
+++ b/Device/ARM/ARMCM33/Source/GCC/startup_ARMCM33.c
@@ -80,7 +80,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM35P/Source/GCC/startup_ARMCM35P.c
+++ b/Device/ARM/ARMCM35P/Source/GCC/startup_ARMCM35P.c
@@ -80,7 +80,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM4/Source/GCC/startup_ARMCM4.c
+++ b/Device/ARM/ARMCM4/Source/GCC/startup_ARMCM4.c
@@ -76,7 +76,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMCM7/Source/GCC/startup_ARMCM7.c
+++ b/Device/ARM/ARMCM7/Source/GCC/startup_ARMCM7.c
@@ -78,7 +78,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMSC000/Source/GCC/startup_ARMSC000.c
+++ b/Device/ARM/ARMSC000/Source/GCC/startup_ARMSC000.c
@@ -70,7 +70,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMSC300/Source/GCC/startup_ARMSC300.c
+++ b/Device/ARM/ARMSC300/Source/GCC/startup_ARMSC300.c
@@ -70,7 +70,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMv8MBL/Source/GCC/startup_ARMv8MBL.c
+++ b/Device/ARM/ARMv8MBL/Source/GCC/startup_ARMv8MBL.c
@@ -70,7 +70,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration

--- a/Device/ARM/ARMv8MML/Source/GCC/startup_ARMv8MML.c
+++ b/Device/ARM/ARMv8MML/Source/GCC/startup_ARMv8MML.c
@@ -84,7 +84,11 @@ void Reset_Handler  (void) __attribute__ ((noreturn));
 //<h> Stack Configuration
 //  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 //</h>
+#if defined (__NEWLIB__)
+#define  __STACK_SIZE  0x0001D000
+#else
 #define  __STACK_SIZE  0x00000400
+#endif
 static uint8_t stack[__STACK_SIZE] __attribute__ ((aligned(8), used, section(".stack")));
 
 //<h> Heap Configuration


### PR DESCRIPTION
Current Newlib crt0.S implementation assumes stack size more than 0x400
See https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=libgloss/arm/crt0.S;h=1deb73aa5f66982848f5a3808d5a94dbe01a81e0;hb=HEAD#l201