### PR TITLE
Removed useless vld1q_f32 from arm_correlate_f32

### DIFF
--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f32.c
@@ -390,8 +390,6 @@ void arm_correlate_f32(
 
         x1v = x2v;
         px+=4;
-        x2v = vld1q_f32(px);
-
       } while (--k);
       
       /* If the srcBLen is not a multiple of 4, compute any remaining MACs here.


### PR DESCRIPTION
The same vld1q_f32 was computed at the beginning and at the end of a do-while loop. I removed the one at the end (in the disassembly it was already ignored by the compiler)