### PR TITLE
CMSIS-DSP: Fix -Wundef warning and -fpermissive error

### DIFF
--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -1282,7 +1282,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
     q31_t   result;
     q63_t   absNum;
     q31_t   normalized;
-    q31_t   norm;
+    int     norm;
 
     /*
      * if sum fits in 32bits

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -970,7 +970,7 @@ MSVC is not going to be used to cross-compile to ARM. So, having a MSVC
 compiler file in Core or Core_A would not make sense.
 
 */
-#if defined ( _MSC_VER ) || (__GNUC_PYTHON__)
+#if defined ( _MSC_VER ) || defined (__GNUC_PYTHON__)
     __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t data)
     {
       if (data == 0U) { return 32U; }
@@ -8427,7 +8427,7 @@ float32_t arm_yule_distance(const uint32_t *pA, const uint32_t *pB, uint32_t num
   #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
   #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
        
-#elif defined ( _MSC_VER ) || (__GNUC_PYTHON__)
+#elif defined ( _MSC_VER ) || defined (__GNUC_PYTHON__)
       #define LOW_OPTIMIZATION_ENTER
       #define LOW_OPTIMIZATION_EXIT
       #define IAR_ONLY_LOW_OPTIMIZATION_ENTER 


### PR DESCRIPTION
The first patch simply silences this warning:

```
cmsis/dsp/arm_math.h:973:30: warning: "__GNUC_PYTHON__" is not defined, evaluates to 0 [-Wundef]
 #if defined ( _MSC_VER ) || (__GNUC_PYTHON__)
                              ^~~~~~~~~~~~~~~
```

FYI: it's not enough to `-D__GNUC_PYTHON__=0`, because that this code won't include the `cmsis_compiler.h` file anymore:

```c
/* Included for instrinsics definitions */
#if defined (_MSC_VER ) 
#include <stdint.h>
#define __STATIC_FORCEINLINE static __forceinline
#define __STATIC_INLINE static __inline
#define __ALIGNED(x) __declspec(align(x))

#elif defined (__GNUC_PYTHON__)
#include <stdint.h>
#define  __ALIGNED(x) __attribute__((aligned(x)))
#define __STATIC_FORCEINLINE static __attribute__((inline))
#define __STATIC_INLINE static __attribute__((inline))
#pragma GCC diagnostic ignored "-Wunused-function"
#pragma GCC diagnostic ignored "-Wattributes"

#else
#include "cmsis_compiler.h"
#endif
```

Considering that all other conditional compilations check for macro *definition* not *trueness*, I assume my patch is correct.

The second patch is a bit more ambiguous. I use CMSIS-DSP in a C++ project which is less forgiving about casting to another type:

```
cmsis/dsp/arm_math.h: In function 'q31_t arm_div_q63_to_q31(q63_t, q31_t)':
cmsis/dsp/arm_math.h:1292:45: error: invalid conversion from 'q31_t*' {aka 'long int*'} to 'int*' [-fpermissive]
     arm_norm_64_to_32u(absNum, &normalized, &norm);
                                             ^~~~~
cmsis/dsp/arm_math.h:1228:80: note:   initializing argument 3 of 'void arm_norm_64_to_32u(uint64_t, q31_t*, int*)'
 __STATIC_INLINE  void arm_norm_64_to_32u(uint64_t in, q31_t * normalized, int *norm)
                                                                           ~~~~~^~~~
```

I'm not sure if the function signature should be fixed, or the function call. The function `arm_norm_64_to_32u` itself casts `q31_t` to `int`, which is fine, since `typedef int32_t q31_t;`, but whether that is mathematically correct, I don't know. I leave this decision to the experts.