### PR TITLE
arm_add_q7: rewrite while-loop to for-loop. NFC.

### DIFF
--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q7.c
@@ -140,15 +140,10 @@ void arm_add_q7(
 
 #endif /* #if defined (ARM_MATH_LOOPUNROLL) */
 
-  while (blkCnt > 0U)
+  for (int i = 0; i < blkCnt; i++)
   {
     /* C = A + B */
-
-    /* Add and store result in destination buffer. */
-    *pDst++ = (q7_t) __SSAT((q15_t) *pSrcA++ + *pSrcB++, 8);
-
-    /* Decrement loop counter */
-    blkCnt--;
+    pDst[i] = (q7_t) __SSAT((q15_t) pSrcA[i] + pSrcB[i], 8);
   }
 
 }


### PR DESCRIPTION
Non-functional change to rewrite this counting down while-loop into a for-loop,
and also using array indexing instead of pointer arithmetic.

This is a little experiment how you guys feel about simplifying this code: I
hope it's easy to agree that first of all this increases readability of the
code and, believe it or not, makes the life of the compiler and
auto-vectorisation easier. I am in the process of fixing the vectoriser who is
struggling with this counting down loop (in the context of MVE and
tail-predication), but thought that a rewrite of this loop would be good too.

If we like this, I think I will give a few more kernels a similar treatment.