### PR TITLE
Fix Doxygen warning

### DIFF
--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c
@@ -232,4 +232,8 @@ arm_status arm_depthwise_conv_u8_basic_ver1(const uint8_t *input,
     return status;
 }
 
+/**
+ * @} end of NNConv group
+ */
+
 


### PR DESCRIPTION
In arm_depthwise_conv_u8_basic_ver1.c added end of
group(Doxygen) for file.