### PR TITLE
fixed unused variable error for arm_convolve_s8_1x1_fast

### DIFF
--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -144,6 +144,7 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
 
 #elif defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
     int32_t i_element;
+    (void)input_x;
     (void)input_y;
 
     /* Partial(two columns) im2col buffer */


### PR DESCRIPTION
The **input_x** is unused just as the **input_y** when in **ARM_MATH_LOOPUNROLL** and **ARM_MATH_DSP** mode