### PR TITLE
CMSIS: Update c startup source code to support multi-file compilation mode in IAR

### DIFF
--- a/CMSIS/DSP/Platforms/MPS3/ARMv81MML/Include/ARMv81MML_DSP_DP_MVE_FP.h
+++ b/CMSIS/DSP/Platforms/MPS3/ARMv81MML/Include/ARMv81MML_DSP_DP_MVE_FP.h
@@ -1,0 +1,132 @@
+/**************************************************************************//**
+ * @file     ARMv81MML_DP.h
+ * @brief    CMSIS Core Peripheral Access Layer Header File for
+ *           Armv8.1-M Mainline Device Series (configured for Armv8.1-M Mainline with double precision FPU, with DSP extension, with TrustZone)
+ * @version  V1.0.0
+ * @date     25. February 2019
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ARMv81MML_DSP_DP_H
+#define ARMv81MML_DSP_DP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* -------------------------  Interrupt Number Definition  ------------------------ */
+
+typedef enum IRQn
+{
+/* --------------------  Armv8.1-M Mainline Processor Exceptions Numbers  --------- */
+  NonMaskableInt_IRQn           = -14,      /*  2 Non Maskable Interrupt */
+  HardFault_IRQn                = -13,      /*  3 HardFault Interrupt */
+  MemoryManagement_IRQn         = -12,      /*  4 Memory Management Interrupt */
+  BusFault_IRQn                 = -11,      /*  5 Bus Fault Interrupt */
+  UsageFault_IRQn               = -10,      /*  6 Usage Fault Interrupt */
+  SecureFault_IRQn              =  -9,      /*  7 Secure Fault Interrupt */
+  SVCall_IRQn                   =  -5,      /* 11 SV Call Interrupt */
+  DebugMonitor_IRQn             =  -4,      /* 12 Debug Monitor Interrupt */
+  PendSV_IRQn                   =  -2,      /* 14 Pend SV Interrupt */
+  SysTick_IRQn                  =  -1,      /* 15 System Tick Interrupt */
+
+/* -------------------  Processor Interrupt Numbers  ------------------------------ */
+  Interrupt0_IRQn               =   0,
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9
+  /* Interrupts 10 .. 480 are left out */
+} IRQn_Type;
+
+
+/* ================================================================================ */
+/* ================      Processor and Core Peripheral Section     ================ */
+/* ================================================================================ */
+
+/* -------  Start of section using anonymous unions and disabling warnings  ------- */
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+/* ---  Configuration of the Armv8.1-M Mainline Processor and Core Peripherals  --- */
+#define __ARMv81MML_REV           0x0001U   /* Core revision r0p1 */
+#define __SAUREGION_PRESENT       1U        /* SAU regions present */
+#define __MPU_PRESENT             1U        /* MPU present */
+#define __VTOR_PRESENT            1U        /* VTOR present */
+#define __NVIC_PRIO_BITS          3U        /* Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */
+#define __FPU_PRESENT             1U        /* FPU present */
+#define __FPU_DP                  1U        /* double precision FPU */
+#define __DSP_PRESENT             1U        /* DSP extension present */
+#define __MVE_PRESENT             1U        /* MVE extensions present */
+#define __MVE_FP                  1U        /* MVE floating point present */
+
+#include "core_armv81mml.h"                 /* Processor and core peripherals */
+#include "system_ARMv81MML.h"               /* System Header */
+
+
+/* --------  End of section using anonymous unions and disabling warnings  -------- */
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* ARMv81MML_DSP_DP_H */

--- a/CMSIS/DSP/Platforms/MPS3/ARMv81MML/Include/system_ARMv81MML.h
+++ b/CMSIS/DSP/Platforms/MPS3/ARMv81MML/Include/system_ARMv81MML.h
@@ -1,0 +1,55 @@
+/**************************************************************************//**
+ * @file     system_ARMv81MML.h
+ * @brief    CMSIS Device System Header File for
+ *           Armv8.1-M Mainline Device Series
+ * @version  V1.0.0
+ * @date     25. February 2019
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYSTEM_ARMv81MML_H
+#define SYSTEM_ARMv81MML_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock) */
+
+
+/**
+  \brief Setup the microcontroller system.
+
+   Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+
+/**
+  \brief  Update SystemCoreClock variable.
+
+   Updates the SystemCoreClock with current core Clock retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_ARMv81MML_H */

--- a/CMSIS/DSP/Platforms/MPS3/ARMv81MML/LinkScripts/AC6/lnk.sct
+++ b/CMSIS/DSP/Platforms/MPS3/ARMv81MML/LinkScripts/AC6/lnk.sct
@@ -1,0 +1,63 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m33 -xc
+; command above MUST be in first line (no comment above!)
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+#include "mem_ARMv81MML.h"
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE     0x10000000
+#define __ROM_SIZE     0x00300000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM1 Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM1 Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM1_BASE     0x30000000
+#define __RAM1_SIZE     0x00400000
+
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    STACK_SIZE
+#define __HEAP_SIZE     HEAP_SIZE
+#define __RAM2_RW_SIZE 	(__RAM1_SIZE - __STACK_SIZE - __HEAP_SIZE)
+
+
+
+LR_ROM __ROM_BASE __ROM_SIZE  {                             ; load region size_region
+  ER_ROM +0 {                                               ; load address = execution address
+   *.o (RESET, +First)
+   * (InRoot$$Sections)
+;   *(Veneer$$CMSE)                                         ; uncomment for secure applications
+   * (+RO-CODE)
+;   * (+XO)
+  }
+
+  /* make sure stack-overflow will cause bus-fault (which might be escalated to hardfault) */
+  ARM_LIB_STACK __RAM1_BASE ALIGN 8 EMPTY __STACK_SIZE {   ; Reserve empty region for stack
+  }
+  
+  RW_RAM1 +0 __RAM2_RW_SIZE {
+    * (+RO-DATA)
+    .ANY (+RW +ZI)
+  }
+
+  ARM_LIB_HEAP  +0 ALIGN 8 EMPTY __HEAP_SIZE  {             ; Reserve empty region for heap
+  }
+
+
+}

--- a/CMSIS/DSP/Platforms/MPS3/ARMv81MML/LinkScripts/AC6/mem_ARMv81MML.h
+++ b/CMSIS/DSP/Platforms/MPS3/ARMv81MML/LinkScripts/AC6/mem_ARMv81MML.h
@@ -1,0 +1,38 @@
+/**************************************************************************//**
+ * @file     mem_ARMCM7.h
+ * @brief    Memory base and size definitions (used in scatter file)
+ * @version  V1.1.0
+ * @date     15. May 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MEM_ARMV81MML_H
+#define __MEM_ARMV81MML_H
+
+
+
+#define STACK_SIZE     0x00003000
+#define HEAP_SIZE      0x00100000
+
+
+
+#endif /* __MEM_ARMV81MML_H */

--- a/CMSIS/DSP/Platforms/MPS3/ARMv81MML/Startup/AC6/startup_ARMv81MML.c
+++ b/CMSIS/DSP/Platforms/MPS3/ARMv81MML/Startup/AC6/startup_ARMv81MML.c
@@ -1,0 +1,150 @@
+/******************************************************************************
+ * @file     startup_ARMv81MML.c
+ * @brief    CMSIS Core Device Startup File for ARMv81MML Device
+ * @version  V2.0.1
+ * @date     23. July 2019
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMv81MML_DSP_DP_MVE_FP)
+  #include "ARMv81MML_DSP_DP_MVE_FP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler Function Prototype
+ *----------------------------------------------------------------------------*/
+typedef void( *pFunc )( void );
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+
+extern void __PROGRAM_START(void) __NO_RETURN;
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void) __NO_RETURN;
+void Reset_Handler  (void) __NO_RETURN;
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const pFunc __VECTOR_TABLE[496];
+       const pFunc __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (pFunc)(&__INITIAL_SP),                   /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+void Reset_Handler(void)
+{
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+
+  SystemInit();                             /* CMSIS System Initialization */
+
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}

--- a/Device/ARM/ARMCM0/Source/startup_ARMCM0.c
+++ b/Device/ARM/ARMCM0/Source/startup_ARMCM0.c
@@ -45,23 +45,27 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -119,18 +123,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}

--- a/Device/ARM/ARMCM0plus/Source/startup_ARMCM0plus.c
+++ b/Device/ARM/ARMCM0plus/Source/startup_ARMCM0plus.c
@@ -51,23 +51,27 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -125,18 +129,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}

--- a/Device/ARM/ARMCM1/Source/startup_ARMCM1.c
+++ b/Device/ARM/ARMCM1/Source/startup_ARMCM1.c
@@ -45,23 +45,27 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -117,20 +121,4 @@ void Reset_Handler(void)
 {
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
-}
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
 }

--- a/Device/ARM/ARMCM23/Source/startup_ARMCM23.c
+++ b/Device/ARM/ARMCM23/Source/startup_ARMCM23.c
@@ -52,23 +52,27 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -126,20 +130,4 @@ void Reset_Handler(void)
 
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
-}
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
 }

--- a/Device/ARM/ARMCM3/Source/startup_ARMCM3.c
+++ b/Device/ARM/ARMCM3/Source/startup_ARMCM3.c
@@ -45,27 +45,31 @@ __NO_RETURN void Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -123,18 +127,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}

--- a/Device/ARM/ARMCM33/Source/startup_ARMCM33.c
+++ b/Device/ARM/ARMCM33/Source/startup_ARMCM33.c
@@ -56,28 +56,32 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SecureFault_Handler    , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -137,19 +141,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}

--- a/Device/ARM/ARMCM35P/Source/startup_ARMCM35P.c
+++ b/Device/ARM/ARMCM35P/Source/startup_ARMCM35P.c
@@ -56,28 +56,32 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SecureFault_Handler    , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -135,21 +139,4 @@ void Reset_Handler(void)
 
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
-}
-
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
 }

--- a/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
+++ b/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
@@ -51,27 +51,31 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -129,18 +133,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}

--- a/Device/ARM/ARMCM7/Source/startup_ARMCM7.c
+++ b/Device/ARM/ARMCM7/Source/startup_ARMCM7.c
@@ -53,27 +53,31 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -129,20 +133,4 @@ void Reset_Handler(void)
 {
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
-}
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
 }

--- a/Device/ARM/ARMSC000/Source/startup_ARMSC000.c
+++ b/Device/ARM/ARMSC000/Source/startup_ARMSC000.c
@@ -45,23 +45,27 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -117,20 +121,4 @@ void Reset_Handler(void)
 {
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
-}
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
 }

--- a/Device/ARM/ARMSC300/Source/startup_ARMSC300.c
+++ b/Device/ARM/ARMSC300/Source/startup_ARMSC300.c
@@ -45,27 +45,31 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -123,18 +127,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}

--- a/Device/ARM/ARMv81MML/Source/startup_ARMv81MML.c
+++ b/Device/ARM/ARMv81MML/Source/startup_ARMv81MML.c
@@ -50,28 +50,33 @@ void Reset_Handler  (void) __NO_RETURN;
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ 
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SecureFault_Handler    , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -131,19 +136,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}

--- a/Device/ARM/ARMv8MBL/Source/startup_ARMv8MBL.c
+++ b/Device/ARM/ARMv8MBL/Source/startup_ARMv8MBL.c
@@ -46,23 +46,27 @@ void __NO_RETURN Reset_Handler  (void);
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -120,20 +124,4 @@ void Reset_Handler(void)
 
   SystemInit();                             /* CMSIS System Initialization */
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
-}
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
 }

--- a/Device/ARM/ARMv8MML/Source/startup_ARMv8MML.c
+++ b/Device/ARM/ARMv8MML/Source/startup_ARMv8MML.c
@@ -60,28 +60,33 @@ void Reset_Handler  (void) __NO_RETURN;
 /*----------------------------------------------------------------------------
   Exception / Interrupt Handler
  *----------------------------------------------------------------------------*/
+ 
+ #define WEAK_ISR(__NAME, ...)                                                  \
+    __attribute__ ((weak))                                                      \
+    void __NAME(void) { __VA_ARGS__ }
+ 
 /* Exceptions */
-void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void HardFault_Handler      (void) __attribute__ ((weak));
-void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
-void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
-void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
-void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
-void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
-void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( NMI_Handler           )
+WEAK_ISR( HardFault_Handler      , while(1);)
+WEAK_ISR( MemManage_Handler      , while(1);)
+WEAK_ISR( BusFault_Handler       , while(1);)
+WEAK_ISR( UsageFault_Handler     , while(1);)
+WEAK_ISR( SecureFault_Handler    , while(1);)
+WEAK_ISR( SVC_Handler           )
+WEAK_ISR( DebugMon_Handler       , while(1);)
+WEAK_ISR( PendSV_Handler        )
+WEAK_ISR( SysTick_Handler       )
 
-void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
-void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+WEAK_ISR( Interrupt0_Handler    )
+WEAK_ISR( Interrupt1_Handler    )
+WEAK_ISR( Interrupt2_Handler    )
+WEAK_ISR( Interrupt3_Handler    )
+WEAK_ISR( Interrupt4_Handler    )
+WEAK_ISR( Interrupt5_Handler    )
+WEAK_ISR( Interrupt6_Handler    )
+WEAK_ISR( Interrupt7_Handler    )
+WEAK_ISR( Interrupt8_Handler    )
+WEAK_ISR( Interrupt9_Handler    )
 
 
 /*----------------------------------------------------------------------------
@@ -141,19 +146,3 @@ void Reset_Handler(void)
   __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }
 
-
-/*----------------------------------------------------------------------------
-  Hard Fault Handler
- *----------------------------------------------------------------------------*/
-void HardFault_Handler(void)
-{
-  while(1);
-}
-
-/*----------------------------------------------------------------------------
-  Default Handler for Exceptions / Interrupts
- *----------------------------------------------------------------------------*/
-void Default_Handler(void)
-{
-  while(1);
-}


### PR DESCRIPTION
The previous version of Cortex-M c startup file cannot be used in IAR multi-file compilation mode which applies strict function and variable type check.

When users implement their own ISR functions, the function's default attribute conflict with the ISR functions defined in the c startup code, i.e. the existence of "alias" attribute.

By removing "alias" from the default ISR function attribute (while keeping the weak), the new c startup code can work with IAR multi-file compilation mode,  Arm Compiler 5, Arm Compiler 6 and GCC.