### PR TITLE
Protect TRUE/FALSE defines for RTOS2

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_core_cm.h
+++ b/CMSIS/RTOS2/RTX/Source/rtx_core_cm.h
@@ -33,8 +33,14 @@
 
 #include <stdbool.h>
 typedef bool bool_t;
+
+#ifndef FALSE
 #define FALSE                   ((bool_t)0)
+#endif
+
+#ifndef TRUE
 #define TRUE                    ((bool_t)1)
+#endif
 
 #ifdef  RTE_CMSIS_RTOS2_RTX5_ARMV8M_NS
 #define DOMAIN_NS               1


### PR DESCRIPTION
The file `rtx_core_cm.h` defines `TRUE` and `FALSE` macros. This change protects these definitions in case they are already defined. This can happen if the MCU's CMSIS register definition header defines such macros, which will included through the `#include CMSIS_device_header` line.

A much better fix would be to use the `true` and `false` definitions from `<stdbool.h>`, which is already included in this header. There is no need to define your custom bool types, especially since they are just redefined to the same as the ones in `<stdbool.h>`. If you'll accept such a proper fix, I'll make the changes.