### PR TITLE
Fix issues with inline asm version of PIN_DELAY_SLOW() for v6-M

### DIFF
--- a/CMSIS/DAP/Firmware/Include/DAP.h
+++ b/CMSIS/DAP/Firmware/Include/DAP.h
@@ -287,10 +287,11 @@ __STATIC_FORCEINLINE void PIN_DELAY_SLOW (uint32_t delay) {
 #else
 __STATIC_FORCEINLINE void PIN_DELAY_SLOW (uint32_t delay) {
   __ASM volatile (
+  ".syntax unified\n"
   "0:\n\t"
     "subs %0,%0,#1\n\t"
     "bne  0b\n"
-  : "+r" (delay) : : "cc"
+  : "+l" (delay) : : "cc"
   );
 }
 #endif


### PR DESCRIPTION
Due to a bug in gcc when compiling for v6-M, it is necessary to explicitly switch to unified syntax. The compiler automatically inserts a `.syntax divided` directive just before the inline asm, and returns to unified syntax afterwards.

Without this patch, you'll get an error like this…

    Error: instruction not supported in Thumb16 mode -- `subs r7,r7,#1'

when compiling for M0 or M0+.

See [gcc bug 15348](https://sourceware.org/bugzilla/show_bug.cgi?id=15348). There are also multiple forum topics online where people ran into the same issue with inline asm based delay routines.

It was also necessary to change the operand constraint for delay from `r` to `l` so that only low registers are selected.