### PR TITLE
CMSIS-NN: Fixed bug in arm_q7_to_q15_with_offset

### DIFF
--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -133,7 +133,7 @@ void      arm_q7_to_q15_reordered_no_shift(const q7_t * pSrc, q15_t * pDst, uint
  * </pre>
  *
  */
-void arm_q7_to_q15_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q7_t offset);
+void arm_q7_to_q15_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q15_t offset);
 
 /**
  * @brief Converts the elements of the q7 vector to reordered q15 vector with an added offset
@@ -148,7 +148,7 @@ void arm_q7_to_q15_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size,
  *           order.
  *
  */
-void arm_q7_to_q15_reordered_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q7_t offset);
+void arm_q7_to_q15_reordered_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q15_t offset);
 
 /**
  * @brief Converts the elements from a q7 vector and accumulate to a q15 vector

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -157,7 +157,7 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
         arm_q7_to_q15_reordered_with_offset(&input[i_element * 2 * input_ch],
                                             two_column_buffer,
                                             input_ch * 2,
-                                            (q7_t)input_offset);
+                                            input_offset);
 
         out = arm_nn_mat_mult_kernel_s8_s16_reordered(kernel,
                                                       two_column_buffer,
@@ -179,7 +179,7 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
 
         arm_q7_to_q15_reordered_with_offset(
             &input[(num_elements - 1) * input_ch],
-            two_column_buffer, input_ch, (q7_t)input_offset);
+            two_column_buffer, input_ch, input_offset);
 
         for (i_ch_out = 0; i_ch_out < output_ch; i_ch_out++)
         {

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c
@@ -47,7 +47,7 @@
  *
  */
 
-void arm_q7_to_q15_reordered_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q7_t offset)
+void arm_q7_to_q15_reordered_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q15_t offset)
 {
 
 #if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
@@ -65,7 +65,7 @@ void arm_q7_to_q15_reordered_with_offset(const q7_t *src, q15_t *dst, uint32_t b
     {
         /* convert from q7 to q15 and then store the results in the destination buffer */
         in_q7x4 = arm_nn_read_q7x4_ia(&src);
-        q31_t offset_q15x2 = (offset << 16l) | offset;
+        q31_t offset_q15x2 = __PKHBT(offset, offset, 16);
 
         /* Extract and sign extend each of the four q7 values to q15 */
         out_q15x2_1 = __SXTB16(__ROR(in_q7x4, 8));

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
@@ -42,7 +42,7 @@
 void arm_q7_to_q15_with_offset(const q7_t *src,
                                q15_t *dst,
                                uint32_t block_size,
-                               q7_t offset)
+                               q15_t offset)
 {
     int block_cnt;
 
@@ -80,7 +80,7 @@ void arm_q7_to_q15_with_offset(const q7_t *src,
     {
         /* convert from q7 to q15 and then store the results in the destination buffer */
         in_q7x4 = arm_nn_read_q7x4_ia(&src);
-        q31_t offset_q15x2 = (offset << 16l) | offset;
+        q31_t offset_q15x2 = __PKHBT(offset, offset, 16);
 
         /* Extract and sign extend each of the four q7 values to q15 */
         in_q15x2_1 = __SXTB16(__ROR(in_q7x4, 8));


### PR DESCRIPTION
The issue was related to the offset casted to int8_t rather than int16_t.
In case of int8_t offset, we could not handle properly the cases with negative offset.
In particular, the creation of the vector variable offset_q15x2 was not correct
since we did not extend the sign bit

Signed-off-by: Gian Marco Iodice <gianmarco.iodice@arm.com>