### PR TITLE
CMSIS-NN : Move out 'if' checks from inner loop of depthwise conv

### DIFF
--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -711,14 +711,14 @@ extern    "C"
    * @param[in]       output_activation_max   Minimum value to clamp the output to. Range: int8
    * @param[in]       dilation_x   dilation along x. Not used. Dilation factor of 1 is used.
    * @param[in]       dilation_y   dilation along y. Not used. Dilation factor of 1 is used.
-   * @param[in]       buffer_a     pointer to buffer space used for optimization. Size information will be updated along
-   *                               with the optimized version.
+   * @param[in]       buffer_a     Not used.
+   *
    * @return     The function returns <code>ARM_MATH_SUCCESS</code>
    *
    * @details
    *    1. Supported framework: TensorFlow Lite
    *    2. q7 is used as data type eventhough it is s8 data. It is done so to be consistent with existing APIs.
-   *    3. The optimized version to follow can have limitations on the ranges of certain inputs.
+   *    3. Optimization using DSP extension is not available for the generic case where channel multiplier is > 1.
    *
    */
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
@@ -45,7 +45,7 @@
    *
    * @note
    *        - Refer header file for details.
-   *        - The optimized version to follow can have limitations on the ranges of certain inputs.
+   *        - Optimization using DSP extension is not available for the generic case where channel multiplier is > 1.
    *
    */
 arm_status arm_depthwise_conv_s8(const q7_t *input,
@@ -92,25 +92,24 @@ arm_status arm_depthwise_conv_s8(const q7_t *input,
                 {
                     const int idx_out_ch = i_ch_mult + i_input_ch * ch_mult;
                     int32_t acc_0;
+                    /* Condition for kernel start dimension: (base_idx_<x,y> + ker_<x,y>_start) >= 0 */
+                    const int ker_y_start = MAX(0, -base_idx_y);
+                    const int ker_x_start = MAX(0, -base_idx_x);
+                    /* Condition for kernel end dimension: (base_idx_<x,y> + ker_<x,y>_end) < input_<x,y> */
+                    const int ker_y_end = MIN(input_y, input_y - base_idx_y);
+                    const int ker_x_end = MIN(input_x, input_x - base_idx_x);
                     acc_0 = bias[idx_out_ch];
 
-                    for (int i_ker_y = 0; i_ker_y < kernel_y; i_ker_y++)
+                    for (int i_ker_y = ker_y_start; i_ker_y < ker_y_end; i_ker_y++)
                     {
                         const int32_t idx_y = base_idx_y + i_ker_y;
-                        const int32_t y_in_range = (idx_y >= 0) && (idx_y < input_y);
-                        for (int i_ker_x = 0; i_ker_x < kernel_x; i_ker_x++)
+                        for (int i_ker_x = ker_x_start; i_ker_x < ker_x_end; i_ker_x++)
                         {
-                            if (1 == y_in_range)
-                            {
-                                const int32_t idx_x = base_idx_x + i_ker_x;
-                                if (idx_x >= 0 && idx_x < input_x)
-                                {
-                                    int32_t idx_0 = (idx_y * input_x + idx_x) * input_ch + i_input_ch;
-                                    int32_t ker_idx_0 = (i_ker_y * kernel_x + i_ker_x) * (input_ch * ch_mult) + idx_out_ch;
+                            const int32_t idx_x = base_idx_x + i_ker_x;
+                            int32_t idx_0 = (idx_y * input_x + idx_x) * input_ch + i_input_ch;
+                            int32_t ker_idx_0 = (i_ker_y * kernel_x + i_ker_x) * (input_ch * ch_mult) + idx_out_ch;
 
-                                    acc_0 += (input[idx_0] + input_offset) * kernel[ker_idx_0];
-                                }
-                            }
+                            acc_0 += (input[idx_0] + input_offset) * kernel[ker_idx_0];
                         }
                     }
                     /* Requantize and clamp output to provided range */


### PR DESCRIPTION
Update to remove range checks from inner loop of generic  depthwise
conv s8 implementation.