### PR TITLE
Change osRtxInfo init to avoid warning

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_kernel.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_kernel.c
@@ -89,8 +89,8 @@ static osStatus_t svcRtxKernelInitialize (void) {
   }
 #endif
 
-  // Initialize osRtxInfo
-  memset(&osRtxInfo.kernel, 0, sizeof(osRtxInfo) - offsetof(osRtxInfo_t, kernel));
+  // Initialize osRtxInfo from kernel member onwards (leaving the OS ID and Version)
+  memset((char *)&osRtxInfo + offsetof(osRtxInfo_t, kernel), 0, sizeof(osRtxInfo) - offsetof(osRtxInfo_t, kernel));
 
   osRtxInfo.isr_queue.data = osRtxConfig.isr_queue.data;
   osRtxInfo.isr_queue.max  = osRtxConfig.isr_queue.max;


### PR DESCRIPTION
GCC 9 produces a quite reasonable warning about the odd initialisation of `osRtxInfo`:

    [Warning] rtx_kernel.c@93,3: 'memset' offset [17, 164] from the
    object at 'osRtxInfo' is out of the bounds of referenced subobject
    'kernel' with type 'struct <anonymous>' at offset 8 [-Warray-bounds]

Change the initialisation to be expressed in terms of `&osRtxInfo` to avoid the warning - I feel this also makes the operation clearer.