### PR TITLE
CMSIS-NN: Add function for q7 to q15 conversion with offset

### DIFF
--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -21,7 +21,7 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        13. July 2018
+ * $Date:        July 2019
  * $Revision:    V.1.0.0
  *
  * Target Processor:  Cortex-M cores
@@ -104,7 +104,7 @@ void      arm_q7_to_q15_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t block
  *  sum = input[0] + input[1] + .. + input[block_size -1]
  * </pre>
  *
- */
+ * */
 void arm_nn_add_q7(const q7_t *input, q31_t *output, uint32_t block_size);
 
 /**
@@ -115,8 +115,26 @@ void arm_nn_add_q7(const q7_t *input, q31_t *output, uint32_t block_size);
  * @return none.
  *
  */
-
 void      arm_q7_to_q15_reordered_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t blockSize);
+
+/**
+ * @brief Converts the elements from a q7 vector to a q15 vector with an added offset
+ * @param[in]    *src       points to the q7 input vector
+ * @param[out]   *dst       points to the q15 output vector
+ * @param[in]    block_size length of the input vector
+ * @param[in]    offset     q7 offset to be added to each input vector element.
+ * @return none.
+ *
+ * \par Description:
+ *
+ * The equation used for the conversion process is:
+ *
+ * <pre>
+ *  dst[n] = (q15_t) src[n] + offset;   0 <= n < block_size.
+ * </pre>
+ *
+ */
+void arm_q7_to_q15_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q7_t offset);
 
 #if defined (ARM_MATH_DSP)
 

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c
@@ -30,81 +30,71 @@
 
 #include "arm_nnsupportfunctions.h"
 
-/**    
- * @ingroup groupSupport    
+/**
+ * @ingroup groupSupport
  */
 
-/**    
- * @addtogroup nndata_convert    
- * @{    
+/**
+ * @addtogroup nndata_convert
+ * @{
  */
 
-/**    
- * @brief Converts the elements of the Q7 vector to Q15 vector without left-shift 
- * @param[in]       *pSrc points to the Q7 input vector    
- * @param[out]      *pDst points to the Q15 output vector   
- * @param[in]       blockSize length of the input vector    
- * @return none.    
- *    
- * \par Description:    
- *    
- * The equation used for the conversion process is:    
- *   
- * <pre>    
- * 	pDst[n] = (q15_t) pSrc[n];   0 <= n < blockSize.    
- * </pre>    
- *   
+/**
+ * @brief Converts the elements of the Q7 vector to Q15 vector without left-shift
+ * @param[in]       *pSrc points to the Q7 input vector
+ * @param[out]      *pDst points to the Q15 output vector
+ * @param[in]       blockSize length of the input vector
+ * @return none.
+ *
+ * \par Description:
+ *
+ * The equation used for the conversion process is:
+ *
+ * <pre>
+ * 	pDst[n] = (q15_t) pSrc[n];   0 <= n < blockSize.
+ * </pre>
+ *
  */
 
 void arm_q7_to_q15_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t blockSize)
 {
-    const q7_t *pIn = pSrc;     /* Src pointer */
-    uint32_t  blkCnt;           /* loop counter */
+    const q7_t *pIn = pSrc;
+    uint32_t  blkCnt;
 
-#ifndef ARM_MATH_CM0_FAMILY
+#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
     q31_t     in;
     q31_t     in1, in2;
     q31_t     out1, out2;
 
-    /* Run the below code for Cortex-M4 and Cortex-M3 */
-
     /*loop Unrolling */
     blkCnt = blockSize >> 2u;
 
-    /* First part of the processing with loop unrolling.  Compute 4 outputs at a time.    
-     ** a second loop below computes the remaining 1 to 3 samples. */
+    /* First part of the processing with loop unrolling.  Compute 4 outputs at a time. */
     while (blkCnt > 0u)
     {
-        /* C = (q15_t) A << 8 */
-        /* convert from q7 to q15 and then store the results in the destination buffer */
-        in = *__SIMD32(pIn)++;
+        in = arm_nn_read_q7x4_ia(&pIn);
 
         /* rotatate in by 8 and extend two q7_t values to q15_t values */
         in1 = __SXTB16(__ROR(in, 8));
 
-        /* extend remainig two q7_t values to q15_t values */
+        /* extend remaining two q7_t values to q15_t values */
         in2 = __SXTB16(in);
 
 #ifndef ARM_MATH_BIG_ENDIAN
-
         out2 = __PKHTB(in1, in2, 16);
         out1 = __PKHBT(in2, in1, 16);
-
 #else
-
         out1 = __PKHTB(in1, in2, 16);
         out2 = __PKHBT(in2, in1, 16);
-
 #endif
-
-        *__SIMD32(pDst)++ = out1;
-        *__SIMD32(pDst)++ = out2;
+        write_q15x2_ia(&pDst, out1);
+        write_q15x2_ia(&pDst, out2);
 
         /* Decrement the loop counter */
         blkCnt--;
     }
 
-    /* If the blockSize is not a multiple of 4, compute any remaining output samples here.    
+    /* If the blockSize is not a multiple of 4, compute any remaining output samples here.
      ** No loop unrolling is used. */
     blkCnt = blockSize % 0x4u;
 
@@ -119,9 +109,8 @@ void arm_q7_to_q15_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t blockSize)
 
     while (blkCnt > 0u)
     {
-        /* C = (q15_t) A << 8 */
         /* convert from q7 to q15 and then store the results in the destination buffer */
-        *pDst++ = (q15_t) * pIn++;
+        *pDst++ = (q15_t)*pIn++;
 
         /* Decrement the loop counter */
         blkCnt--;
@@ -129,6 +118,6 @@ void arm_q7_to_q15_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t blockSize)
 
 }
 
-/**    
- * @} end of nndata_convert group   
+/**
+ * @} end of nndata_convert group
  */

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2010-2018 Arm Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in_q7x4 compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in_q7x4 writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_q7_to_q15_with_offset.c
+ * Description:  Converts the elements of the Q7 vector to Q15 vector with an added offset
+ *
+ * $Date:        July 2019
+ * $Revision:    V.1.0.0
+ *
+ * Target Processor:  Cortex-M cores
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnsupportfunctions.h"
+
+/**
+ * @ingroup groupSupport
+ */
+
+/**
+ * @addtogroup nndata_convert
+ * @{
+ */
+
+void arm_q7_to_q15_with_offset(const q7_t *src,
+                               q15_t *dst,
+                               uint32_t block_size,
+                               q7_t offset)
+{
+    uint32_t  block_cnt;
+
+#if defined(ARM_MATH_LOOPUNROLL) && defined (ARM_MATH_DSP)
+    /* Run the below code for cores that support SIMD instructions  */
+    q31_t in_q7x4;
+    q31_t in_q15x2_1;
+    q31_t in_q15x2_2;
+    q31_t out_q15x2_1;
+    q31_t out_q15x2_2;
+
+    /*loop unrolling */
+    block_cnt = block_size >> 2u;
+
+    /* First part of the processing with loop unrolling.  Compute 4 outputs at a time. */
+    while (block_cnt > 0u)
+    {
+        /* convert from q7 to q15 and then store the results in the destination buffer */
+        in_q7x4 = arm_nn_read_q7x4_ia(&src);
+        q31_t offset_q15x2 = (offset << 16l) | offset;
+
+        /* Extract and sign extend each of the four q7 values to q15 */
+        in_q15x2_1 = __SXTB16(__ROR(in_q7x4, 8));
+        in_q15x2_2 = __SXTB16(in_q7x4);
+
+        out_q15x2_2 = __PKHTB(in_q15x2_1, in_q15x2_2, 16);
+        /* Maximum of 9 bits from the addition is expected */
+        out_q15x2_2 = __SADD16(out_q15x2_2, offset_q15x2);
+
+        out_q15x2_1 = __PKHBT(in_q15x2_2, in_q15x2_1, 16);
+        out_q15x2_1 = __SADD16(out_q15x2_1, offset_q15x2);
+
+        write_q15x2_ia(&dst, out_q15x2_1);
+        write_q15x2_ia(&dst, out_q15x2_2);
+
+        block_cnt--;
+    }
+    /* Handle left over samples */
+    block_cnt = block_size % 0x4u;
+
+#else
+    /* Run the below code for Cortex-M0 */
+    /* Loop over block_size number of values */
+    block_cnt = block_size;
+#endif
+
+    while (block_cnt > 0u)
+    {
+        *dst++ = (q15_t)*src++ + offset;
+
+        /* Decrement the loop counter */
+        block_cnt--;
+    }
+}
+
+/**
+ * @} end of nndata_convert group
+ */


### PR DESCRIPTION
1. Added function arm_q7_to_q15_with_offset.c

2. Replaced __SIMD32 macros in arm_q7_to_q15_no_shift.c
   as an improvement.