### PR TITLE
Device: SC300: Fix wrong SC300 core header file inclusion

### DIFF
--- a/ARM.CMSIS.pdsc
+++ b/ARM.CMSIS.pdsc
@@ -2692,7 +2692,7 @@ and 8-bit Java bytecodes in Jazelle state.
     </component>
 
     <!-- Cortex-SC000 -->
-    <component Cclass="Device" Cgroup="Startup" Cvariant="C Startup" Cversion="2.0.2" condition="ARMSC000 CMSIS">
+    <component Cclass="Device" Cgroup="Startup" Cvariant="C Startup" Cversion="2.0.3" condition="ARMSC000 CMSIS">
       <description>System and Startup for Generic Arm SC000 device</description>
       <files>
         <!-- include folder / device header file -->
@@ -2705,7 +2705,7 @@ and 8-bit Java bytecodes in Jazelle state.
         <file category="sourceC"      name="Device/ARM/ARMSC000/Source/system_ARMSC000.c"      version="1.0.0" attr="config"/>
       </files>
     </component>
-    <component Cclass="Device" Cgroup="Startup"                      Cversion="1.2.2" condition="ARMSC000 CMSIS">
+    <component Cclass="Device" Cgroup="Startup"                      Cversion="1.2.3" condition="ARMSC000 CMSIS">
       <description>DEPRECATED: System and Startup for Generic Arm SC000 device</description>
       <files>
         <!-- include folder / device header file -->
@@ -2720,7 +2720,7 @@ and 8-bit Java bytecodes in Jazelle state.
     </component>
 
     <!-- Cortex-SC300 -->
-    <component Cclass="Device" Cgroup="Startup" Cvariant="C Startup" Cversion="2.0.2" condition="ARMSC300 CMSIS">
+    <component Cclass="Device" Cgroup="Startup" Cvariant="C Startup" Cversion="2.0.3" condition="ARMSC300 CMSIS">
       <description>System and Startup for Generic Arm SC300 device</description>
       <files>
         <!-- include folder / device header file -->
@@ -2733,7 +2733,7 @@ and 8-bit Java bytecodes in Jazelle state.
         <file category="sourceC"      name="Device/ARM/ARMSC300/Source/system_ARMSC300.c"      version="1.0.1" attr="config"/>
       </files>
     </component>
-    <component Cclass="Device" Cgroup="Startup"                      Cversion="1.2.2" condition="ARMSC300 CMSIS">
+    <component Cclass="Device" Cgroup="Startup"                      Cversion="1.2.3" condition="ARMSC300 CMSIS">
       <description>DEPRECATED: System and Startup for Generic Arm SC300 device</description>
       <files>
         <!-- include folder / device header file -->

--- a/Device/ARM/ARMSC000/Include/ARMSC000.h
+++ b/Device/ARM/ARMSC000/Include/ARMSC000.h
@@ -2,8 +2,8 @@
  * @file     ARMSC000.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMSC000 Device
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     10. Jan 2020
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -95,7 +95,7 @@ typedef enum IRQn
 #define __NVIC_PRIO_BITS          2U        /* Number of Bits used for Priority Levels */
 #define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */
 
-#include "core_SC000.h"                     /* Processor and core peripherals */
+#include "core_sc000.h"                     /* Processor and core peripherals */
 #include "system_ARMSC000.h"                /* System Header */
 
 

--- a/Device/ARM/ARMSC300/Include/ARMSC300.h
+++ b/Device/ARM/ARMSC300/Include/ARMSC300.h
@@ -2,8 +2,8 @@
  * @file     ARMSC300.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMSC300 Device
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     10. Jan 2020
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -95,7 +95,7 @@ typedef enum IRQn
 #define __NVIC_PRIO_BITS          3U        /* Number of Bits used for Priority Levels */
 #define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */
 
-#include "core_SC300.h"                     /* Processor and core peripherals */
+#include "core_sc300.h"                     /* Processor and core peripherals */
 #include "system_ARMSC300.h"                /* System Header */
 
 


### PR DESCRIPTION
 core_sc300.h should be included instead of core_SC300.h
