### PR TITLE
CMSIS-NN: Fix arm_mve_requantize_32x4 renaming

### DIFF
--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
@@ -166,7 +166,7 @@ arm_status arm_depthwise_conv_s8_opt(const q7_t *input,
             int32x4_t shift = vldrwq_z_s32(output_shift, p);
             output_mult += 4;
             output_shift += 4;
-            res = arm_mve_requantize_32x4(res, mult, shift);
+            res = arm_requantize_mve_32x4(res, mult, shift);
 
             res = vaddq_n_s32(res, output_offset);
             res = vmaxq_s32(res, vdupq_n_s32(output_activation_min));

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_depthwise_conv_s8_core.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_depthwise_conv_s8_core.c
@@ -136,8 +136,8 @@ q7_t *arm_nn_depthwise_conv_s8_core(const q7_t *row,
         out_mult += 4;
         out_shift += 4;
 
-        out_0 = arm_mve_requantize_32x4(out_0, mult, shift);
-        out_1 = arm_mve_requantize_32x4(out_1, mult, shift);
+        out_0 = arm_requantize_mve_32x4(out_0, mult, shift);
+        out_1 = arm_requantize_mve_32x4(out_1, mult, shift);
 
         out_0 = vaddq_n_s32(out_0, out_offset);
         out_0 = vmaxq_s32(out_0, vdupq_n_s32(activation_min));
@@ -185,8 +185,8 @@ q7_t *arm_nn_depthwise_conv_s8_core(const q7_t *row,
         const int32x4_t mult = vldrwq_z_s32(out_mult, p);
         const int32x4_t shift = vldrwq_z_s32(out_shift, p);
 
-        col_0_sum = arm_mve_requantize_32x4(col_0_sum, mult, shift);
-        col_1_sum = arm_mve_requantize_32x4(col_1_sum, mult, shift);
+        col_0_sum = arm_requantize_mve_32x4(col_0_sum, mult, shift);
+        col_1_sum = arm_requantize_mve_32x4(col_1_sum, mult, shift);
 
         col_0_sum = vaddq_n_s32(col_0_sum, out_offset);
         col_0_sum = vmaxq_s32(col_0_sum, vdupq_n_s32(activation_min));


### PR DESCRIPTION
Fix names that  were missed in the renaming of
arm_mve_requantize_32x4 to arm_requantize_mve_32x4.

