### PR TITLE
parentheses in macros

### DIFF
--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -43,8 +43,8 @@ extern    "C"
 #define Q31_MIN (0x80000000L)
 #define Q31_MAX (0x7FFFFFFFL)
 
-#define MAX(A,B) (A) > (B) ? (A) : (B)
-#define MIN(A,B) (A) < (B) ? (A) : (B)
+#define MAX(A,B) ((A) > (B) ? (A) : (B))
+#define MIN(A,B) ((A) < (B) ? (A) : (B))
 
 /**
  * @brief Union for SIMD access of q31/q15/q7 types


### PR DESCRIPTION
Using parentheses in macros is a good way to avoid problems.