### PR TITLE
Added __EARLY_INIT provision for all currently supported Cortex cores

### DIFF
--- a/CMSIS/Core/Include/cmsis_armcc.h
+++ b/CMSIS/Core/Include/cmsis_armcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armcc.h
  * @brief    CMSIS compiler ARMCC (Arm Compiler 5) header file
- * @version  V5.1.1
- * @date     30. July 2019
+ * @version  V5.1.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -109,6 +109,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 #define __PROGRAM_START           __main

--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
  * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
- * @version  V5.2.1
- * @date     30. July 2019
+ * @version  V5.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -115,6 +115,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 #define __PROGRAM_START           __main

--- a/CMSIS/Core/Include/cmsis_armclang_ltm.h
+++ b/CMSIS/Core/Include/cmsis_armclang_ltm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang_ltm.h
  * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
- * @version  V1.2.1
- * @date     30. July 2019
+ * @version  V1.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2018-2019 Arm Limited. All rights reserved.
@@ -115,6 +115,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 #define __PROGRAM_START           __main

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
  * @brief    CMSIS compiler GCC header file
- * @version  V5.2.1
- * @date     30. July 2019
+ * @version  V5.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -118,6 +118,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 

--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_iccarm.h
  * @brief    CMSIS compiler ICCARM (IAR Compiler for Arm) header file
- * @version  V5.1.1
- * @date     30. July 2019
+ * @version  V5.1.2
+ * @date     08. August 2019
  ******************************************************************************/
 
 //------------------------------------------------------------------------------
@@ -242,6 +242,10 @@ __packed struct  __iar_u32 { uint32_t v; };
   #else
     #define __WEAK _Pragma("__weak")
   #endif
+#endif
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 #ifndef __PROGRAM_START

--- a/CMSIS/Core_A/Include/cmsis_armcc.h
+++ b/CMSIS/Core_A/Include/cmsis_armcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armcc.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.0.4
- * @date     30. July 2019
+ * @brief    CMSIS compiler ARMCC (Arm Compiler 5) header file
+ * @version  V1.0.5
+ * @date     09. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -24,6 +24,7 @@
 
 #ifndef __CMSIS_ARMCC_H
 #define __CMSIS_ARMCC_H
+
 
 #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 400677)
   #error "Please use Arm Compiler Toolchain V4.0.677 or later!"
@@ -88,6 +89,12 @@
 #endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __memory_changed()
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 /* ##########################  Core Instruction Access  ######################### */

--- a/CMSIS/Core_A/Include/cmsis_armclang.h
+++ b/CMSIS/Core_A/Include/cmsis_armclang.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.1.2
- * @date     30. July 2019
+ * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
+ * @version  V1.1.3
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -104,6 +104,12 @@
 #endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 /* ##########################  Core Instruction Access  ######################### */

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.2.1
- * @date     30. July 2019
+ * @brief    CMSIS compiler GCC header file
+ * @version  V1.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -37,7 +37,6 @@
 #endif
 
 /* CMSIS compiler specific defines */
-
 #ifndef   __ASM
   #define __ASM                                  __asm
 #endif
@@ -107,6 +106,12 @@
 #endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 
@@ -554,6 +559,7 @@ __extension__ \
  })
 
 /* ###########################  Core Function Access  ########################### */
+
 
 /**
   \brief   Enable IRQ Interrupts

--- a/CMSIS/Core_A/Include/cmsis_iccarm.h
+++ b/CMSIS/Core_A/Include/cmsis_iccarm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_iccarm.h
  * @brief    CMSIS compiler ICCARM (IAR Compiler for Arm) header file
- * @version  V5.0.7
- * @date     15. May 2019
+ * @version  V5.0.8
+ * @date     08. August 2019
  ******************************************************************************/
 
 //------------------------------------------------------------------------------
@@ -209,6 +209,9 @@
   #endif
 #endif
 
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __ICCARM_INTRINSICS_VERSION__
   #define __ICCARM_INTRINSICS_VERSION__  0

--- a/Device/ARM/ARMCA5/Source/AC6/startup_ARMCA5.c
+++ b/Device/ARM/ARMCA5/Source/AC6/startup_ARMCA5.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA5/Source/GCC/startup_ARMCA5.c
+++ b/Device/ARM/ARMCA5/Source/GCC/startup_ARMCA5.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA7/Source/AC6/startup_ARMCA7.c
+++ b/Device/ARM/ARMCA7/Source/AC6/startup_ARMCA7.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA7/Source/GCC/startup_ARMCA7.c
+++ b/Device/ARM/ARMCA7/Source/GCC/startup_ARMCA7.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA9/Source/AC6/startup_ARMCA9.c
+++ b/Device/ARM/ARMCA9/Source/AC6/startup_ARMCA9.c
@@ -80,6 +80,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA9/Source/GCC/startup_ARMCA9.c
+++ b/Device/ARM/ARMCA9/Source/GCC/startup_ARMCA9.c
@@ -80,6 +80,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCM0/Source/startup_ARMCM0.c
+++ b/Device/ARM/ARMCM0/Source/startup_ARMCM0.c
@@ -115,6 +115,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM0plus/Source/startup_ARMCM0plus.c
+++ b/Device/ARM/ARMCM0plus/Source/startup_ARMCM0plus.c
@@ -121,6 +121,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM1/Source/startup_ARMCM1.c
+++ b/Device/ARM/ARMCM1/Source/startup_ARMCM1.c
@@ -115,6 +115,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM23/Source/startup_ARMCM23.c
+++ b/Device/ARM/ARMCM23/Source/startup_ARMCM23.c
@@ -123,7 +123,7 @@ extern const pFunc __VECTOR_TABLE[240];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM3/Source/startup_ARMCM3.c
+++ b/Device/ARM/ARMCM3/Source/startup_ARMCM3.c
@@ -119,6 +119,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM33/Source/startup_ARMCM33.c
+++ b/Device/ARM/ARMCM33/Source/startup_ARMCM33.c
@@ -132,7 +132,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM35P/Source/startup_ARMCM35P.c
+++ b/Device/ARM/ARMCM35P/Source/startup_ARMCM35P.c
@@ -132,7 +132,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
+++ b/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
@@ -125,6 +125,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM7/Source/startup_ARMCM7.c
+++ b/Device/ARM/ARMCM7/Source/startup_ARMCM7.c
@@ -127,6 +127,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMSC000/Source/startup_ARMSC000.c
+++ b/Device/ARM/ARMSC000/Source/startup_ARMSC000.c
@@ -115,6 +115,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMSC300/Source/startup_ARMSC300.c
+++ b/Device/ARM/ARMSC300/Source/startup_ARMSC300.c
@@ -119,6 +119,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMv81MML/Source/startup_ARMv81MML.c
+++ b/Device/ARM/ARMv81MML/Source/startup_ARMv81MML.c
@@ -126,7 +126,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMv8MBL/Source/startup_ARMv8MBL.c
+++ b/Device/ARM/ARMv8MBL/Source/startup_ARMv8MBL.c
@@ -117,7 +117,7 @@ extern const pFunc __VECTOR_TABLE[240];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMv8MML/Source/startup_ARMv8MML.c
+++ b/Device/ARM/ARMv8MML/Source/startup_ARMv8MML.c
@@ -136,7 +136,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }


### PR DESCRIPTION
Early init is a must for implementation where ECC for RAM (and probably TCM) must be initialized before Stack being used.
This PR just pulls in a provision for that. Separate pull request will extend __EARLY_INIT by optional ECC implementation for Cortex-m7 etc