### PR TITLE
CMSIS-NN: Optimized mat_mul_s8 with DSP acceleration

### DIFF
--- a/CMSIS/Core/Include/cmsis_armcc.h
+++ b/CMSIS/Core/Include/cmsis_armcc.h
@@ -62,9 +62,9 @@
 #ifndef   __STATIC_INLINE
   #define __STATIC_INLINE                        static __inline
 #endif
-#ifndef   __STATIC_FORCEINLINE                 
+#ifndef   __STATIC_FORCEINLINE
   #define __STATIC_FORCEINLINE                   static __forceinline
-#endif           
+#endif
 #ifndef   __NO_RETURN
   #define __NO_RETURN                            __declspec(noreturn)
 #endif
@@ -460,7 +460,7 @@ __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
  */
 #define __DMB()                           __dmb(0xF)
 
-                  
+
 /**
   \brief   Reverse byte order (32 bit)
   \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
@@ -874,6 +874,21 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __USAT(int32_t val, uint
 
 #define __SMMLA(ARG1,ARG2,ARG3)          ( (int32_t)((((int64_t)(ARG1) * (ARG2)) + \
                                                       ((int64_t)(ARG3) << 32U)     ) >> 32U))
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR8(uint32_t x)
+{
+  return (__SXTB16(__ROR(x, 8)));
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR16(uint32_t x)
+{
+  return (__SXTB16(__ROR(x, 16)));
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR24(uint32_t x)
+{
+  return (__SXTB16(__ROR(x, 24)));
+}
 
 #endif /* ((defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     ) */
 /*@} end of group CMSIS_SIMD_intrinsics */

--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -594,7 +594,7 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence zero is returned always in non-secure
   mode.
-  
+
   \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
   \return               PSPLIM Register value
  */
@@ -640,7 +640,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence the write is silently ignored in non-secure
   mode.
-  
+
   \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
   \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
  */
@@ -1435,6 +1435,30 @@ __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
 
   __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
   return(result);
+}
+
+__STATIC_FORCEINLINE int32_t __SXTB16_ROR8(int32_t op1)
+{
+  int32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #8" : "=r" (result) : "r" (op1) );
+  return (result);
+}
+
+__STATIC_FORCEINLINE int32_t __SXTB16_ROR16(int32_t op1)
+{
+  int32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #16" : "=r" (result) : "r" (op1) );
+  return (result);
+}
+
+__STATIC_FORCEINLINE int32_t __SXTB16_ROR24(int32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #24" : "=r" (result) : "r" (op1) );
+  return (result);
 }
 
 #endif /* (__ARM_FEATURE_DSP == 1) */

--- a/CMSIS/Core/Include/cmsis_armclang_ltm.h
+++ b/CMSIS/Core/Include/cmsis_armclang_ltm.h
@@ -595,7 +595,7 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence zero is returned always in non-secure
   mode.
-  
+
   \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
   \return               PSPLIM Register value
  */
@@ -641,7 +641,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence the write is silently ignored in non-secure
   mode.
-  
+
   \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
   \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
  */
@@ -1704,6 +1704,30 @@ __STATIC_FORCEINLINE uint32_t __SXTB16(uint32_t op1)
 
   __ASM volatile ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
   return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR8(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #8" : "=r" (result) : "r" (op1) );
+  return (result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #16" : "=r" (result) : "r" (op1) );
+  return (result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR24(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #24" : "=r" (result) : "r" (op1) );
+  return (result);
 }
 
 __STATIC_FORCEINLINE uint32_t __SXTAB16(uint32_t op1, uint32_t op2)

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -46,9 +46,9 @@
 #ifndef   __STATIC_INLINE
   #define __STATIC_INLINE                        static inline
 #endif
-#ifndef   __STATIC_FORCEINLINE                 
+#ifndef   __STATIC_FORCEINLINE
   #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static inline
-#endif                                           
+#endif
 #ifndef   __NO_RETURN
   #define __NO_RETURN                            __attribute__((__noreturn__))
 #endif
@@ -126,23 +126,23 @@
   \details This default implementations initialized all data and additional bss
            sections relying on .copy.table and .zero.table specified properly
            in the used linker script.
-  
+
  */
 __STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
 {
   extern void _start(void) __NO_RETURN;
-  
+
   typedef struct {
     uint32_t const* src;
     uint32_t* dest;
     uint32_t  wlen;
   } __copy_table_t;
-  
+
   typedef struct {
     uint32_t* dest;
     uint32_t  wlen;
   } __zero_table_t;
-  
+
   extern const __copy_table_t __copy_table_start__;
   extern const __copy_table_t __copy_table_end__;
   extern const __zero_table_t __zero_table_start__;
@@ -153,16 +153,16 @@ __STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
       pTable->dest[i] = pTable->src[i];
     }
   }
- 
+
   for (__zero_table_t const* pTable = &__zero_table_start__; pTable < &__zero_table_end__; ++pTable) {
     for(uint32_t i=0u; i<pTable->wlen; ++i) {
       pTable->dest[i] = 0u;
     }
   }
- 
+
   _start();
 }
-  
+
 #define __PROGRAM_START           __cmsis_start
 #endif
 
@@ -652,7 +652,7 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence zero is returned always in non-secure
   mode.
-  
+
   \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
   \return               PSPLIM Register value
  */
@@ -697,7 +697,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence the write is silently ignored in non-secure
   mode.
-  
+
   \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
   \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
  */
@@ -834,7 +834,7 @@ __STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
 {
 #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
      (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
-#if __has_builtin(__builtin_arm_get_fpscr) 
+#if __has_builtin(__builtin_arm_get_fpscr)
 // Re-enable using built-in when GCC has been fixed
 // || (__GNUC__ > 7) || (__GNUC__ == 7 && __GNUC_MINOR__ >= 2)
   /* see https://gcc.gnu.org/ml/gcc-patches/2017-04/msg00443.html */
@@ -1960,6 +1960,30 @@ __STATIC_FORCEINLINE uint32_t __SXTB16(uint32_t op1)
 
   __ASM ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
   return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR8(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #8" : "=r" (result) : "r" (op1) );
+  return (result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #16" : "=r" (result) : "r" (op1) );
+  return (result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_ROR24(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1, ROR #24" : "=r" (result) : "r" (op1) );
+  return (result);
 }
 
 __STATIC_FORCEINLINE uint32_t __SXTAB16(uint32_t op1, uint32_t op2)

--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -29,7 +29,7 @@
    * ------------
    *
    * This user manual describes the CMSIS DSP software library,
-   * a suite of common signal processing functions for use on Cortex-M and Cortex-A processor 
+   * a suite of common signal processing functions for use on Cortex-M and Cortex-A processor
    * based devices.
    *
    * The library is divided into a number of functions each covering a specific category:
@@ -54,7 +54,7 @@
    * ------------
    *
    * The library installer contains prebuilt versions of the libraries in the <code>Lib</code> folder.
-   * Pre-built libraries will not be updated to contain new functions. 
+   * Pre-built libraries will not be updated to contain new functions.
    * So, SVM, Bayes, Distance functions and experimental functions are not included in those libraries.
    * If you want to use those functions, you'll have to modify the projects, include the missing
    * files and rebuild.
@@ -131,12 +131,12 @@
    * - ARM_MATH_NEON:
    *
    * Define macro ARM_MATH_NEON to enable Neon versions of the DSP functions.
-   * It is not enabled by default when Neon is available because performances are 
+   * It is not enabled by default when Neon is available because performances are
    * dependent on the compiler and target architecture.
    *
    * - ARM_MATH_NEON_EXPERIMENTAL:
    *
-   * Define macro ARM_MATH_NEON_EXPERIMENTAL to enable experimental Neon versions of 
+   * Define macro ARM_MATH_NEON_EXPERIMENTAL to enable experimental Neon versions of
    * of some DSP functions. Experimental Neon versions currently do not have better
    * performances than the scalar versions.
    *
@@ -294,11 +294,11 @@
  * generated from the scikit-learn object. Some examples are given in
  * DSP/Testing/PatternGeneration/SVM.py
  *
- * If more than 2 classes are needed, the functions in this folder 
+ * If more than 2 classes are needed, the functions in this folder
  * will have to be used, as building blocks, to do multi-class classification.
  *
  * No multi-class classification is provided in this SVM folder.
- * 
+ *
  */
 
 
@@ -357,7 +357,7 @@ extern "C"
 
 
 /* Included for instrinsics definitions */
-#if defined (_MSC_VER ) 
+#if defined (_MSC_VER )
 #include <stdint.h>
 #define __STATIC_FORCEINLINE static __forceinline
 #define __STATIC_INLINE static __inline
@@ -700,7 +700,7 @@ extern "C"
    * @brief 16-bit float 64-bit vector data type.
    */
   typedef  __ALIGNED(2) float16x4_t f16x4_t;
-#endif 
+#endif
 
   /**
    * @brief 32-bit floating-point 128-bit vector triplet data type
@@ -759,7 +759,7 @@ extern "C"
    * @brief 16-bit floating-point 64-bit vector quadruplet data type
    */
   typedef float16x4x4_t f16x4x4_t;
-#endif 
+#endif
 
   /**
    * @brief 32-bit fractional 64-bit vector pair data type in 1.31 format
@@ -824,7 +824,7 @@ extern "C"
       float16x4_t     f;
       int16x4_t       i;
   } any16x4_t;
-#endif 
+#endif
 
   /**
    * @brief 32-bit status 64-bit vector data type.
@@ -1676,6 +1676,42 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
                        ((((q31_t)x <<  8) >>  8) & (q31_t)0xFFFF0000)  ));
   }
 
+   /*
+   * @brief C custom defined SXTB16 with immediate rotate right 8 bits
+   */
+  __STATIC_FORCEINLINE uint32_t __SXTB16_ROR8(
+  uint32_t x)
+  {
+    uint32_t y = __ROR(x, 8);
+
+    return ((uint32_t)(((((q31_t)y << 24) >> 24) & (q31_t)0x0000FFFF) |
+                       ((((q31_t)y <<  8) >>  8) & (q31_t)0xFFFF0000)  ));
+  }
+
+   /*
+   * @brief C custom defined SXTB16 with immediate rotate right 16 bits
+   */
+  __STATIC_FORCEINLINE uint32_t __SXTB16_ROR16(
+  uint32_t x)
+  {
+    uint32_t y = __ROR(x, 16);
+
+    return ((uint32_t)(((((q31_t)y << 24) >> 24) & (q31_t)0x0000FFFF) |
+                       ((((q31_t)y <<  8) >>  8) & (q31_t)0xFFFF0000)  ));
+  }
+
+   /*
+   * @brief C custom defined SXTB16 with immediate rotate right 24 bits
+   */
+  __STATIC_FORCEINLINE uint32_t __SXTB16_ROR24(
+  uint32_t x)
+  {
+    uint32_t y = __ROR(x, 24);
+
+    return ((uint32_t)(((((q31_t)y << 24) >> 24) & (q31_t)0x0000FFFF) |
+                       ((((q31_t)y <<  8) >>  8) & (q31_t)0xFFFF0000)  ));
+  }
+
   /*
    * @brief C custom defined SMMLA
    */
@@ -1911,7 +1947,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
   {
       float32_t coeffs[8][4]; /**< Points to the array of modified coefficients.  The array is of length 32. There is one per stage */
   } arm_biquad_mod_coef_f32;
-#endif 
+#endif
 
   /**
    * @brief Processing function for the Q15 Biquad cascade filter.
@@ -2020,11 +2056,11 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
   void arm_biquad_cascade_df1_mve_init_f32(
       arm_biquad_casd_df1_inst_f32 * S,
       uint8_t numStages,
-      const float32_t * pCoeffs, 
-      arm_biquad_mod_coef_f32 * pCoeffsMod, 
+      const float32_t * pCoeffs,
+      arm_biquad_mod_coef_f32 * pCoeffsMod,
       float32_t * pState);
 #endif
-  
+
   void arm_biquad_cascade_df1_init_f32(
         arm_biquad_casd_df1_inst_f32 * S,
         uint8_t numStages,
@@ -2118,7 +2154,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
 
   /**
    * @brief         Compute the logical bitwise NOT of a fixed-point vector.
-   * @param[in]     pSrc       points to input vector 
+   * @param[in]     pSrc       points to input vector
    * @param[out]    pDst       points to output vector
    * @param[in]     blockSize  number of samples in each vector
    * @return        none
@@ -2130,7 +2166,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
 
   /**
    * @brief         Compute the logical bitwise NOT of a fixed-point vector.
-   * @param[in]     pSrc       points to input vector 
+   * @param[in]     pSrc       points to input vector
    * @param[out]    pDst       points to output vector
    * @param[in]     blockSize  number of samples in each vector
    * @return        none
@@ -2142,7 +2178,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
 
   /**
    * @brief         Compute the logical bitwise NOT of a fixed-point vector.
-   * @param[in]     pSrc       points to input vector 
+   * @param[in]     pSrc       points to input vector
    * @param[out]    pDst       points to output vector
    * @param[in]     blockSize  number of samples in each vector
    * @return        none
@@ -2229,11 +2265,11 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
   /**
    * @brief Instance structure for the sorting algorithms.
    */
-  typedef struct            
+  typedef struct
   {
     arm_sort_alg alg;        /**< Sorting algorithm selected */
     arm_sort_dir dir;        /**< Sorting order (direction)  */
-  } arm_sort_instance_f32;  
+  } arm_sort_instance_f32;
 
   /**
    * @param[in]  S          points to an instance of the sorting structure.
@@ -2242,9 +2278,9 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_sort_f32(
-    const arm_sort_instance_f32 * S, 
-          float32_t * pSrc, 
-          float32_t * pDst, 
+    const arm_sort_instance_f32 * S,
+          float32_t * pSrc,
+          float32_t * pDst,
           uint32_t blockSize);
 
   /**
@@ -2254,9 +2290,9 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
    * @param[in]      inPlaceFlag  In place flag.
    */
   void arm_sort_init_f32(
-    arm_sort_instance_f32 * S, 
-    arm_sort_alg alg, 
-    arm_sort_dir dir); 
+    arm_sort_instance_f32 * S,
+    arm_sort_alg alg,
+    arm_sort_dir dir);
 
   /**
    * @brief Struct for specifying cubic spline type
@@ -2313,7 +2349,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
     uint16_t numCols;     /**< number of columns of the matrix.  */
     float32_t *pData;     /**< points to the data of the matrix. */
   } arm_matrix_instance_f32;
- 
+
  /**
    * @brief Instance structure for the floating-point matrix structure.
    */
@@ -4663,7 +4699,7 @@ arm_status arm_fir_decimate_init_f32(
         uint32_t blockSize);
 
 
-#if defined(ARM_MATH_NEON) 
+#if defined(ARM_MATH_NEON)
 void arm_biquad_cascade_df2T_compute_coefs_f32(
   arm_biquad_cascade_df2T_instance_f32 * S,
   uint8_t numStages,
@@ -7832,7 +7868,7 @@ typedef struct
  */
 
 
-void arm_svm_linear_init_f32(arm_svm_linear_instance_f32 *S, 
+void arm_svm_linear_init_f32(arm_svm_linear_instance_f32 *S,
   uint32_t nbOfSupportVectors,
   uint32_t vectorDimension,
   float32_t intercept,
@@ -7848,9 +7884,9 @@ void arm_svm_linear_init_f32(arm_svm_linear_instance_f32 *S,
  * @return none.
  *
  */
-  
-void arm_svm_linear_predict_f32(const arm_svm_linear_instance_f32 *S, 
-   const float32_t * in, 
+
+void arm_svm_linear_predict_f32(const arm_svm_linear_instance_f32 *S,
+   const float32_t * in,
    int32_t * pResult);
 
 
@@ -7871,7 +7907,7 @@ void arm_svm_linear_predict_f32(const arm_svm_linear_instance_f32 *S,
  */
 
 
-void arm_svm_polynomial_init_f32(arm_svm_polynomial_instance_f32 *S, 
+void arm_svm_polynomial_init_f32(arm_svm_polynomial_instance_f32 *S,
   uint32_t nbOfSupportVectors,
   uint32_t vectorDimension,
   float32_t intercept,
@@ -7891,8 +7927,8 @@ void arm_svm_polynomial_init_f32(arm_svm_polynomial_instance_f32 *S,
  * @return none.
  *
  */
-void arm_svm_polynomial_predict_f32(const arm_svm_polynomial_instance_f32 *S, 
-   const float32_t * in, 
+void arm_svm_polynomial_predict_f32(const arm_svm_polynomial_instance_f32 *S,
+   const float32_t * in,
    int32_t * pResult);
 
 
@@ -7910,7 +7946,7 @@ void arm_svm_polynomial_predict_f32(const arm_svm_polynomial_instance_f32 *S,
  *
  */
 
-void arm_svm_rbf_init_f32(arm_svm_rbf_instance_f32 *S, 
+void arm_svm_rbf_init_f32(arm_svm_rbf_instance_f32 *S,
   uint32_t nbOfSupportVectors,
   uint32_t vectorDimension,
   float32_t intercept,
@@ -7928,8 +7964,8 @@ void arm_svm_rbf_init_f32(arm_svm_rbf_instance_f32 *S,
  * @return none.
  *
  */
-void arm_svm_rbf_predict_f32(const arm_svm_rbf_instance_f32 *S, 
-   const float32_t * in, 
+void arm_svm_rbf_predict_f32(const arm_svm_rbf_instance_f32 *S,
+   const float32_t * in,
    int32_t * pResult);
 
 /**
@@ -7947,7 +7983,7 @@ void arm_svm_rbf_predict_f32(const arm_svm_rbf_instance_f32 *S,
  *
  */
 
-void arm_svm_sigmoid_init_f32(arm_svm_sigmoid_instance_f32 *S, 
+void arm_svm_sigmoid_init_f32(arm_svm_sigmoid_instance_f32 *S,
   uint32_t nbOfSupportVectors,
   uint32_t vectorDimension,
   float32_t intercept,
@@ -7966,8 +8002,8 @@ void arm_svm_sigmoid_init_f32(arm_svm_sigmoid_instance_f32 *S,
  * @return none.
  *
  */
-void arm_svm_sigmoid_predict_f32(const arm_svm_sigmoid_instance_f32 *S, 
-   const float32_t * in, 
+void arm_svm_sigmoid_predict_f32(const arm_svm_sigmoid_instance_f32 *S,
+   const float32_t * in,
    int32_t * pResult);
 
 
@@ -7996,8 +8032,8 @@ typedef struct
  */
 
 
-uint32_t arm_gaussian_naive_bayes_predict_f32(const arm_gaussian_naive_bayes_instance_f32 *S, 
-   const float32_t * in, 
+uint32_t arm_gaussian_naive_bayes_predict_f32(const arm_gaussian_naive_bayes_instance_f32 *S,
+   const float32_t * in,
    float32_t *pBuffer);
 
 /**
@@ -8796,11 +8832,11 @@ float32_t arm_yule_distance(const uint32_t *pA, const uint32_t *pB, uint32_t num
   #define LOW_OPTIMIZATION_EXIT
   #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
   #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
-       
+
 #elif defined ( _MSC_VER ) || defined(__GNUC_PYTHON__)
       #define LOW_OPTIMIZATION_ENTER
       #define LOW_OPTIMIZATION_EXIT
-      #define IAR_ONLY_LOW_OPTIMIZATION_ENTER 
+      #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
       #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 #endif
 

--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -235,6 +235,50 @@ q7_t *arm_nn_mat_mult_s8(const q7_t *input_row,
                          const int32_t *const bias,
                          q7_t *out);
 
+   /**
+   * @brief General Matrix-multiplication function with per-channel requantization.
+   *        This function assumes:
+   *        - LHS input matrix NOT transposed
+   *        - RHS input matrix transposed
+   *
+   *  @note This operation also performs the broadcast bias addition before the requantization
+   *
+   * @param[in]  lhs                Pointer to the LHS input matrix
+   * @param[in]  rhs                Pointer to the RHS input matrix
+   * @param[in]  bias               Pointer to the bias vector. The length of this vector is equal to the number of output columns (or RHS input rows)
+   * @param[in]  dst_multipliers    Pointer to the multipliers vector needed for the per-channel requantization. The length of this vector is equal to
+    *                              the number of output columns (or RHS input rows)
+   * @param[in]  dst_shifts         Pointer to the shifts vector needed for the per-channel requantization. The length of this vector is equal to
+    *                              the number of output columns (or RHS input rows)
+   * @param[in]  m                  Number of LHS input rows
+   * @param[in]  n                  Number of RHS input rows
+   * @param[in]  k                  Number of LHS/RHS input columns
+   * @param[in]  lhs_offset         Offset to be applied to the LHS input valus
+   * @param[in]  dst_offset         Offset to be applied the output result
+   * @param[in]  activation_min     Minimum value to clamp down the output. Range : int8
+   * @param[in]  activation_max     Maximum value to clamp up the output. Range : int8
+   * @param[out] dst                Pointer to the output matrix with "m" rows and "n" colums
+   *
+   * @return     The function returns one of the two
+   *              1. The incremented output pointer for a successful operation or
+   *              2. NULL if implementation is not available.
+   *
+   * @details   Supported framework: TensorFlow Lite
+   */
+q7_t *arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
+                              const q7_t *rhs,
+                              const int32_t *bias,
+                              const int32_t *dst_multipliers,
+                              const int32_t *dst_shifts,
+                              const int32_t m,
+                              const int32_t n,
+                              const int32_t k,
+                              const int32_t lhs_offset,
+                              const int32_t dst_offset,
+                              const int32_t activation_min,
+                              const int32_t activation_max,
+                              q7_t *dst);
+
 /**
   @brief         Read 2 q15 elements and post increment pointer.
   @param[in]     in_q15   Pointer to pointer that holds address of input.

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -72,13 +72,14 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
                                     const uint16_t output_y,
                                     q15_t *buffer_a)
 {
+#if defined(ARM_MATH_MVEI)
     if (input_ch % 4 != 0 || output_ch % 2 != 0 ||
         pad_x != 0 || pad_y != 0 ||
         stride_x != 1 || stride_y != 1)
     {
         return ARM_MATH_SIZE_MISMATCH;
     }
-#if defined(ARM_MATH_MVEI)
+
     (void)buffer_a;
     /* Process 4 * N input elements */
     output = arm_nn_mat_mult_s8(kernel,
@@ -143,76 +144,127 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
     }
 
 #elif defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
-    int32_t i_element;
-    (void)input_y;
-
-    /* Partial(two columns) im2col buffer */
-    q15_t *two_column_buffer = buffer_a;
-    q7_t *out = output;
-    const int32_t num_elements = output_x * output_y * input_batches;
-
-    for (i_element = 0; i_element < num_elements / 2; i_element++)
+    if(pad_x == 0 && pad_y == 0 && stride_x == 1 && stride_y == 1)
     {
-        /* Fill buffer for partial im2col - two columns at a time */
-        arm_q7_to_q15_reordered_with_offset(&input[i_element * 2 * input_ch],
-                                            two_column_buffer,
-                                            input_ch * 2,
-                                            (q7_t)input_offset);
+        (void)buffer_a;
 
-        out = arm_nn_mat_mult_kernel_s8_s16_reordered(kernel,
-                                                      two_column_buffer,
-                                                      output_ch,
-                                                      output_shift,
-                                                      output_mult,
-                                                      (q7_t)out_offset,
-                                                      out_activation_min,
-                                                      out_activation_max,
-                                                      input_ch * DIM_KER_Y * DIM_KER_X,
-                                                      bias, out);
-    }
-
-    /* check if there is an odd column left-over for computation */
-    if (num_elements & 0x1)
-    {
-        int32_t i_ch_out;
-        const q7_t *ker_a = kernel;
-
-        arm_q7_to_q15_reordered_with_offset(
-            &input[(num_elements - 1) * input_ch],
-            two_column_buffer, input_ch, (q7_t)input_offset);
-
-        for (i_ch_out = 0; i_ch_out < output_ch; i_ch_out++)
+        // Check input constraint. "output_ch" must be a multiple of two
+        if (output_ch % 2)
         {
-            q31_t sum = bias[i_ch_out];
+            return ARM_MATH_SIZE_MISMATCH;
+        }
 
-            /* Point to the beginning of the im2col buffer where the input is available as a rearranged column */
-            const q15_t *ip_as_col = buffer_a;
-            uint16_t col_count = (input_ch * DIM_KER_X * DIM_KER_Y) >> 2;
+        const int32_t m = input_x * input_y;
+        const int32_t n = output_ch;
+        const int32_t k = input_ch;
+        const int32_t input_stride_b  = m * k;
+        const int32_t output_stride_b = m * n;
 
-            while (col_count)
+        for(int i = 0; i < input_batches; ++i)
+        {
+            output = arm_nn_mat_mult_nt_t_s8(input,
+                                             kernel,
+                                             bias,
+                                             output_mult,
+                                             output_shift,
+                                             m,
+                                             n,
+                                             k,
+                                             input_offset,
+                                             out_offset,
+                                             out_activation_min,
+                                             out_activation_max,
+                                             output);
+            input += input_stride_b;
+            output += output_stride_b;
+        }
+    }
+    else
+    {
+        if (input_ch % 4 != 0 || output_ch % 2 != 0 ||
+            pad_x != 0 || pad_y != 0 ||
+            stride_x != 1 || stride_y != 1)
+        {
+            return ARM_MATH_SIZE_MISMATCH;
+        }
+
+        int32_t i_element;
+        (void)input_y;
+
+        /* Partial(two columns) im2col buffer */
+        q15_t *two_column_buffer = buffer_a;
+        q7_t *out = output;
+        const int32_t num_elements = output_x * output_y * input_batches;
+
+        for (i_element = 0; i_element < num_elements / 2; i_element++)
+        {
+            /* Fill buffer for partial im2col - two columns at a time */
+            arm_q7_to_q15_reordered_with_offset(&input[i_element * 2 * input_ch],
+                                                two_column_buffer,
+                                                input_ch * 2,
+                                                (q7_t)input_offset);
+
+            out = arm_nn_mat_mult_kernel_s8_s16_reordered(kernel,
+                                                          two_column_buffer,
+                                                          output_ch,
+                                                          output_shift,
+                                                          output_mult,
+                                                          (q7_t)out_offset,
+                                                          out_activation_min,
+                                                          out_activation_max,
+                                                          input_ch * DIM_KER_Y * DIM_KER_X,
+                                                          bias, out);
+        }
+
+        /* check if there is an odd column left-over for computation */
+        if (num_elements & 0x1)
+        {
+            int32_t i_ch_out;
+            const q7_t *ker_a = kernel;
+
+            arm_q7_to_q15_reordered_with_offset(
+                &input[(num_elements - 1) * input_ch],
+                two_column_buffer, input_ch, (q7_t)input_offset);
+
+            for (i_ch_out = 0; i_ch_out < output_ch; i_ch_out++)
             {
-                q31_t ker_a1, ker_a2;
-                q31_t in_b1, in_b2;
-                ker_a = read_and_pad_reordered(ker_a, &ker_a1, &ker_a2);
+                q31_t sum = bias[i_ch_out];
 
-                in_b1 = arm_nn_read_q15x2_ia(&ip_as_col);
-                sum = __SMLAD(ker_a1, in_b1, sum);
-                in_b2 = arm_nn_read_q15x2_ia(&ip_as_col);
-                sum = __SMLAD(ker_a2, in_b2, sum);
+                /* Point to the beginning of the im2col buffer where the input is available as a rearranged column */
+                const q15_t *ip_as_col = buffer_a;
+                uint16_t col_count = (input_ch * DIM_KER_X * DIM_KER_Y) >> 2;
 
-                col_count--;
+                while (col_count)
+                {
+                    q31_t ker_a1, ker_a2;
+                    q31_t in_b1, in_b2;
+                    ker_a = read_and_pad_reordered(ker_a, &ker_a1, &ker_a2);
+
+                    in_b1 = arm_nn_read_q15x2_ia(&ip_as_col);
+                    sum = __SMLAD(ker_a1, in_b1, sum);
+                    in_b2 = arm_nn_read_q15x2_ia(&ip_as_col);
+                    sum = __SMLAD(ker_a2, in_b2, sum);
+
+                    col_count--;
+                }
+
+                sum = arm_nn_requantize(sum, output_mult[i_ch_out],
+                                        output_shift[i_ch_out]);
+                sum += out_offset;
+                sum = MAX(sum, out_activation_min);
+                sum = MIN(sum, out_activation_max);
+                *out++ = (q7_t)sum;
             }
-
-            sum = arm_nn_requantize(sum, output_mult[i_ch_out],
-                                    output_shift[i_ch_out]);
-            sum += out_offset;
-            sum = MAX(sum, out_activation_min);
-            sum = MIN(sum, out_activation_max);
-            *out++ = (q7_t)sum;
         }
     }
 
 #else
+    if (input_ch % 4 != 0 || output_ch % 2 != 0 ||
+        pad_x != 0 || pad_y != 0 ||
+        stride_x != 1 || stride_y != 1)
+    {
+        return ARM_MATH_SIZE_MISMATCH;
+    }
     /* Run the following code as reference implementation for M cores with no DSP extension or when loop unrolling is
        not to be done */
     return arm_convolve_s8(input, input_x, input_y,


### PR DESCRIPTION
The new implementation does not require temporary buffers and assumes that the RHS input matrix is transposed (conv1x1 case)