### PR TITLE
Fixed DAP PIN_DELAY_SLOW() when highly optimized

### DIFF
--- a/CMSIS/DAP/Firmware/Include/DAP.h
+++ b/CMSIS/DAP/Firmware/Include/DAP.h
@@ -280,9 +280,7 @@ extern void     DAP_Setup (void);
 #define DELAY_SLOW_CYCLES       3U      // Number of cycles for one iteration
 #endif
 __STATIC_FORCEINLINE void PIN_DELAY_SLOW (uint32_t delay) {
-  uint32_t count;
-
-  count = delay;
+  volatile uint32_t count = delay;
   while (--count);
 }
 


### PR DESCRIPTION
The `PIN_DELAY_SLOW()` function in `DAP.h` was disappearing when built with gcc using any optimization setting but `-O0` or `-Og`. The cause is that the loop count variable needs to be volatile, otherwise an optimizing compiler is likely to elide the entire while loop.

Closes #389.