### PR TITLE
Removed unnecessary casts

### DIFF
--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7.c
@@ -146,7 +146,7 @@ arm_fully_connected_q7(const q7_t * pV,
         {
             q31_t     inV1, inV2, inM11, inM12;
 
-            pB = (q7_t *) read_and_pad_reordered((void *)pB, &inM11, &inM12);
+            pB = read_and_pad_reordered(pB, &inM11, &inM12);
 
             inV1 = *__SIMD32(pA)++;
             sum = __SMLAD(inV1, inM11, sum);


### PR DESCRIPTION
Casting using **void*** gives a compiler error (on _arm-none-eabi-g++_), as it discards the **const qualifier**.
**void*** cast is not needed since **read_and_pad_reordered**'s first parameter is **const q7_t***
Also, **read_and_pad_reordered** returns **const q7_t***, so the **q7_t*** cast is not needed since variable **pB** is already **const q7_t***.