### PR TITLE
cortex-m implementation of early_init

### DIFF
--- a/CMSIS/Core/Include/cmsis_armcc.h
+++ b/CMSIS/Core/Include/cmsis_armcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armcc.h
  * @brief    CMSIS compiler ARMCC (Arm Compiler 5) header file
- * @version  V5.1.1
- * @date     30. July 2019
+ * @version  V5.1.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -109,6 +109,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 #define __PROGRAM_START           __main

--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
  * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
- * @version  V5.2.1
- * @date     30. July 2019
+ * @version  V5.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -115,6 +115,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 #define __PROGRAM_START           __main

--- a/CMSIS/Core/Include/cmsis_armclang_ltm.h
+++ b/CMSIS/Core/Include/cmsis_armclang_ltm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang_ltm.h
  * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
- * @version  V1.2.1
- * @date     30. July 2019
+ * @version  V1.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2018-2019 Arm Limited. All rights reserved.
@@ -115,6 +115,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 #define __PROGRAM_START           __main

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
  * @brief    CMSIS compiler GCC header file
- * @version  V5.2.2
- * @date     08. August 2019
+ * @version  V5.2.3
+ * @date     09. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -120,7 +120,33 @@
 /* #########################  Startup and Lowlevel Init  ######################## */
 
 #ifndef __EARLY_INIT
-#define __EARLY_INIT()
+  /**
+    \brief   Early system init: ECC, TCM etc.
+    \details This default implementation initializes ECC memory sections
+             relying on .ecc.table properly in the used linker script.
+
+   */
+__STATIC_FORCEINLINE void __cmsis_cpu_init(void)
+{
+#if defined (__ECC_PRESENT) && (__ECC_PRESENT == 1U)
+  typedef struct {
+    uint32_t* dest;
+    uint32_t  wlen;
+  } __ecc_table_t;
+
+  extern const __ecc_table_t __ecc_table_start__;
+  extern const __ecc_table_t __ecc_table_end__;
+
+  for (__ecc_table_t const* pTable = &__ecc_table_start__; pTable < &__ecc_table_end__; ++pTable) {
+    for(uint32_t i=0u; i<pTable->wlen; ++i) {
+      pTable->dest[i] = 0xDEADBEEF;
+    }
+  }
+#endif
+
+}
+
+#define __EARLY_INIT __cmsis_cpu_init
 #endif
 
 #ifndef __PROGRAM_START

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
  * @brief    CMSIS compiler GCC header file
- * @version  V5.2.1
- * @date     30. July 2019
+ * @version  V5.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -118,6 +118,10 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __PROGRAM_START
 

--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_iccarm.h
  * @brief    CMSIS compiler ICCARM (IAR Compiler for Arm) header file
- * @version  V5.1.1
- * @date     30. July 2019
+ * @version  V5.1.2
+ * @date     08. August 2019
  ******************************************************************************/
 
 //------------------------------------------------------------------------------
@@ -242,6 +242,10 @@ __packed struct  __iar_u32 { uint32_t v; };
   #else
     #define __WEAK _Pragma("__weak")
   #endif
+#endif
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 #ifndef __PROGRAM_START

--- a/CMSIS/Core/Include/core_cm7.h
+++ b/CMSIS/Core/Include/core_cm7.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     core_cm7.h
  * @brief    CMSIS Cortex-M7 Core Peripheral Access Layer Header File
- * @version  V5.1.1
- * @date     28. March 2019
+ * @version  V5.1.2
+ * @date     09. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -217,6 +217,11 @@
   #ifndef __Vendor_SysTickConfig
     #define __Vendor_SysTickConfig    0U
     #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ECC_PRESENT
+    #define __ECC_PRESENT            0U
+    #warning "__ECC_PRESENT not defined in device header file; using default!"
   #endif
 #endif
 

--- a/CMSIS/Core_A/Include/cmsis_armcc.h
+++ b/CMSIS/Core_A/Include/cmsis_armcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armcc.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.0.4
- * @date     30. July 2019
+ * @brief    CMSIS compiler ARMCC (Arm Compiler 5) header file
+ * @version  V1.0.5
+ * @date     09. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -24,6 +24,7 @@
 
 #ifndef __CMSIS_ARMCC_H
 #define __CMSIS_ARMCC_H
+
 
 #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 400677)
   #error "Please use Arm Compiler Toolchain V4.0.677 or later!"
@@ -88,6 +89,12 @@
 #endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __memory_changed()
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 /* ##########################  Core Instruction Access  ######################### */

--- a/CMSIS/Core_A/Include/cmsis_armclang.h
+++ b/CMSIS/Core_A/Include/cmsis_armclang.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.1.2
- * @date     30. July 2019
+ * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
+ * @version  V1.1.3
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -104,6 +104,12 @@
 #endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 /* ##########################  Core Instruction Access  ######################### */

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.2.1
- * @date     30. July 2019
+ * @brief    CMSIS compiler GCC header file
+ * @version  V1.2.2
+ * @date     08. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -37,7 +37,6 @@
 #endif
 
 /* CMSIS compiler specific defines */
-
 #ifndef   __ASM
   #define __ASM                                  __asm
 #endif
@@ -107,6 +106,12 @@
 #endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
 #endif
 
 
@@ -554,6 +559,7 @@ __extension__ \
  })
 
 /* ###########################  Core Function Access  ########################### */
+
 
 /**
   \brief   Enable IRQ Interrupts

--- a/CMSIS/Core_A/Include/cmsis_iccarm.h
+++ b/CMSIS/Core_A/Include/cmsis_iccarm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_iccarm.h
  * @brief    CMSIS compiler ICCARM (IAR Compiler for Arm) header file
- * @version  V5.0.7
- * @date     15. May 2019
+ * @version  V5.0.8
+ * @date     08. August 2019
  ******************************************************************************/
 
 //------------------------------------------------------------------------------
@@ -209,6 +209,9 @@
   #endif
 #endif
 
+#ifndef __EARLY_INIT
+#define __EARLY_INIT()
+#endif
 
 #ifndef __ICCARM_INTRINSICS_VERSION__
   #define __ICCARM_INTRINSICS_VERSION__  0

--- a/Device/ARM/ARMCA5/Source/AC6/startup_ARMCA5.c
+++ b/Device/ARM/ARMCA5/Source/AC6/startup_ARMCA5.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA5/Source/GCC/startup_ARMCA5.c
+++ b/Device/ARM/ARMCA5/Source/GCC/startup_ARMCA5.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA7/Source/AC6/startup_ARMCA7.c
+++ b/Device/ARM/ARMCA7/Source/AC6/startup_ARMCA7.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA7/Source/GCC/startup_ARMCA7.c
+++ b/Device/ARM/ARMCA7/Source/GCC/startup_ARMCA7.c
@@ -74,6 +74,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA9/Source/AC6/startup_ARMCA9.c
+++ b/Device/ARM/ARMCA9/Source/AC6/startup_ARMCA9.c
@@ -80,6 +80,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCA9/Source/GCC/startup_ARMCA9.c
+++ b/Device/ARM/ARMCA9/Source/GCC/startup_ARMCA9.c
@@ -80,6 +80,7 @@ void Vectors(void) {
   Reset Handler called on controller reset
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void) {
+  __EARLY_INIT();
   __ASM volatile(
 
   // Mask interrupts

--- a/Device/ARM/ARMCM0/Source/startup_ARMCM0.c
+++ b/Device/ARM/ARMCM0/Source/startup_ARMCM0.c
@@ -115,6 +115,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM0plus/Source/startup_ARMCM0plus.c
+++ b/Device/ARM/ARMCM0plus/Source/startup_ARMCM0plus.c
@@ -121,6 +121,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM1/Source/startup_ARMCM1.c
+++ b/Device/ARM/ARMCM1/Source/startup_ARMCM1.c
@@ -115,6 +115,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM23/Source/startup_ARMCM23.c
+++ b/Device/ARM/ARMCM23/Source/startup_ARMCM23.c
@@ -123,7 +123,7 @@ extern const pFunc __VECTOR_TABLE[240];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM3/Source/startup_ARMCM3.c
+++ b/Device/ARM/ARMCM3/Source/startup_ARMCM3.c
@@ -119,6 +119,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM33/Source/startup_ARMCM33.c
+++ b/Device/ARM/ARMCM33/Source/startup_ARMCM33.c
@@ -132,7 +132,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM35P/Source/startup_ARMCM35P.c
+++ b/Device/ARM/ARMCM35P/Source/startup_ARMCM35P.c
@@ -132,7 +132,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
+++ b/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
@@ -125,6 +125,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMCM7/Include/ARMCM7.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7.h
@@ -2,11 +2,11 @@
  * @file     ARMCM7.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM7 Device (configured for CM7 without FPU)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     09. August 2019
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -99,6 +99,7 @@ typedef enum IRQn
 #define __ICACHE_PRESENT          1U
 #define __DCACHE_PRESENT          1U
 #define __DTCM_PRESENT            1U
+#define __ECC_PRESENT             0U        /* no Memory with Error Correcting Code */
 
 #include "core_cm7.h"                       /* Processor and core peripherals */
 #include "system_ARMCM7.h"                  /* System Header */

--- a/Device/ARM/ARMCM7/Include/ARMCM7_DP.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7_DP.h
@@ -2,11 +2,11 @@
  * @file     ARMCM7_DP.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM7 Device (configured for CM7 with double precision FPU)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     09. August 2019
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -99,6 +99,7 @@ typedef enum IRQn
 #define __ICACHE_PRESENT          1U
 #define __DCACHE_PRESENT          1U
 #define __DTCM_PRESENT            1U
+#define __ECC_PRESENT             0U        /* no Memory with Error Correcting Code */
 
 #include "core_cm7.h"                       /* Processor and core peripherals */
 #include "system_ARMCM7.h"                  /* System Header */

--- a/Device/ARM/ARMCM7/Include/ARMCM7_SP.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7_SP.h
@@ -2,11 +2,11 @@
  * @file     ARMCM7_SP.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM7 Device (configured for CM7 with single precision FPU)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     09. August 2019
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -99,6 +99,7 @@ typedef enum IRQn
 #define __ICACHE_PRESENT          1U
 #define __DCACHE_PRESENT          1U
 #define __DTCM_PRESENT            1U
+#define __ECC_PRESENT             0U        /* no Memory with Error Correcting Code */
 
 #include "core_cm7.h"                       /* Processor and core peripherals */
 #include "system_ARMCM7.h"                  /* System Header */

--- a/Device/ARM/ARMCM7/Source/GCC/gcc_arm.ld
+++ b/Device/ARM/ARMCM7/Source/GCC/gcc_arm.ld
@@ -1,8 +1,8 @@
 /******************************************************************************
  * @file     gcc_arm.ld
  * @brief    GNU Linker Script for Cortex-M based device
- * @version  V2.0.0
- * @date     21. May 2019
+ * @version  V2.0.1
+ * @date     09. August 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -71,6 +71,8 @@ MEMORY
  * It defines following symbols, which code can use without definition:
  *   __exidx_start
  *   __exidx_end
+ *   __ecc_table_start__
+ *   __ecc_table_end__
  *   __copy_table_start__
  *   __copy_table_end__
  *   __zero_table_start__
@@ -148,6 +150,38 @@ SECTIONS
   } > FLASH
   __exidx_end = .;
 
+  /* ECC initialization is done by 32-bit writes thus used symbols
+   * must be 4byte aligned */
+  .ecc.table :
+  {
+    . = ALIGN(4);
+    __ecc_table_start__ = .;
+
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+/*
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+
+    LONG (__end__)
+    LONG ((__HeapLimit - __end__) / 4)
+
+    LONG (__StackLimit)
+    LONG ((__StackLimit - __StackTop) / 4)
+
+    __ecc_table_end__ = .;
+  } > FLASH
+
   .copy.table :
   {
     . = ALIGN(4);
@@ -175,6 +209,7 @@ SECTIONS
 */
     __zero_table_end__ = .;
   } > FLASH
+
 
   /**
    * Location counter can end up 2byte aligned with narrow Thumb code but
@@ -222,7 +257,7 @@ SECTIONS
    * Secondary data section, optional
    *
    * Remember to add each additional data section
-   * to the .copy.table above to asure proper
+   * to the .copy.table and .ecc.table above to asure proper
    * initialization during startup.
    */
 /*
@@ -255,7 +290,7 @@ SECTIONS
    * Secondary bss section, optional
    *
    * Remember to add each additional bss section
-   * to the .zero.table above to asure proper
+   * to the .zero.table and .ecc.table above to asure proper
    * initialization during startup.
    */
 /*

--- a/Device/ARM/ARMCM7/Source/startup_ARMCM7.c
+++ b/Device/ARM/ARMCM7/Source/startup_ARMCM7.c
@@ -127,6 +127,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMSC000/Source/startup_ARMSC000.c
+++ b/Device/ARM/ARMSC000/Source/startup_ARMSC000.c
@@ -115,6 +115,7 @@ extern const pFunc __VECTOR_TABLE[48];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMSC300/Source/startup_ARMSC300.c
+++ b/Device/ARM/ARMSC300/Source/startup_ARMSC300.c
@@ -119,6 +119,7 @@ extern const pFunc __VECTOR_TABLE[240];
  *----------------------------------------------------------------------------*/
 void Reset_Handler(void)
 {
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMv81MML/Source/startup_ARMv81MML.c
+++ b/Device/ARM/ARMv81MML/Source/startup_ARMv81MML.c
@@ -126,7 +126,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMv8MBL/Source/startup_ARMv8MBL.c
+++ b/Device/ARM/ARMv8MBL/Source/startup_ARMv8MBL.c
@@ -117,7 +117,7 @@ extern const pFunc __VECTOR_TABLE[240];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/Device/ARM/ARMv8MML/Source/startup_ARMv8MML.c
+++ b/Device/ARM/ARMv8MML/Source/startup_ARMv8MML.c
@@ -136,7 +136,7 @@ extern const pFunc __VECTOR_TABLE[496];
 void Reset_Handler(void)
 {
   __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
-
+  __EARLY_INIT();
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }


### PR DESCRIPTION
This is the second part of EARLY_INIT support where optional ECC implementation for cortex-m7 is added.
