### PR TITLE
CMSIS_NN : Fix compiler warnings for Wall and Wextra

### DIFF
--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -40,8 +40,8 @@ extern    "C"
 
 #define LEFT_SHIFT(_shift)  (_shift > 0 ? _shift : 0)
 #define RIGHT_SHIFT(_shift) (_shift > 0 ? 0 : -_shift)
-#define Q31_MIN (0x80000000L)
-#define Q31_MAX (0x7FFFFFFFL)
+#define Q31_MIN ((q31_t)(0x80000000L))
+#define Q31_MAX ((q31_t)(0x7FFFFFFFL))
 
 #define MAX(A,B) ((A) > (B) ? (A) : (B))
 #define MIN(A,B) ((A) < (B) ? (A) : (B))

--- a/CMSIS/NN/Source/ActivationFunctions/arm_relu_q15.c
+++ b/CMSIS/NN/Source/ActivationFunctions/arm_relu_q15.c
@@ -66,7 +66,7 @@ void arm_relu_q15(q15_t *data, uint16_t size)
 
     while (i)
     {
-        in = arm_nn_read_q15x2_ia(&input);
+        in = arm_nn_read_q15x2_ia((const q15_t **)&input);
 
         /* extract the first bit */
         buf = __ROR(in & 0x80008000, 15);

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
@@ -97,7 +97,7 @@ arm_elementwise_mul_s8(const int8_t *input_1_vect,
     input_2 = (int16_t)(b_2 & 0x0FFFFL);
 
     mul_res = input_1 * input_2;
-    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) ;
+    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) + out_offset;
 
     mul_res = MAX(mul_res, out_activation_min);
     mul_res = MIN(mul_res, out_activation_max);
@@ -108,7 +108,7 @@ arm_elementwise_mul_s8(const int8_t *input_1_vect,
     input_2 = (int16_t)((b_2 >> 16U) & 0x0FFFFL);
 
     mul_res = input_1 * input_2;
-    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) ;
+    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) + out_offset;
     mul_res = MAX(mul_res, out_activation_min);
     mul_res = MIN(mul_res, out_activation_max);
     r3 = (q7_t)mul_res;
@@ -118,7 +118,7 @@ arm_elementwise_mul_s8(const int8_t *input_1_vect,
     input_2 = (int16_t)(a_2 & 0x0FFFFL);
 
     mul_res = input_1 * input_2;
-    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) ;
+    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) + out_offset;
     mul_res = MAX(mul_res, out_activation_min);
     mul_res = MIN(mul_res, out_activation_max);
     r2 = (q7_t)mul_res;
@@ -128,7 +128,7 @@ arm_elementwise_mul_s8(const int8_t *input_1_vect,
     input_2 = (int16_t)((a_2 >> 16U) & 0x0FFFFL);
 
     mul_res = input_1 * input_2;
-    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) ;
+    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) + out_offset;
     mul_res = MAX(mul_res, out_activation_min);
     mul_res = MIN(mul_res, out_activation_max);
     r4 = (q7_t)mul_res;
@@ -151,7 +151,7 @@ arm_elementwise_mul_s8(const int8_t *input_1_vect,
     input_2 = *input_2_vect++ + input_2_offset;
 
     mul_res = input_1 * input_2;
-    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) ;
+    mul_res = arm_nn_divide_by_power_of_two(arm_nn_sat_doubling_high_mult(mul_res, out_mult), -out_shift) + out_offset;
 
     mul_res = MAX(mul_res, out_activation_min);
     mul_res = MIN(mul_res, out_activation_max);

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_HWC_q7_fast_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_HWC_q7_fast_nonsquare.c
@@ -60,13 +60,13 @@
  * @param[in,out]   Im_out       pointer to output tensor
  * @param[in]       dim_im_out_x output tensor dimension x
  * @param[in]       dim_im_out_y output tensor dimension y
- * @param[in,out]   bufferA      pointer to buffer space for input 
+ * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
  * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
  *
  * This function is optimized for convolution with 1x1 kernel size (i.e., dim_kernel_x=1
- * and dim_kernel_y=1). It can be used for the second half of MobileNets [1] after depthwise 
+ * and dim_kernel_y=1). It can be used for the second half of MobileNets [1] after depthwise
  * separable convolution.
  *
  * This function is the version with full list of optimization tricks, but with
@@ -95,14 +95,14 @@ arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t * Im_in,
                                                   const uint16_t out_shift,
                                                   q7_t * Im_out,
                                                   const uint16_t dim_im_out_x,
-                                                  const uint16_t dim_im_out_y, 
-                                                  q15_t * bufferA, 
+                                                  const uint16_t dim_im_out_y,
+                                                  q15_t * bufferA,
                                                   q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
-
+    (void)dim_im_in_y;
     int16_t   i_out_y, i_out_x;
     int16_t   i_ch_out;
 
@@ -183,7 +183,7 @@ arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t * Im_in,
 
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-		
+
     int       i, j, k, l, m, n;
     int       conv_out;
     int       in_row, in_col;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -83,6 +83,7 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
     /* Optimized version for M cores with DSP extension */
     int16_t i_out_y, i_out_x;
     int16_t i_ch_out;
+    (void)input_y;
 
     /* Partial(two columns) im2col buffer */
     q15_t *two_column_buffer = buffer_a;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c
@@ -57,7 +57,7 @@
    * @param[in]       dim_im_out  output tensor dimension
    * @param[in,out]   bufferA     pointer to buffer space for input
    * @param[in,out]   bufferB     pointer to buffer space for output
-   * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
+   * @return     The function returns <code>ARM_MATH_SUCCESS</code>
    *
    * @details
    *
@@ -68,7 +68,7 @@
    * bufferB size: 0
    *
    * This basic version is designed to work for any input tensor and weight
-   * dimension. 
+   * dimension.
    */
 
 arm_status
@@ -83,12 +83,12 @@ arm_convolve_HWC_q15_basic(const q15_t * Im_in,
                            const q15_t * bias,
                            const uint16_t bias_shift,
                            const uint16_t out_shift,
-                           q15_t * Im_out, 
-                           const uint16_t dim_im_out, 
-                           q15_t * bufferA, 
+                           q15_t * Im_out,
+                           const uint16_t dim_im_out,
+                           q15_t * bufferA,
                            q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c
@@ -55,7 +55,7 @@
    * @param[in]       out_shift   amount of right-shift for output
    * @param[in,out]   Im_out      pointer to output tensor
    * @param[in]       dim_im_out  output tensor dimension
-   * @param[in,out]   bufferA     pointer to buffer space for input 
+   * @param[in,out]   bufferA     pointer to buffer space for input
    * @param[in,out]   bufferB     pointer to buffer space for output
    * @return     The function returns either
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
@@ -70,7 +70,7 @@
    *
    * <b>Input dimension constraints:</b>
    *
-   * ch_im_in is multiple of 2 
+   * ch_im_in is multiple of 2
    *
    * ch_im_out is multipe of 2
    *
@@ -88,12 +88,12 @@ arm_convolve_HWC_q15_fast(const q15_t * Im_in,
                           const q15_t * bias,
                           const uint16_t bias_shift,
                           const uint16_t out_shift,
-                          q15_t * Im_out, 
-                          const uint16_t dim_im_out, 
-                          q15_t * bufferA, 
+                          q15_t * Im_out,
+                          const uint16_t dim_im_out,
+                          q15_t * bufferA,
                           q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     int16_t   i_out_y, i_out_x, i_ker_y, i_ker_x;
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c
@@ -60,7 +60,7 @@
    * @param[in,out]   Im_out       pointer to output tensor
    * @param[in]       dim_im_out_x output tensor dimension x
    * @param[in]       dim_im_out_y output tensor dimension y
-   * @param[in,out]   bufferA      pointer to buffer space for input 
+   * @param[in,out]   bufferA      pointer to buffer space for input
    * @param[in,out]   bufferB      pointer to buffer space for output
    * @return     The function returns either
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
@@ -75,7 +75,7 @@
    *
    * <b>Input dimension constraints:</b>
    *
-   * ch_im_in is multiple of 2 
+   * ch_im_in is multiple of 2
    *
    * ch_im_out is multipe of 2
    *
@@ -99,11 +99,11 @@ arm_convolve_HWC_q15_fast_nonsquare(const q15_t * Im_in,
                                     const uint16_t out_shift,
                                     q15_t * Im_out,
                                     const uint16_t dim_im_out_x,
-                                    const uint16_t dim_im_out_y, 
-                                    q15_t * bufferA, 
+                                    const uint16_t dim_im_out_y,
+                                    q15_t * bufferA,
                                     q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     int16_t   i_out_y, i_out_x, i_ker_y, i_ker_x;
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c
@@ -90,7 +90,7 @@ arm_convolve_HWC_q7_RGB(const q7_t * Im_in,
                         const uint16_t out_shift,
                         q7_t * Im_out, const uint16_t dim_im_out, q15_t * bufferA, q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
     int16_t   i_out_y, i_out_x, i_ker_y, i_ker_x;
@@ -124,7 +124,7 @@ arm_convolve_HWC_q7_RGB(const q7_t * Im_in,
                         pBuffer += 3;
                     } else
                     {
-                        /* 
+                        /*
                          * Equivalent to:
                          *  arm_q7_to_q15_no_shift( (q7_t*)Im_in+(i_ker_y*dim_im_in+i_ker_x)*3, pBuffer, 3);
                          */
@@ -154,14 +154,14 @@ arm_convolve_HWC_q7_RGB(const q7_t * Im_in,
                         *__SIMD32(pBuffer) = __PKHBT(bottom.word, top.word, 0);
 #else
                         /*
-                         *  big-endian,    | 1st  | 2nd  | 3rd  | omit | 
+                         *  big-endian,    | 1st  | 2nd  | 3rd  | omit |
                          *                MSB                         LSB
                          *  top | 2nd | omit |; bottom | 1st | 3rd |
-                         * 
+                         *
                          *  version 1, need to swap 2nd and 3rd weight
                          * *__SIMD32(pBuffer) = bottom.word;
                          * *(pBuffer+2) = top.half_words[1];
-                         * 
+                         *
                          *  version 2, no weight shuffling required
                          */
                         *pBuffer++ = bottom.half_words[0];

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c
@@ -54,9 +54,9 @@
    * @param[in]       out_shift   amount of right-shift for output
    * @param[in,out]   Im_out      pointer to output tensor
    * @param[in]       dim_im_out  output tensor dimension
-   * @param[in,out]   bufferA     pointer to buffer space for input 
+   * @param[in,out]   bufferA     pointer to buffer space for input
    * @param[in,out]   bufferB     pointer to buffer space for output
-   * @return     The function returns <code>ARM_MATH_SUCCESS</code> 
+   * @return     The function returns <code>ARM_MATH_SUCCESS</code>
    *
    * @details
    *
@@ -67,7 +67,7 @@
    * bufferB size: 0
    *
    * This basic version is designed to work for any input tensor and weight
-   * dimension. 
+   * dimension.
    */
 
 arm_status
@@ -82,18 +82,18 @@ arm_convolve_HWC_q7_basic(const q7_t * Im_in,
                           const q7_t * bias,
                           const uint16_t bias_shift,
                           const uint16_t out_shift,
-                          q7_t * Im_out, 
-                          const uint16_t dim_im_out, 
-                          q15_t * bufferA, 
+                          q7_t * Im_out,
+                          const uint16_t dim_im_out,
+                          q15_t * bufferA,
                           q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
     int16_t   i_out_y, i_out_x, i_ker_y, i_ker_x;
 
-    /* 
+    /*
      *  Here we use bufferA as q15_t internally as computation are done with q15_t level
      *  im2col are done to output in q15_t format from q7_t input
      */

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c
@@ -85,13 +85,13 @@ arm_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t * Im_in,
                                                q15_t * bufferA,
                                                q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
     int16_t   i_out_y, i_out_x, i_ker_y, i_ker_x;
 
-    /* 
+    /*
      *  Here we use bufferA as q15_t internally as computation are done with q15_t level
      *  im2col are done to output in q15_t format from q7_t input
      */
@@ -205,8 +205,8 @@ arm_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t * Im_in,
                             for (l = 0; l < ch_im_in; l++)
                             {
                                 conv_out +=
-                                    Im_in[(in_row * dim_im_in_x + in_col) * ch_im_in + l] * 
-                                         wt[i * ch_im_in * dim_kernel_y * dim_kernel_x + 
+                                    Im_in[(in_row * dim_im_in_x + in_col) * ch_im_in + l] *
+                                         wt[i * ch_im_in * dim_kernel_y * dim_kernel_x +
                                          (m * dim_kernel_x + n) * ch_im_in + l];
                             }
                         }

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c
@@ -55,7 +55,7 @@
    * @param[in]       out_shift   amount of right-shift for output
    * @param[in,out]   Im_out      pointer to output tensor
    * @param[in]       dim_im_out  output tensor dimension
-   * @param[in,out]   bufferA     pointer to buffer space for input 
+   * @param[in,out]   bufferA     pointer to buffer space for input
    * @param[in,out]   bufferB     pointer to buffer space for output
    * @return     The function returns either
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
@@ -77,7 +77,7 @@
    * The im2col converts the Q7 tensor input into Q15 column, which is stored in
    * bufferA. There is reordering happenning during this im2col process with
    * arm_q7_to_q15_reordered_no_shift. For every four elements, the second and
-   * third elements are swapped. 
+   * third elements are swapped.
    *
    * The computation kernel arm_nn_mat_mult_kernel_q7_q15_reordered does the
    * GEMM computation with the reordered columns.
@@ -100,12 +100,12 @@ arm_convolve_HWC_q7_fast(const q7_t * Im_in,
                          const q7_t * bias,
                          const uint16_t bias_shift,
                          const uint16_t out_shift,
-                         q7_t * Im_out, 
-                         const uint16_t dim_im_out, 
-                         q15_t * bufferA, 
+                         q7_t * Im_out,
+                         const uint16_t dim_im_out,
+                         q15_t * bufferA,
                          q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast_nonsquare.c
@@ -60,7 +60,7 @@
  * @param[in,out]   Im_out       pointer to output tensor
  * @param[in]       dim_im_out_x output tensor dimension x
  * @param[in]       dim_im_out_y output tensor dimension y
- * @param[in,out]   bufferA      pointer to buffer space for input 
+ * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
  * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
@@ -88,11 +88,11 @@ arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t * Im_in,
                                               const uint16_t out_shift,
                                               q7_t * Im_out,
                                               const uint16_t dim_im_out_x,
-                                              const uint16_t dim_im_out_y, 
-                                              q15_t * bufferA, 
+                                              const uint16_t dim_im_out_y,
+                                              q15_t * bufferA,
                                               q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
@@ -357,7 +357,7 @@ arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t * Im_in,
                             for (l = 0; l < ch_im_in; l++)
                             {
                                 conv_out += Im_in[(in_row * dim_im_in_x + in_col) * ch_im_in + l] *
-                                    wt[i * ch_im_in * dim_kernel_y * dim_kernel_x + (m * dim_kernel_x + n) * ch_im_in + l];      
+                                    wt[i * ch_im_in * dim_kernel_y * dim_kernel_x + (m * dim_kernel_x + n) * ch_im_in + l];
                             }
                         }
                     }

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -175,7 +175,7 @@ arm_status arm_convolve_s8(const q7_t *input,
     }
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-
+    (void)buffer_a;
     uint16_t i, j, k, l, m, n;
     int conv_out;
     signed char in_row, in_col;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
@@ -78,6 +78,7 @@ arm_status arm_depthwise_conv_s8(const q7_t *input,
     (void)dilation_x;
     (void)dilation_y;
     (void)buffer_a;
+    (void)output_ch;
 
     for (int i_out_y = 0; i_out_y < output_y; i_out_y++)
     {
@@ -95,8 +96,8 @@ arm_status arm_depthwise_conv_s8(const q7_t *input,
                     const int ker_y_start = MAX(0, -base_idx_y);
                     const int ker_x_start = MAX(0, -base_idx_x);
                     /* Condition for kernel end dimension: (base_idx_<x,y> + ker_<x,y>_end) < input_<x,y> */
-                    const int ker_y_end = MIN(input_y, input_y - base_idx_y);
-                    const int ker_x_end = MIN(input_x, input_x - base_idx_x);
+                    const int ker_y_end = MIN(kernel_y, input_y - base_idx_y);
+                    const int ker_x_end = MIN(kernel_x, input_x - base_idx_x);
                     acc_0 = bias[idx_out_ch];
 
                     for (int i_ker_y = ker_y_start; i_ker_y < ker_y_end; i_ker_y++)
@@ -111,6 +112,7 @@ arm_status arm_depthwise_conv_s8(const q7_t *input,
                             acc_0 += (input[idx_0] + input_offset) * kernel[ker_idx_0];
                         }
                     }
+
                     /* Requantize and clamp output to provided range */
                     acc_0 = arm_nn_requantize(acc_0, output_mult[idx_out_ch], output_shift[idx_out_ch]);
                     acc_0 += output_offset;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
@@ -84,6 +84,8 @@ arm_status arm_depthwise_conv_s8_opt(const q7_t *input,
 
 #if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
     /* Run the following code in cores using DSP extension */
+    (void)dilation_x;
+    (void)dilation_y;
 
     int16_t i_out_y, i_out_x;
     int16_t i_ker_y, i_ker_x;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7.c
@@ -90,12 +90,12 @@ arm_status arm_depthwise_separable_conv_HWC_q7(const q7_t * Im_in,
                                                const q7_t * bias,
                                                const uint16_t bias_shift,
                                                const uint16_t out_shift,
-                                               q7_t * Im_out, 
-                                               const uint16_t dim_im_out, 
-                                               q15_t * bufferA, 
+                                               q7_t * Im_out,
+                                               const uint16_t dim_im_out,
+                                               q15_t * bufferA,
                                                q7_t * bufferB)
 {
-
+    (void)bufferB;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7_nonsquare.c
@@ -93,6 +93,8 @@ arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t * Im_in,
                                                          q7_t * bufferB)
 {
 
+    (void)bufferB;
+
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15.c
@@ -71,12 +71,12 @@ arm_fully_connected_mat_q7_vec_q15(const q15_t * pV,
                                    const uint16_t dim_vec,
                                    const uint16_t num_of_rows,
                                    const uint16_t bias_shift,
-                                   const uint16_t out_shift, 
-                                   const q7_t * bias, 
-                                   q15_t * pOut, 
+                                   const uint16_t out_shift,
+                                   const q7_t * bias,
+                                   q15_t * pOut,
                                    q15_t * vec_buffer)
 {
-
+    (void)vec_buffer;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15_opt.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15_opt.c
@@ -93,7 +93,7 @@
    *  | a17 | a27 | a37 | a47 |
    *
    *  For the left-over rows, we do 1x1 computation, so the data remains
-   *  as its original order. 
+   *  as its original order.
    *
    *  So the stored weight matrix looks like this:
    *
@@ -122,6 +122,7 @@ arm_fully_connected_mat_q7_vec_q15_opt(const q15_t * pV,
                                        const uint16_t out_shift, const q7_t * bias, q15_t * pOut, q15_t * vec_buffer)
 {
 
+    (void)vec_buffer;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
@@ -319,8 +320,8 @@ arm_fully_connected_mat_q7_vec_q15_opt(const q15_t * pV,
     {
         q31_t     sum =  ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
         q31_t     sum2 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
-        q31_t     sum3 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift); 
-        q31_t     sum4 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift); 
+        q31_t     sum3 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
+        q31_t     sum4 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
         uint16_t  colCnt = dim_vec >> 1;
 
         pA = pV;

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15.c
@@ -68,12 +68,12 @@ arm_fully_connected_q15(const q15_t * pV,
                         const uint16_t dim_vec,
                         const uint16_t num_of_rows,
                         const uint16_t bias_shift,
-                        const uint16_t out_shift, 
-                        const q15_t * bias, 
+                        const uint16_t out_shift,
+                        const q15_t * bias,
                         q15_t * pOut,
                         q15_t * vec_buffer)
 {
-
+    (void)vec_buffer;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
@@ -124,7 +124,7 @@ arm_fully_connected_q15(const q15_t * pV,
         }                       /* while over colCnt */
         *pO++ =  (q15_t) (__SSAT((sum >> out_shift), 16));
         *pO++ = (q15_t) (__SSAT((sum2>> out_shift), 16));
-		
+
         /* adjust the pointers and counters */
         pB = pB + dim_vec;
         rowCnt --;
@@ -138,20 +138,20 @@ arm_fully_connected_q15(const q15_t * pV,
         uint16_t  colCnt = dim_vec >> 2;
 
         pA = pV;
-      
+
         while (colCnt) {
             q31_t     inV1, inM1;
             inV1 = *__SIMD32(pA)++;
             inM1 = *__SIMD32(pB)++;
             sum = __SMLAD(inV1, inM1, sum);
-            
+
             inV1 = *__SIMD32(pA)++;
             inM1 = *__SIMD32(pB)++;
             sum = __SMLAD(inV1, inM1, sum);
-				
+
             colCnt--;
 	}
-			
+
 	/* left-over of the vector */
 	colCnt = dim_vec & 0x3;
 	while(colCnt) {
@@ -164,7 +164,7 @@ arm_fully_connected_q15(const q15_t * pV,
 	}
 
         *pO++ =  (q15_t) (__SSAT((sum >> out_shift), 16));
-			
+
         rowCnt --;
     }
 

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15_opt.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15_opt.c
@@ -99,12 +99,12 @@ arm_fully_connected_q15_opt(const q15_t * pV,
                             const uint16_t dim_vec,
                             const uint16_t num_of_rows,
                             const uint16_t bias_shift,
-                            const uint16_t out_shift, 
-                            const q15_t * bias, 
-                            q15_t * pOut, 
+                            const uint16_t out_shift,
+                            const q15_t * bias,
+                            q15_t * pOut,
                             q15_t * vec_buffer)
 {
-
+    (void)vec_buffer;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
@@ -118,9 +118,9 @@ arm_fully_connected_q15_opt(const q15_t * pV,
     while (rowCnt)
     {
         q31_t     sum =  ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
-        q31_t     sum2 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift); 
-        q31_t     sum3 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift); 
-        q31_t     sum4 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift); 
+        q31_t     sum2 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
+        q31_t     sum3 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
+        q31_t     sum4 = ((q31_t)(*pBias++) << bias_shift) + NN_ROUND(out_shift);
 
         uint16_t  colCnt = dim_vec >> 1;
 

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
@@ -213,6 +213,7 @@ arm_fully_connected_s8(const int8_t *pInput,
     return (ARM_MATH_SUCCESS);
 
 #else
+    (void)vec_buffer;
     const int8_t *pInputA;
     const int8_t *pBiasTmp = pBias;
     const int8_t *pWeightTmp = pWeight;

--- a/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
@@ -32,6 +32,8 @@
 #include "arm_nnfunctions.h"
 
 
+#if defined(ARM_MATH_LOOPUNROLL) && defined (ARM_MATH_DSP)
+
 static void buffer_scale_back_q15_to_q7(q15_t * buffer, q7_t * target, uint16_t length, uint16_t scale)
 {
     int       i;
@@ -42,8 +44,6 @@ static void buffer_scale_back_q15_to_q7(q15_t * buffer, q7_t * target, uint16_t 
         target[i] = (q7_t) (buffer[i] / scale);
     }
 }
-
-#if defined (ARM_MATH_DSP)
 
 static void buffer_scale_back_q15_to_q7_and_clamp(q15_t * buffer, q7_t * target, uint16_t length, uint16_t count,const int act_min,
   const int act_max)
@@ -188,9 +188,9 @@ void arm_avgpool_s8(const int dim_src_height,
 
 /* Reference C code adapted from CMSIS-NN arm_avepool_q7_HWC.
  */
+    (void)bufferA;
     int16_t   i_ch_in, i_x, i_y;
     int16_t   k_x, k_y;
-
 
     for (i_y = 0; i_y < dim_dst_height; i_y++)
     {

--- a/CMSIS/NN/Source/PoolingFunctions/arm_pool_q7_HWC.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_pool_q7_HWC.c
@@ -154,14 +154,10 @@ static void accumulate_q7_to_q15(q15_t * base, q7_t * target, const uint16_t len
    * @param[in]       padding     padding sizes
    * @param[in]       stride      convolution stride
    * @param[in]       dim_im_out  output tensor dimension
-   * @param[in,out]   bufferA     pointer to buffer space for input
+   * @param[in,out]   bufferA     Not used
    * @param[in,out]   Im_out      pointer to output tensor
    *
    * @details
-   *
-   * <b>Buffer size:</b>
-   *
-   * bufferA size:  0
    *
    * The pooling function is implemented as split x-pooling then
    * y-pooling.
@@ -179,7 +175,7 @@ arm_maxpool_q7_HWC(q7_t * Im_in,
                    const uint16_t padding,
                    const uint16_t stride, const uint16_t dim_im_out, q7_t * bufferA, q7_t * Im_out)
 {
-
+    (void)bufferA;
 #if defined (ARM_MATH_DSP)
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
@@ -264,7 +260,6 @@ arm_maxpool_q7_HWC(q7_t * Im_in,
 
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-
     int16_t   i_ch_in, i_x, i_y;
     int16_t   k_x, k_y;
 
@@ -422,6 +417,7 @@ arm_avepool_q7_HWC(q7_t * Im_in,
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
 
+    (void)bufferA;
     int16_t   i_ch_in, i_x, i_y;
     int16_t   k_x, k_y;
 


### PR DESCRIPTION
In the process the following bugs are fixed.

1. Incorrect index  calculation in inner loop of depthwise conv s8.
2. output offset was unused in mul s8.