### PR TITLE
Nn/nonsquare 1d

### DIFF
--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -1178,6 +1178,33 @@ void arm_maxpool_q7_HWC_nonsquare(q7_t * Im_in,
                    q7_t * bufferA, 
                    q7_t * Im_out);
 
+static inline
+void      arm_maxpool_q7_HWC_1d(q7_t * Im_in,
+                             const uint16_t dim_im_in,
+                             const uint16_t ch_im_in,
+                             const uint16_t dim_kernel,
+                             const uint16_t padding,
+                             const uint16_t stride, 
+                             const uint16_t dim_im_out, 
+                             q7_t * bufferA, 
+                             q7_t * Im_out) {
+  arm_maxpool_q7_HWC_nonsquare(
+    Im_in,        //q7_t * Im_in,
+    dim_im_in,    //const uint16_t dim_im_in_x,
+    1,            //const uint16_t dim_im_in_y,
+    ch_im_in,     //const uint16_t ch_im_in,
+    dim_kernel,   //const uint16_t dim_kernel_x,
+    1,            //const uint16_t dim_kernel_y,
+    padding,      //const uint16_t padding_x,
+    0,            //const uint16_t padding_y,
+    stride,       //const uint16_t stride_x,
+    0,            //const uint16_t stride_y,
+    dim_im_out,   //const uint16_t dim_im_out_x,
+    1,            //const uint16_t dim_im_out_y,
+    bufferA,      //q7_t * bufferA, 
+    Im_out);      //q7_t * Im_out);
+}
+
   /**
    * @brief Q7 average pooling function
    * @param[in]       Im_in       pointer to input tensor
@@ -1236,6 +1263,33 @@ void arm_avepool_q7_HWC_nonsquare(q7_t * Im_in,
                    const uint16_t dim_im_out_y,
                    q7_t * bufferA, 
                    q7_t * Im_out);
+
+static inline
+void      arm_avepool_q7_HWC_1d(q7_t * Im_in,
+                             const uint16_t dim_im_in,
+                             const uint16_t ch_im_in,
+                             const uint16_t dim_kernel,
+                             const uint16_t padding,
+                             const uint16_t stride, 
+                             const uint16_t dim_im_out, 
+                             q7_t * bufferA, 
+                             q7_t * Im_out) {
+  arm_avepool_q7_HWC_nonsquare(
+    Im_in,        //q7_t * Im_in,
+    dim_im_in,    //const uint16_t dim_im_in_x,
+    1,            //const uint16_t dim_im_in_y,
+    ch_im_in,     //const uint16_t ch_im_in,
+    dim_kernel,   //const uint16_t dim_kernel_x,
+    1,            //const uint16_t dim_kernel_y,
+    padding,      //const uint16_t padding_x,
+    0,            //const uint16_t padding_y,
+    stride,       //const uint16_t stride_x,
+    0,            //const uint16_t stride_y,
+    dim_im_out,   //const uint16_t dim_im_out_x,
+    1,            //const uint16_t dim_im_out_y,
+    bufferA,      //q7_t * bufferA, 
+    Im_out);      //q7_t * Im_out);
+}
 
 
 /**

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -224,7 +224,7 @@ extern    "C"
    * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
    */
 
-static inline arm_status arm_convolve_HWC_q7_basic_nonsquare(
+static inline arm_status arm_convolve_HWC_q7_basic_1d(
   const q7_t * Im_in,
   const uint16_t dim_im_in,
   const uint16_t ch_im_in,
@@ -412,6 +412,12 @@ static inline arm_status arm_convolve_HWC_q7_basic_nonsquare(
    * @param[in,out]   bufferA      pointer to buffer space for input
    * @param[in,out]   bufferB      pointer to buffer space for output
    * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   *
+   * This function is the version with full list of optimization tricks, but with
+   * some contraints:
+   *   ch_im_in is multiple of 4
+   *   ch_im_out is multiple of 2
    */
 
 static inline arm_status arm_convolve_HWC_q7_fast_1d(
@@ -673,6 +679,22 @@ static inline arm_status arm_convolve_HWC_q7_fast_1d(
    * @param[in,out]   bufferA      pointer to buffer space for input
    * @param[in,out]   bufferB      pointer to buffer space for output
    * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   *
+   * @details
+   *
+   * <b>Buffer size:</b>
+   *
+   * bufferA size: 2*ch_im_in*dim_kernel_x*dim_kernel_y
+   *
+   * bufferB size: 0
+   *
+   * <b>Input dimension constraints:</b>
+   *
+   * ch_im_in is multiple of 2 
+   *
+   * ch_im_out is multipe of 2
+   *
    */
 static inline arm_status arm_convolve_HWC_q15_fast_1d(
   const q7_t * Im_in,

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -204,6 +204,26 @@ extern    "C"
                                                   q15_t * bufferA,
                                                   q7_t * bufferB);
 
+  /**
+   * @brief Basic Q7 convolution function (1D)
+   * @param[in]       Im_in        pointer to input tensor
+   * @param[in]       dim_im_in   input tensor dimention y
+   * @param[in]       ch_im_in     number of input tensor channels
+   * @param[in]       wt           pointer to kernel weights
+   * @param[in]       ch_im_out    number of filters, i.e., output tensor channels
+   * @param[in]       dim_kernel   filter kernel size y
+   * @param[in]       padding      padding size y
+   * @param[in]       stride.      convolution stride y
+   * @param[in]       bias         pointer to bias
+   * @param[in]       bias_shift   amount of left-shift for bias
+   * @param[in]       out_shift    amount of right-shift for output
+   * @param[in,out]   Im_out       pointer to output tensor
+   * @param[in]       dim_im_out.  output tensor dimension y
+   * @param[in,out]   bufferA      pointer to buffer space for input
+   * @param[in,out]   bufferB      pointer to buffer space for output
+   * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
+   */
+
 static inline arm_status arm_convolve_HWC_q7_basic_nonsquare(
   const q7_t * Im_in,
   const uint16_t dim_im_in,
@@ -373,6 +393,26 @@ static inline arm_status arm_convolve_HWC_q7_basic_nonsquare(
                                                   const uint16_t dim_im_out_y,
                                                   q15_t * bufferA,
                                                   q7_t * bufferB);
+
+  /**
+   * @brief Fast Q7 convolution function (1D)
+   * @param[in]       Im_in        pointer to input tensor
+   * @param[in]       dim_im_in   input tensor dimention y
+   * @param[in]       ch_im_in     number of input tensor channels
+   * @param[in]       wt           pointer to kernel weights
+   * @param[in]       ch_im_out    number of filters, i.e., output tensor channels
+   * @param[in]       dim_kernel   filter kernel size y
+   * @param[in]       padding      padding size y
+   * @param[in]       stride.      convolution stride y
+   * @param[in]       bias         pointer to bias
+   * @param[in]       bias_shift   amount of left-shift for bias
+   * @param[in]       out_shift    amount of right-shift for output
+   * @param[in,out]   Im_out       pointer to output tensor
+   * @param[in]       dim_im_out.  output tensor dimension y
+   * @param[in,out]   bufferA      pointer to buffer space for input
+   * @param[in,out]   bufferB      pointer to buffer space for output
+   * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
+   */
 
 static inline arm_status arm_convolve_HWC_q7_fast_1d(
   const q7_t * Im_in,
@@ -614,6 +654,26 @@ static inline arm_status arm_convolve_HWC_q7_fast_1d(
                               q15_t * bufferA, 
                               q7_t * bufferB);
 			
+
+  /**
+   * @brief Fast Q15 convolution function (1D)
+   * @param[in]       Im_in        pointer to input tensor
+   * @param[in]       dim_im_in   input tensor dimention y
+   * @param[in]       ch_im_in     number of input tensor channels
+   * @param[in]       wt           pointer to kernel weights
+   * @param[in]       ch_im_out    number of filters, i.e., output tensor channels
+   * @param[in]       dim_kernel   filter kernel size y
+   * @param[in]       padding      padding size y
+   * @param[in]       stride.      convolution stride y
+   * @param[in]       bias         pointer to bias
+   * @param[in]       bias_shift   amount of left-shift for bias
+   * @param[in]       out_shift    amount of right-shift for output
+   * @param[in,out]   Im_out       pointer to output tensor
+   * @param[in]       dim_im_out.  output tensor dimension y
+   * @param[in,out]   bufferA      pointer to buffer space for input
+   * @param[in,out]   bufferB      pointer to buffer space for output
+   * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
+   */
 static inline arm_status arm_convolve_HWC_q15_fast_1d(
   const q7_t * Im_in,
   const uint16_t dim_im_in,

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -1144,6 +1144,40 @@ extern    "C"
                                  q7_t * bufferA, 
                                  q7_t * Im_out);
 
+    /**
+   * @brief Q7 max pooling function
+   * @param[in, out]  Im_in         pointer to input tensor
+   * @param[in]       dim_im_in_x   input tensor dimention along X axis
+   * @param[in]       dim_im_in_y   input tensor dimention along Y axis
+   * @param[in]       ch_im_in      number of input tensor channels
+   * @param[in]       dim_kernel_x  filter kernel size along X axis
+   * @param[in]       dim_kernel_y  filter kernel size along Y axis
+   * @param[in]       padding_x     padding sizes along X axis
+   * @param[in]       padding_y     padding sizes along Y axis
+   * @param[in]       stride_x      convolution stride along X axis
+   * @param[in]       stride_y      convolution stride along Y axis
+   * @param[in]       dim_im_out_x  output tensor dimension along X axis
+   * @param[in]       dim_im_out_y  output tensor dimension along Y axis
+   * @param[in,out]   bufferA       pointer to buffer space for input
+   * @param[in,out]   Im_out        pointer to output tensor
+   * @return none.
+   */
+
+void arm_maxpool_q7_HWC_nonsquare(q7_t * Im_in,
+                   const uint16_t dim_im_in_x,
+                   const uint16_t dim_im_in_y,
+                   const uint16_t ch_im_in,
+                   const uint16_t dim_kernel_x,
+                   const uint16_t dim_kernel_y,
+                   const uint16_t padding_x,
+                   const uint16_t padding_y,
+                   const uint16_t stride_x,
+                   const uint16_t stride_y,
+                   const uint16_t dim_im_out_x,
+                   const uint16_t dim_im_out_y,
+                   q7_t * bufferA, 
+                   q7_t * Im_out);
+
   /**
    * @brief Q7 average pooling function
    * @param[in]       Im_in       pointer to input tensor
@@ -1168,6 +1202,41 @@ extern    "C"
                                  const uint16_t dim_im_out, 
                                  q7_t * bufferA, 
                                  q7_t * Im_out);
+
+  /**
+   * @brief Q7 average pooling function
+   * @param[in, out]  Im_in         pointer to input tensor
+   * @param[in]       dim_im_in_x   input tensor dimention along X axis
+   * @param[in]       dim_im_in_y   input tensor dimention along Y axis
+   * @param[in]       ch_im_in      number of input tensor channels
+   * @param[in]       dim_kernel_x  filter kernel size along X axis
+   * @param[in]       dim_kernel_y  filter kernel size along Y axis
+   * @param[in]       padding_x     padding sizes along X axis
+   * @param[in]       padding_y     padding sizes along Y axis
+   * @param[in]       stride_x      convolution stride along X axis
+   * @param[in]       stride_y      convolution stride along Y axis
+   * @param[in]       dim_im_out_x  output tensor dimension along X axis
+   * @param[in]       dim_im_out_y  output tensor dimension along Y axis
+   * @param[in,out]   bufferA       pointer to buffer space for input
+   * @param[in,out]   Im_out        pointer to output tensor
+   * @return none.
+   */
+
+void arm_avepool_q7_HWC_nonsquare(q7_t * Im_in,
+                   const uint16_t dim_im_in_x,
+                   const uint16_t dim_im_in_y,
+                   const uint16_t ch_im_in,
+                   const uint16_t dim_kernel_x,
+                   const uint16_t dim_kernel_y,
+                   const uint16_t padding_x,
+                   const uint16_t padding_y,
+                   const uint16_t stride_x,
+                   const uint16_t stride_y,
+                   const uint16_t dim_im_out_x,
+                   const uint16_t dim_im_out_y,
+                   q7_t * bufferA, 
+                   q7_t * Im_out);
+
 
 /**
  * @defgroup Softmax Softmax Functions

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -468,45 +468,6 @@ static inline arm_status arm_convolve_HWC_q7_fast_1d(
                                                       q15_t * bufferA,
                                                       q7_t * bufferB);
 
-static inline arm_status arm_convolve_1x1_HWC_q7_fast_1d(
-  const q7_t * Im_in,
-  const uint16_t dim_im_in,
-  const uint16_t ch_im_in,
-  const q7_t * wt,
-  const uint16_t ch_im_out,
-  const uint16_t dim_kernel,
-  const uint16_t padding,
-  const uint16_t stride,
-  const q7_t * bias,
-  const uint16_t bias_shift,
-  const uint16_t out_shift,
-  q7_t * Im_out,
-  const uint16_t dim_im_out,
-  q15_t * bufferA,
-  q7_t * bufferB ) {
-        return arm_convolve_1x1_HWC_q7_fast_nonsquare(
-          Im_in,      //const q7_t * Im_in
-          dim_im_in,  //const uint16_t dim_im_in_x,
-          1,          //const uint16_t dim_im_in_y,
-          ch_im_in,   //const uint16_t ch_im_in,
-          wt,         //const q7_t * wt,
-          ch_im_out,  //const uint16_t ch_im_out,
-          dim_kernel, //const uint16_t dim_kernel_x,
-          1,          //const uint16_t dim_kernel_y,
-          padding,    //const uint16_t padding_x,
-          1,          //const uint16_t padding_y,
-          stride,     //const uint16_t stride_x,
-          1,          //const uint16_t stride_y,
-          bias,       //const q7_t * bias,
-          bias_shift, //const uint16_t bias_shift,
-          out_shift,  //const uint16_t out_shift,
-          Im_out,     //q7_t * Im_out,
-          dim_im_out, //const uint16_t dim_im_out_x,
-          1,          //const uint16_t dim_im_out_y,
-          bufferA,    //q15_t * bufferA,
-          bufferB);   //q7_t * bufferB);
-}
-
   /**
    * @brief Q7 version of convolution for RGB image
    * @param[in]       Im_in       pointer to input tensor
@@ -619,7 +580,7 @@ static inline arm_status arm_convolve_1x1_HWC_q7_fast_1d(
    *
    * <b>Buffer size:</b>
    *
-   * bufferA size: 2*ch_im_in*dim_kernel*dim_kernel
+   * bufferA size: 2*ch_im_in*dim_kernel_x*dim_kernel_y
    *
    * bufferB size: 0
    *
@@ -786,45 +747,6 @@ static inline arm_status arm_convolve_HWC_q15_fast_1d(
                                                              q15_t * bufferA,
                                                              q7_t * bufferB);
 
-static inline arm_status arm_depthwise_separable_conv_HWC_q7_1d(
-  const q7_t * Im_in,
-  const uint16_t dim_im_in,
-  const uint16_t ch_im_in,
-  const q7_t * wt,
-  const uint16_t ch_im_out,
-  const uint16_t dim_kernel,
-  const uint16_t padding,
-  const uint16_t stride,
-  const q7_t * bias,
-  const uint16_t bias_shift,
-  const uint16_t out_shift,
-  q7_t * Im_out,
-  const uint16_t dim_im_out,
-  q15_t * bufferA,
-  q7_t * bufferB ) {
-        return arm_depthwise_separable_conv_HWC_q7_nonsquare(
-          Im_in,      //const q7_t * Im_in
-          dim_im_in,  //const uint16_t dim_im_in_x,
-          1,          //const uint16_t dim_im_in_y,
-          ch_im_in,   //const uint16_t ch_im_in,
-          wt,         //const q7_t * wt,
-          ch_im_out,  //const uint16_t ch_im_out,
-          dim_kernel, //const uint16_t dim_kernel_x,
-          1,          //const uint16_t dim_kernel_y,
-          padding,    //const uint16_t padding_x,
-          1,          //const uint16_t padding_y,
-          stride,     //const uint16_t stride_x,
-          1,          //const uint16_t stride_y,
-          bias,       //const q7_t * bias,
-          bias_shift, //const uint16_t bias_shift,
-          out_shift,  //const uint16_t out_shift,
-          Im_out,     //q7_t * Im_out,
-          dim_im_out, //const uint16_t dim_im_out_x,
-          1,          //const uint16_t dim_im_out_y,
-          bufferA,    //q15_t * bufferA,
-          bufferB);   //q7_t * bufferB);
-
-}
 /**
  * @defgroup FC Fully-connected Layer Functions
  *
@@ -1178,32 +1100,29 @@ void arm_maxpool_q7_HWC_nonsquare(q7_t * Im_in,
                    q7_t * bufferA, 
                    q7_t * Im_out);
 
-static inline
-void      arm_maxpool_q7_HWC_1d(q7_t * Im_in,
-                             const uint16_t dim_im_in,
-                             const uint16_t ch_im_in,
-                             const uint16_t dim_kernel,
-                             const uint16_t padding,
-                             const uint16_t stride, 
-                             const uint16_t dim_im_out, 
-                             q7_t * bufferA, 
-                             q7_t * Im_out) {
-  arm_maxpool_q7_HWC_nonsquare(
-    Im_in,        //q7_t * Im_in,
-    dim_im_in,    //const uint16_t dim_im_in_x,
-    1,            //const uint16_t dim_im_in_y,
-    ch_im_in,     //const uint16_t ch_im_in,
-    dim_kernel,   //const uint16_t dim_kernel_x,
-    1,            //const uint16_t dim_kernel_y,
-    padding,      //const uint16_t padding_x,
-    0,            //const uint16_t padding_y,
-    stride,       //const uint16_t stride_x,
-    0,            //const uint16_t stride_y,
-    dim_im_out,   //const uint16_t dim_im_out_x,
-    1,            //const uint16_t dim_im_out_y,
-    bufferA,      //q7_t * bufferA, 
-    Im_out);      //q7_t * Im_out);
-}
+  /**
+   * @brief Q7 1-D max pooling function
+   * @param[in, out]  Im_in       pointer to input tensor
+   * @param[in]       dim_im_in   input tensor dimention
+   * @param[in]       ch_im_in    number of input tensor channels
+   * @param[in]       dim_kernel  filter kernel size
+   * @param[in]       padding     padding sizes
+   * @param[in]       stride      convolution stride
+   * @param[in]       dim_im_out  output tensor dimension
+   * @param[in,out]   bufferA     pointer to buffer space for input
+   * @param[in,out]   Im_out      pointer to output tensor
+   * @return none.
+   */
+
+void arm_maxpool_q7_HWC_1d(const q7_t * Im_in, // input image
+                            const uint16_t dim_im_in,   // input image dimension
+                            const uint16_t ch_im_in,    // number of input image channels
+                            const uint16_t dim_kernel,  // window kernel size
+                            const uint16_t padding, // padding sizes
+                            const uint16_t stride,  // stride
+                            const uint16_t dim_im_out,  // output image dimension
+                            q7_t * bufferA, // a buffer for local storage
+                            q7_t * Im_out);
 
   /**
    * @brief Q7 average pooling function
@@ -1264,32 +1183,29 @@ void arm_avepool_q7_HWC_nonsquare(q7_t * Im_in,
                    q7_t * bufferA, 
                    q7_t * Im_out);
 
-static inline
-void      arm_avepool_q7_HWC_1d(q7_t * Im_in,
-                             const uint16_t dim_im_in,
-                             const uint16_t ch_im_in,
-                             const uint16_t dim_kernel,
-                             const uint16_t padding,
-                             const uint16_t stride, 
-                             const uint16_t dim_im_out, 
-                             q7_t * bufferA, 
-                             q7_t * Im_out) {
-  arm_avepool_q7_HWC_nonsquare(
-    Im_in,        //q7_t * Im_in,
-    dim_im_in,    //const uint16_t dim_im_in_x,
-    1,            //const uint16_t dim_im_in_y,
-    ch_im_in,     //const uint16_t ch_im_in,
-    dim_kernel,   //const uint16_t dim_kernel_x,
-    1,            //const uint16_t dim_kernel_y,
-    padding,      //const uint16_t padding_x,
-    0,            //const uint16_t padding_y,
-    stride,       //const uint16_t stride_x,
-    0,            //const uint16_t stride_y,
-    dim_im_out,   //const uint16_t dim_im_out_x,
-    1,            //const uint16_t dim_im_out_y,
-    bufferA,      //q7_t * bufferA, 
-    Im_out);      //q7_t * Im_out);
-}
+  /**
+   * @brief Q7 1-D max pooling function
+   * @param[in, out]  Im_in       pointer to input tensor
+   * @param[in]       dim_im_in   input tensor dimention
+   * @param[in]       ch_im_in    number of input tensor channels
+   * @param[in]       dim_kernel  filter kernel size
+   * @param[in]       padding     padding sizes
+   * @param[in]       stride      convolution stride
+   * @param[in]       dim_im_out  output tensor dimension
+   * @param[in,out]   bufferA     pointer to buffer space for input
+   * @param[in,out]   Im_out      pointer to output tensor
+   * @return none.
+   */
+
+void arm_avepool_q7_HWC_1d(const q7_t * Im_in, // input image
+                            const uint16_t dim_im_in,   // input image dimension
+                            const uint16_t ch_im_in,    // number of input image channels
+                            const uint16_t dim_kernel,  // window kernel size
+                            const uint16_t padding, // padding sizes
+                            const uint16_t stride,  // stride
+                            const uint16_t dim_im_out,  // output image dimension
+                            q7_t * bufferA, // a buffer for local storage
+                            q7_t * Im_out);
 
 
 /**

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -204,6 +204,45 @@ extern    "C"
                                                   q15_t * bufferA,
                                                   q7_t * bufferB);
 
+static inline arm_status arm_convolve_HWC_q7_basic_nonsquare(
+  const q7_t * Im_in,
+  const uint16_t dim_im_in,
+  const uint16_t ch_im_in,
+  const q7_t * wt,
+  const uint16_t ch_im_out,
+  const uint16_t dim_kernel,
+  const uint16_t padding,
+  const uint16_t stride,
+  const q7_t * bias,
+  const uint16_t bias_shift,
+  const uint16_t out_shift,
+  q7_t * Im_out,
+  const uint16_t dim_im_out,
+  q15_t * bufferA,
+  q7_t * bufferB ) {
+        return arm_convolve_HWC_q7_basic_nonsquare(
+          Im_in,      //const q7_t * Im_in
+          dim_im_in,  //const uint16_t dim_im_in_x,
+          1,          //const uint16_t dim_im_in_y,
+          ch_im_in,   //const uint16_t ch_im_in,
+          wt,         //const q7_t * wt,
+          ch_im_out,  //const uint16_t ch_im_out,
+          dim_kernel, //const uint16_t dim_kernel_x,
+          1,          //const uint16_t dim_kernel_y,
+          padding,    //const uint16_t padding_x,
+          1,          //const uint16_t padding_y,
+          stride,     //const uint16_t stride_x,
+          1,          //const uint16_t stride_y,
+          bias,       //const q7_t * bias,
+          bias_shift, //const uint16_t bias_shift,
+          out_shift,  //const uint16_t out_shift,
+          Im_out,     //q7_t * Im_out,
+          dim_im_out, //const uint16_t dim_im_out_x,
+          1,          //const uint16_t dim_im_out_y,
+          bufferA,    //q15_t * bufferA,
+          bufferB);   //q7_t * bufferB);
+}
+
   /**
    * @brief Basic Q15 convolution function
    * @param[in]       Im_in       pointer to input tensor
@@ -335,6 +374,45 @@ extern    "C"
                                                   q15_t * bufferA,
                                                   q7_t * bufferB);
 
+static inline arm_status arm_convolve_HWC_q7_fast_1d(
+  const q7_t * Im_in,
+  const uint16_t dim_im_in,
+  const uint16_t ch_im_in,
+  const q7_t * wt,
+  const uint16_t ch_im_out,
+  const uint16_t dim_kernel,
+  const uint16_t padding,
+  const uint16_t stride,
+  const q7_t * bias,
+  const uint16_t bias_shift,
+  const uint16_t out_shift,
+  q7_t * Im_out,
+  const uint16_t dim_im_out,
+  q15_t * bufferA,
+  q7_t * bufferB ) {
+        return arm_convolve_HWC_q7_fast_nonsquare(
+          Im_in,      //const q7_t * Im_in
+          dim_im_in,  //const uint16_t dim_im_in_x,
+          1,          //const uint16_t dim_im_in_y,
+          ch_im_in,   //const uint16_t ch_im_in,
+          wt,         //const q7_t * wt,
+          ch_im_out,  //const uint16_t ch_im_out,
+          dim_kernel, //const uint16_t dim_kernel_x,
+          1,          //const uint16_t dim_kernel_y,
+          padding,    //const uint16_t padding_x,
+          1,          //const uint16_t padding_y,
+          stride,     //const uint16_t stride_x,
+          1,          //const uint16_t stride_y,
+          bias,       //const q7_t * bias,
+          bias_shift, //const uint16_t bias_shift,
+          out_shift,  //const uint16_t out_shift,
+          Im_out,     //q7_t * Im_out,
+          dim_im_out, //const uint16_t dim_im_out_x,
+          1,          //const uint16_t dim_im_out_y,
+          bufferA,    //q15_t * bufferA,
+          bufferB);   //q7_t * bufferB);
+}
+
   /**
    * @brief Fast Q7 version of 1x1 convolution (non-sqaure shape)
    * @param[in]       Im_in        pointer to input tensor
@@ -389,6 +467,45 @@ extern    "C"
                                                       const uint16_t dim_im_out_y,
                                                       q15_t * bufferA,
                                                       q7_t * bufferB);
+
+static inline arm_status arm_convolve_1x1_HWC_q7_fast_1d(
+  const q7_t * Im_in,
+  const uint16_t dim_im_in,
+  const uint16_t ch_im_in,
+  const q7_t * wt,
+  const uint16_t ch_im_out,
+  const uint16_t dim_kernel,
+  const uint16_t padding,
+  const uint16_t stride,
+  const q7_t * bias,
+  const uint16_t bias_shift,
+  const uint16_t out_shift,
+  q7_t * Im_out,
+  const uint16_t dim_im_out,
+  q15_t * bufferA,
+  q7_t * bufferB ) {
+        return arm_convolve_1x1_HWC_q7_fast_nonsquare(
+          Im_in,      //const q7_t * Im_in
+          dim_im_in,  //const uint16_t dim_im_in_x,
+          1,          //const uint16_t dim_im_in_y,
+          ch_im_in,   //const uint16_t ch_im_in,
+          wt,         //const q7_t * wt,
+          ch_im_out,  //const uint16_t ch_im_out,
+          dim_kernel, //const uint16_t dim_kernel_x,
+          1,          //const uint16_t dim_kernel_y,
+          padding,    //const uint16_t padding_x,
+          1,          //const uint16_t padding_y,
+          stride,     //const uint16_t stride_x,
+          1,          //const uint16_t stride_y,
+          bias,       //const q7_t * bias,
+          bias_shift, //const uint16_t bias_shift,
+          out_shift,  //const uint16_t out_shift,
+          Im_out,     //q7_t * Im_out,
+          dim_im_out, //const uint16_t dim_im_out_x,
+          1,          //const uint16_t dim_im_out_y,
+          bufferA,    //q15_t * bufferA,
+          bufferB);   //q7_t * bufferB);
+}
 
   /**
    * @brief Q7 version of convolution for RGB image
@@ -535,7 +652,47 @@ extern    "C"
                               const uint16_t dim_im_out_y, 
                               q15_t * bufferA, 
                               q7_t * bufferB);
-										 
+			
+static inline arm_status arm_convolve_HWC_q15_fast_1d(
+  const q7_t * Im_in,
+  const uint16_t dim_im_in,
+  const uint16_t ch_im_in,
+  const q7_t * wt,
+  const uint16_t ch_im_out,
+  const uint16_t dim_kernel,
+  const uint16_t padding,
+  const uint16_t stride,
+  const q7_t * bias,
+  const uint16_t bias_shift,
+  const uint16_t out_shift,
+  q7_t * Im_out,
+  const uint16_t dim_im_out,
+  q15_t * bufferA,
+  q7_t * bufferB ) {
+        return arm_convolve_HWC_q15_fast_nonsquare(
+          Im_in,      //const q7_t * Im_in
+          dim_im_in,  //const uint16_t dim_im_in_x,
+          1,          //const uint16_t dim_im_in_y,
+          ch_im_in,   //const uint16_t ch_im_in,
+          wt,         //const q7_t * wt,
+          ch_im_out,  //const uint16_t ch_im_out,
+          dim_kernel, //const uint16_t dim_kernel_x,
+          1,          //const uint16_t dim_kernel_y,
+          padding,    //const uint16_t padding_x,
+          1,          //const uint16_t padding_y,
+          stride,     //const uint16_t stride_x,
+          1,          //const uint16_t stride_y,
+          bias,       //const q7_t * bias,
+          bias_shift, //const uint16_t bias_shift,
+          out_shift,  //const uint16_t out_shift,
+          Im_out,     //q7_t * Im_out,
+          dim_im_out, //const uint16_t dim_im_out_x,
+          1,          //const uint16_t dim_im_out_y,
+          bufferA,    //q15_t * bufferA,
+          bufferB);   //q7_t * bufferB);
+}
+
+
   /**
    * @brief Q7 depthwise separable convolution function
    * @param[in]       Im_in       pointer to input tensor
@@ -629,7 +786,45 @@ extern    "C"
                                                              q15_t * bufferA,
                                                              q7_t * bufferB);
 
+static inline arm_status arm_depthwise_separable_conv_HWC_q7_1d(
+  const q7_t * Im_in,
+  const uint16_t dim_im_in,
+  const uint16_t ch_im_in,
+  const q7_t * wt,
+  const uint16_t ch_im_out,
+  const uint16_t dim_kernel,
+  const uint16_t padding,
+  const uint16_t stride,
+  const q7_t * bias,
+  const uint16_t bias_shift,
+  const uint16_t out_shift,
+  q7_t * Im_out,
+  const uint16_t dim_im_out,
+  q15_t * bufferA,
+  q7_t * bufferB ) {
+        return arm_depthwise_separable_conv_HWC_q7_nonsquare(
+          Im_in,      //const q7_t * Im_in
+          dim_im_in,  //const uint16_t dim_im_in_x,
+          1,          //const uint16_t dim_im_in_y,
+          ch_im_in,   //const uint16_t ch_im_in,
+          wt,         //const q7_t * wt,
+          ch_im_out,  //const uint16_t ch_im_out,
+          dim_kernel, //const uint16_t dim_kernel_x,
+          1,          //const uint16_t dim_kernel_y,
+          padding,    //const uint16_t padding_x,
+          1,          //const uint16_t padding_y,
+          stride,     //const uint16_t stride_x,
+          1,          //const uint16_t stride_y,
+          bias,       //const q7_t * bias,
+          bias_shift, //const uint16_t bias_shift,
+          out_shift,  //const uint16_t out_shift,
+          Im_out,     //q7_t * Im_out,
+          dim_im_out, //const uint16_t dim_im_out_x,
+          1,          //const uint16_t dim_im_out_y,
+          bufferA,    //q15_t * bufferA,
+          bufferB);   //q7_t * bufferB);
 
+}
 /**
  * @defgroup FC Fully-connected Layer Functions
  *

--- a/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/arm_pool_ref.c
+++ b/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/arm_pool_ref.c
@@ -123,9 +123,11 @@ arm_avepool_q7_HWC_nonsquare_ref(q7_t * Im_in,
             {
                 int sum = 0;
                 int count = 0;
-                for (k_y = i_y * stride_y - padding_y; k_y < i_y * stride_y - padding_y + dim_kernel_y; k_y++)
+                int16_t y_start = i_y * stride_y - padding_y;
+                int16_t x_start = i_x * stride_x - padding_x;
+                for (k_y = y_start; k_y < y_start + dim_kernel_y; k_y++)
                 {
-                    for (k_x = i_x * stride_x - padding_x; k_x < i_x * stride_x - padding_x + dim_kernel_x; k_x++)
+                    for (k_x = x_start; k_x < x_start + dim_kernel_x; k_x++)
                     {
                         if (k_y >= 0 && k_x >= 0 && k_y < dim_im_in_y && k_x < dim_im_in_x)
                         {
@@ -168,9 +170,11 @@ arm_maxpool_q7_HWC_nonsquare_ref(q7_t * Im_in,
             for (i_x = 0; i_x < dim_im_out_x; i_x++)
             {
                 int       max = -129;
-                for (k_y = i_y * stride_y - padding_y; k_y < i_y * stride_y - padding_y + dim_kernel_y; k_y++)
+                int16_t y_start = i_y * stride_y - padding_y;
+                int16_t x_start = i_x * stride_x - padding_x;
+                for (k_y = y_start; k_y < y_start + dim_kernel_y; k_y++)
                 {
-                    for (k_x = i_x * stride_x - padding_x; k_x < i_x * stride_x - padding_x + dim_kernel_x; k_x++)
+                    for (k_x = x_start; k_x < x_start + dim_kernel_x; k_x++)
                     {
                         if (k_y >= 0 && k_x >= 0 && k_y < dim_im_in_y && k_x < dim_im_in_x)
                         {

--- a/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/arm_pool_ref.c
+++ b/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/arm_pool_ref.c
@@ -94,3 +94,95 @@ void arm_maxpool_q7_HWC_ref(const q7_t * Im_in, // input image
         }
     }
 }
+
+void
+arm_avepool_q7_HWC_nonsquare_ref(q7_t * Im_in,
+                   const uint16_t dim_im_in_x,
+                   const uint16_t dim_im_in_y,
+                   const uint16_t ch_im_in,
+                   const uint16_t dim_kernel_x,
+                   const uint16_t dim_kernel_y,
+                   const uint16_t padding_x,
+                   const uint16_t padding_y,
+                   const uint16_t stride_x,
+                   const uint16_t stride_y,
+                   const uint16_t dim_im_out_x,
+                   const uint16_t dim_im_out_y,
+                   q7_t * bufferA, 
+                   q7_t * Im_out) {
+    /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
+
+    int16_t   i_ch_in, i_x, i_y;
+    int16_t   k_x, k_y;
+
+    for (i_ch_in = 0; i_ch_in < ch_im_in; i_ch_in++)
+    {
+        for (i_y = 0; i_y < dim_im_out_y; i_y++)
+        {
+            for (i_x = 0; i_x < dim_im_out_x; i_x++)
+            {
+                int sum = 0;
+                int count = 0;
+                for (k_y = i_y * stride_y - padding_y; k_y < i_y * stride_y - padding_y + dim_kernel_y; k_y++)
+                {
+                    for (k_x = i_x * stride_x - padding_x; k_x < i_x * stride_x - padding_x + dim_kernel_x; k_x++)
+                    {
+                        if (k_y >= 0 && k_x >= 0 && k_y < dim_im_in_y && k_x < dim_im_in_x)
+                        {
+                            sum += Im_in[i_ch_in + ch_im_in * (k_x + k_y * dim_im_in_x)];
+                            count++
+                        }
+                    }
+                }
+                Im_out[i_ch_in + ch_im_in * (i_x + i_y * dim_im_out_x)] = sum/count;
+            }
+        }
+    }
+}
+
+
+void
+arm_maxpool_q7_HWC_nonsquare_ref(q7_t * Im_in,
+                   const uint16_t dim_im_in_x,
+                   const uint16_t dim_im_in_y,
+                   const uint16_t ch_im_in,
+                   const uint16_t dim_kernel_x,
+                   const uint16_t dim_kernel_y,
+                   const uint16_t padding_x,
+                   const uint16_t padding_y,
+                   const uint16_t stride_x,
+                   const uint16_t stride_y,
+                   const uint16_t dim_im_out_x,
+                   const uint16_t dim_im_out_y,
+                   q7_t * bufferA, 
+                   q7_t * Im_out) {
+   /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
+
+    int16_t   i_ch_in, i_x, i_y;
+    int16_t   k_x, k_y;
+
+    for (i_ch_in = 0; i_ch_in < ch_im_in; i_ch_in++)
+    {
+        for (i_y = 0; i_y < dim_im_out_y; i_y++)
+        {
+            for (i_x = 0; i_x < dim_im_out_x; i_x++)
+            {
+                int       max = -129;
+                for (k_y = i_y * stride_y - padding_y; k_y < i_y * stride_y - padding_y + dim_kernel_y; k_y++)
+                {
+                    for (k_x = i_x * stride_x - padding_x; k_x < i_x * stride_x - padding_x + dim_kernel_x; k_x++)
+                    {
+                        if (k_y >= 0 && k_x >= 0 && k_y < dim_im_in_y && k_x < dim_im_in_x)
+                        {
+                            if (Im_in[i_ch_in + ch_im_in * (k_x + k_y * dim_im_in_x)] > max)
+                            {
+                                max = Im_in[i_ch_in + ch_im_in * (k_x + k_y * dim_im_in_x)];
+                            }
+                        }
+                    }
+                }
+                Im_out[i_ch_in + ch_im_in * (i_x + i_y * dim_im_out_x)] = max;
+            }
+        }
+    }
+}

--- a/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/arm_pool_ref.c
+++ b/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/arm_pool_ref.c
@@ -110,8 +110,6 @@ arm_avepool_q7_HWC_nonsquare_ref(q7_t * Im_in,
                    const uint16_t dim_im_out_y,
                    q7_t * bufferA, 
                    q7_t * Im_out) {
-    /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-
     int16_t   i_ch_in, i_x, i_y;
     int16_t   k_x, k_y;
 
@@ -158,8 +156,6 @@ arm_maxpool_q7_HWC_nonsquare_ref(q7_t * Im_in,
                    const uint16_t dim_im_out_y,
                    q7_t * bufferA, 
                    q7_t * Im_out) {
-   /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-
     int16_t   i_ch_in, i_x, i_y;
     int16_t   k_x, k_y;
 
@@ -187,6 +183,74 @@ arm_maxpool_q7_HWC_nonsquare_ref(q7_t * Im_in,
                 }
                 Im_out[i_ch_in + ch_im_in * (i_x + i_y * dim_im_out_x)] = max;
             }
+        }
+    }
+}
+
+
+void
+arm_avepool_q7_HWC_1d_ref(const q7_t * Im_in, // input image
+                            const uint16_t dim_im_in,   // input image dimension
+                            const uint16_t ch_im_in,    // number of input image channels
+                            const uint16_t dim_kernel,  // window kernel size
+                            const uint16_t padding, // padding sizes
+                            const uint16_t stride,  // stride
+                            const uint16_t dim_im_out,  // output image dimension
+                            q7_t * bufferA, // a buffer for local storage
+                            q7_t * Im_out) {
+    int16_t   i_ch_in, i;
+    int16_t   k;
+
+    for (i_ch_in = 0; i_ch_in < ch_im_in; i_ch_in++)
+    {
+        for (i = 0; i < dim_im_out; i++)
+        {
+            int sum = 0;
+            int count = 0;
+            int16_t start = i * stride - padding;
+            for (k = start; k < start + dim_kernel; k++)
+            {
+                if (k >= 0 && k < dim_im_in)
+                {
+                    sum += Im_in[i_ch_in + ch_im_in * k];
+                    count++;
+                }
+            }
+            Im_out[i_ch_in + ch_im_in * i] = sum/count;
+        }
+    }
+}
+
+void
+arm_maxpool_q7_HWC_1d_ref(const q7_t * Im_in, // input image
+                            const uint16_t dim_im_in,   // input image dimension
+                            const uint16_t ch_im_in,    // number of input image channels
+                            const uint16_t dim_kernel,  // window kernel size
+                            const uint16_t padding, // padding sizes
+                            const uint16_t stride,  // stride
+                            const uint16_t dim_im_out,  // output image dimension
+                            q7_t * bufferA, // a buffer for local storage
+                            q7_t * Im_out) {
+    int16_t   i_ch_in, i;
+    int16_t   k;
+
+    for (i_ch_in = 0; i_ch_in < ch_im_in; i_ch_in++)
+    {
+        for (i = 0; i < dim_im_out; i++)
+        {
+            int       max = -129;
+            int16_t start = i * stride - padding;
+            for (k = start; k < start + dim_kernel; k++)
+            {
+                if (k >= 0 && k < dim_im_in)
+                {
+                    if (Im_in[i_ch_in + ch_im_in * k] > max)
+                    {
+                        max = Im_in[i_ch_in + ch_im_in * k];
+                    }
+                }
+            }
+            Im_out[i_ch_in + ch_im_in * i] = max;
         }
     }
 }

--- a/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/ref_functions.h
+++ b/CMSIS/NN/NN_Lib_Tests/nn_test/Ref_Implementations/ref_functions.h
@@ -229,6 +229,39 @@ extern    "C"
                                      q7_t * bufferA,    // a buffer for local storage
                                      q7_t * Im_out);
 
+    void
+arm_maxpool_q7_HWC_nonsquare_ref(q7_t * Im_in,
+                   const uint16_t dim_im_in_x,
+                   const uint16_t dim_im_in_y,
+                   const uint16_t ch_im_in,
+                   const uint16_t dim_kernel_x,
+                   const uint16_t dim_kernel_y,
+                   const uint16_t padding_x,
+                   const uint16_t padding_y,
+                   const uint16_t stride_x,
+                   const uint16_t stride_y,
+                   const uint16_t dim_im_out_x,
+                   const uint16_t dim_im_out_y,
+                   q7_t * bufferA, 
+                   q7_t * Im_out);
+
+
+    void
+arm_avepool_q7_HWC_nonsquare_ref(q7_t * Im_in,
+                   const uint16_t dim_im_in_x,
+                   const uint16_t dim_im_in_y,
+                   const uint16_t ch_im_in,
+                   const uint16_t dim_kernel_x,
+                   const uint16_t dim_kernel_y,
+                   const uint16_t padding_x,
+                   const uint16_t padding_y,
+                   const uint16_t stride_x,
+                   const uint16_t stride_y,
+                   const uint16_t dim_im_out_x,
+                   const uint16_t dim_im_out_y,
+                   q7_t * bufferA, 
+                   q7_t * Im_out);
+
 /*
  *
  * Other reference implemenation

--- a/CMSIS/NN/NN_Lib_Tests/nn_test/arm_nnexamples_nn_test.cpp
+++ b/CMSIS/NN/NN_Lib_Tests/nn_test/arm_nnexamples_nn_test.cpp
@@ -38,15 +38,16 @@
 
 #include "arm_nnexamples_nn_test.h"
 
-//#define TEST_SIGMOID
-//#define TEST_TANH
+#define TEST_SIGMOID
+#define TEST_TANH
 #define TEST_POOL
 #define TEST_POOL_NS
-// #define TEST_RELU
-// #define TEST_IP
-// #define TEST_CONV
-// #define TEST_NONSQUARE
-// #define TEST_NNMULT
+#define TEST_POOL_1D
+#define TEST_RELU
+#define TEST_IP
+#define TEST_CONV
+#define TEST_NONSQUARE
+#define TEST_NNMULT
 
 int test_index = 0;
 q7_t test_flags[50];
@@ -295,76 +296,77 @@ int main()
 
 #ifdef TEST_POOL_NS
 
-#define POOL_NS_IM_DIM 64
+#define POOL_NS_IM_DIM1 64
+#define POOL_NS_IM_DIM2 16
 #define POOL_NS_IM_CH 4
 
-    test1 = new q7_t[POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH * 2];
-    test2 = new q15_t[POOL_NS_IM_DIM * POOL_NS_IM_CH];
-    test3 = new q7_t[POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH];
+    test1 = new q7_t[POOL_NS_IM_DIM1 * POOL_NS_IM_DIM2 * POOL_NS_IM_CH * 2];
+    test2 = new q15_t[(POOL_NS_IM_DIM1 + POOL_NS_IM_DIM2) * POOL_NS_IM_CH];
+    test3 = new q7_t[POOL_NS_IM_DIM1 * POOL_NS_IM_DIM2 * POOL_NS_IM_CH];
 
-    for (int i = 0; i < POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH; i++)
+    for (int i = 0; i < POOL_NS_IM_DIM1 * POOL_NS_IM_DIM2 * POOL_NS_IM_CH; i++)
     {
         test1[i] = (rand() % 256 - 128);
     }
 
-    q7_t     *img_in = test1 + POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH;
+    q7_t     *img_in = test1 + POOL_NS_IM_DIM1 * POOL_NS_IM_DIM2 * POOL_NS_IM_CH;
     q7_t     *pool_out_ref = test3;
-    q7_t     *pool_out_opt = test3 + POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH / 2;
+    q7_t     *pool_out_opt = test3 + POOL_NS_IM_DIM1 * POOL_NS_IM_DIM2 * POOL_NS_IM_CH / 2;
 
-    for (int i = 0; i < POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH; i++)
+    for (int i = 0; i < POOL_NS_IM_DIM1 * POOL_NS_IM_DIM2 * POOL_NS_IM_CH; i++)
     {
         test3[i] = 0;
     }
 
     // copy over the img input
-    for (int i = 0; i < POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH; i++)
+    for (int i = 0; i < POOL_NS_IM_DIM1 * POOL_NS_IM_DIM2 * POOL_NS_IM_CH; i++)
     {
         img_in[i] = test1[i];
     }
 
-    initialize_results_q7(pool_out_ref, pool_out_opt, POOL_NS_IM_DIM / 2 * 1 * POOL_NS_IM_CH);
+    initialize_results_q7(pool_out_ref, pool_out_opt, (POOL_NS_IM_DIM1 / 2) * (POOL_NS_IM_DIM2 / 2) * POOL_NS_IM_CH);
 
     printf("Start maxpool reference implementation\n");
 
-    arm_maxpool_q7_HWC_nonsquare_ref(img_in, POOL_NS_IM_DIM, 1, POOL_NS_IM_CH, 3, 0, 0, 0, 2, 0, POOL_NS_IM_DIM / 2, 1, (q7_t *) test2, pool_out_ref)
+    arm_maxpool_q7_HWC_nonsquare_ref(img_in, POOL_NS_IM_DIM1, POOL_NS_IM_DIM2, POOL_NS_IM_CH, 3, 2, 0, 0, 2, 2, POOL_NS_IM_DIM1 / 2, POOL_NS_IM_DIM2 / 2, (q7_t *) test2, pool_out_ref)
 
     // copy over the img input
-    for (int i = 0; i < POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH; i++)
+    for (int i = 0; i < POOL_NS_IM_DIM1 * 1 * POOL_NS_IM_CH; i++)
     {
         img_in[i] = test1[i];
     }
 
     printf("Start maxpool opt implementation\n");
 
-    arm_maxpool_q7_HWC_nonsquare(img_in, POOL_NS_IM_DIM, 1, POOL_NS_IM_CH, 3, 0, 0, 0, 2, 0, POOL_NS_IM_DIM / 2, 1, (q7_t *) test2, pool_out_opt)
+    arm_maxpool_q7_HWC_nonsquare(img_in, POOL_NS_IM_DIM1, 1, POOL_NS_IM_CH, 3, 2, 0, 0, 2, 2, POOL_NS_IM_DIM1 / 2, POOL_NS_IM_DIM2 / 2, (q7_t *) test2, pool_out_opt)
 
-    verify_results_q7(pool_out_ref, pool_out_opt, POOL_NS_IM_DIM / 2 * 1 * POOL_NS_IM_CH);
+    verify_results_q7(pool_out_ref, pool_out_opt, (POOL_NS_IM_DIM1 / 2) * (POOL_NS_IM_DIM2 / 2) * POOL_NS_IM_CH);
 
     // copy over the img input
-    for (int i = 0; i < POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH; i++)
+    for (int i = 0; i < POOL_NS_IM_DIM1 * 1 * POOL_NS_IM_CH; i++)
     {
         img_in[i] = test1[i];
     }
 
-    initialize_results_q7(pool_out_ref, pool_out_opt, POOL_NS_IM_DIM / 2 * 1 * POOL_NS_IM_CH);
+    initialize_results_q7(pool_out_ref, pool_out_opt, (POOL_NS_IM_DIM1/2) * (POOL_NS_IM_DIM2/2) * POOL_NS_IM_CH);
 
     printf("Start maxpool reference implementation\n");
 
-    arm_avepool_q7_HWC_nonsquare_ref(img_in, POOL_NS_IM_DIM, 1, POOL_NS_IM_CH, 3, 0, 0, 0, 2, 0, POOL_NS_IM_DIM / 2, 1, (q7_t *) test2, pool_out_ref)
+    arm_avepool_q7_HWC_nonsquare_ref(img_in, POOL_NS_IM_DIM1, POOL_NS_IM_DIM2, POOL_NS_IM_CH, 3, 2, 0, 0, 2, 2, POOL_NS_IM_DIM1 / 2, POOL_NS_IM_DIM2 / 2, (q7_t *) test2, pool_out_ref)
 
     // copy over the img input
-    for (int i = 0; i < POOL_NS_IM_DIM * 1 * POOL_NS_IM_CH; i++)
+    for (int i = 0; i < POOL_NS_IM_DIM1 * 1 * POOL_NS_IM_CH; i++)
     {
         img_in[i] = test1[i];
     }
 
     printf("Start maxpool opt implementation\n");
 
-    arm_avepool_q7_HWC_nonsquare(img_in, POOL_NS_IM_DIM, 1, POOL_NS_IM_CH, 3, 0, 0, 0, 2, 0, POOL_NS_IM_DIM / 2, 1, (q7_t *) test2, pool_out_opt)
+    arm_avepool_q7_HWC_nonsquare(img_in, POOL_NS_IM_DIM1, POOL_NS_IM_DIM2, POOL_NS_IM_CH, 3, 2, 0, 0, 2, 2, POOL_NS_IM_DIM1 / 2, POOL_NS_IM_DIM2 / 2, (q7_t *) test2, pool_out_opt)
 
     // special check here
     bool      if_ave_pool_match = true;
-    for (int i = 0; i < POOL_NS_IM_DIM / 2 * 1 * POOL_NS_IM_CH; i++)
+    for (int i = 0; i < (POOL_NS_IM_DIM1 / 2) * (POOL_NS_IM_DIM2 / 2) * POOL_NS_IM_CH; i++)
     {
         // we tolerate at most difference of 1 here because of rounding errors
         if (pool_out_ref[i] - pool_out_opt[i] >= 2 || pool_out_opt[i] - pool_out_ref[i] >= 2)
@@ -382,11 +384,97 @@ int main()
     delete[]test2;
     delete[]test3;
 
-
-
-
 #endif//TEST_POOL_NS
 
+
+#ifdef TEST_POOL_1D
+
+#define POOL_IM_DIM_1D 32
+#define POOL_IM_CH_1D 8
+
+    test1 = new q7_t[POOL_IM_DIM_1D * POOL_IM_CH_1D * 2];
+    test2 = new q15_t[POOL_IM_CH_1D];
+    test3 = new q7_t[POOL_IM_DIM_1D * POOL_IM_CH_1D];
+
+    for (int i = 0; i < POOL_IM_DIM_1D * POOL_IM_CH_1D; i++)
+    {
+        test1[i] = (rand() % 256 - 128);
+    }
+
+    q7_t     *img_in = test1 + POOL_IM_DIM_1D * POOL_IM_CH_1D;
+    q7_t     *pool_out_ref = test3;
+    q7_t     *pool_out_opt = test3 + POOL_IM_DIM_1D * POOL_IM_CH_1D / 2;
+
+    for (int i = 0; i < POOL_IM_DIM_1D * POOL_IM_CH_1D; i++)
+    {
+        test3[i] = 0;
+    }
+
+    // copy over the img input
+    for (int i = 0; i < POOL_IM_DIM_1D * POOL_IM_CH_1D; i++)
+    {
+        img_in[i] = test1[i];
+    }
+
+    initialize_results_q7(pool_out_ref, pool_out_opt, POOL_IM_DIM_1D / 2 * POOL_IM_CH_1D);
+
+    printf("Start maxpool reference implementation\n");
+
+    arm_maxpool_q7_HWC_1d_ref(img_in, POOL_IM_DIM_1D, POOL_IM_CH_1D, 3, 0, 2, POOL_IM_DIM_1D / 2, (q7_t *) test2, pool_out_ref);
+
+    // copy over the img input
+    for (int i = 0; i < POOL_IM_DIM_1D * POOL_IM_CH_1D; i++)
+    {
+        img_in[i] = test1[i];
+    }
+
+    printf("Start maxpool opt implementation\n");
+
+    arm_maxpool_q7_HWC_1d(img_in, POOL_IM_DIM_1D, POOL_IM_CH_1D, 3, 0, 2, POOL_IM_DIM_1D / 2, (q7_t *) test2, pool_out_opt);
+
+    verify_results_q7(pool_out_ref, pool_out_opt, POOL_IM_DIM_1D / 2 * POOL_IM_CH_1D);
+
+    // copy over the img input
+    for (int i = 0; i < POOL_IM_DIM_1D * POOL_IM_CH_1D; i++)
+    {
+        img_in[i] = test1[i];
+    }
+
+    printf("Start avepool ref implementation\n");
+
+    arm_avepool_q7_HWC_1d_ref(img_in, POOL_IM_DIM_1D, POOL_IM_CH_1D, 3, 0, 2, POOL_IM_DIM_1D / 2, (q7_t *) test2, pool_out_ref);
+
+    // copy over the img input
+    for (int i = 0; i < POOL_IM_DIM_1D * POOL_IM_CH_1D; i++)
+    {
+        img_in[i] = test1[i];
+    }
+
+    printf("Start avepool opt implementation\n");
+
+    arm_avepool_q7_HWC_1d(img_in, POOL_IM_DIM_1D, POOL_IM_CH_1D, 3, 0, 2, POOL_IM_DIM_1D / 2, (q7_t *) test2, pool_out_opt);
+
+    // special check here
+    bool      if_ave_pool_match = true;
+    for (int i = 0; i < POOL_IM_DIM_1D / 2 * POOL_IM_CH_1D; i++)
+    {
+        // we tolerate at most difference of 1 here because of rounding errors
+        if (pool_out_ref[i] - pool_out_opt[i] >= 2 || pool_out_opt[i] - pool_out_ref[i] >= 2)
+        {
+            printf("Output mismatch at %d, expected %d, actual %d\n", i, pool_out_ref[i], pool_out_opt[i]);
+            if_ave_pool_match = false;
+        }
+    }
+    if (if_ave_pool_match == true)
+    {
+        printf("Outputs match.\n");
+    }
+
+    delete[]test1;
+    delete[]test2;
+    delete[]test3;
+
+#endif//TEST_POOL_1D
 
 #ifdef TEST_RELU
 


### PR DESCRIPTION
Proposed four reference functions for non-square and 1D pooling (Max and Ave). It doesn't make a bunch of sense to have non-square CNNS but not non-square pooling as referenced in issue 455 ( #455) Also added the 1D convolution because it can be done slightly faster by separating it into its own function. I also added 1D wrappers around the non-square CNN functions to allow simplified code for 1D CNNs to work with the 1D pooling. This would make issue 541 simpler. ( #541 ) I didn't seperate the CNN's into their own functions because there was not an obvious potential to save OPs
Note I did add test to the test code but I don't have Keil so I haven't tested my implementations so there are probably bugs in the shapes of the Non-Square functions
