### PR TITLE
CMSIS-DSP: Corrected issues 773 and 774

### DIFF
--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -2264,11 +2264,9 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
              /**< Heap sort      */
     ARM_SORT_INSERTION = 3,
              /**< Insertion sort */
-    ARM_SORT_MERGE     = 4,
-             /**< Merge sort     */
-    ARM_SORT_QUICK     = 5,
+    ARM_SORT_QUICK     = 4,
              /**< Quick sort     */
-    ARM_SORT_SELECTION = 6
+    ARM_SORT_SELECTION = 5
              /**< Selection sort */
   } arm_sort_alg;
 
@@ -2315,6 +2313,37 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
     arm_sort_dir dir); 
 
   /**
+   * @brief Instance structure for the sorting algorithms.
+   */
+  typedef struct            
+  {
+    arm_sort_dir dir;        /**< Sorting order (direction)  */
+    float32_t * buffer;      /**< Working buffer */
+  } arm_merge_sort_instance_f32;  
+
+  /**
+   * @param[in]      S          points to an instance of the sorting structure.
+   * @param[in,out]  pSrc       points to the block of input data.
+   * @param[out]     pDst       points to the block of output data
+   * @param[in]      blockSize  number of samples to process.
+   */
+  void arm_merge_sort_f32(
+    const arm_merge_sort_instance_f32 * S,
+          float32_t *pSrc,
+          float32_t *pDst,
+          uint32_t blockSize);
+
+  /**
+   * @param[in,out]  S            points to an instance of the sorting structure.
+   * @param[in]      dir          Sorting order.
+   * @param[in]      buffer       Working buffer.
+   */
+  void arm_merge_sort_init_f32(
+    arm_merge_sort_instance_f32 * S,
+    arm_sort_dir dir,
+    float32_t * buffer);
+
+  /**
    * @brief Struct for specifying cubic spline type
    */
   typedef enum
@@ -2330,6 +2359,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
   {
     uint32_t n_x;              /**< Number of known data points */
     arm_spline_type type;      /**< Type (boundary conditions) */
+    float32_t * buffer;
   } arm_spline_instance_f32;
 
   /**
@@ -2347,7 +2377,7 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
     const float32_t * y,
     const float32_t * xq,
           float32_t * pDst,
-	  uint32_t blockSize);
+          uint32_t blockSize);
 
   /**
    * @brief Initialization function for the floating-point cubic spline interpolation.
@@ -2358,7 +2388,8 @@ __STATIC_INLINE q31_t arm_div_q63_to_q31(q63_t num, q31_t den)
   void arm_spline_init_f32(
     arm_spline_instance_f32 * S,
     uint32_t n,
-    arm_spline_type type);
+    arm_spline_type type,
+    float32_t * buffer);
 
   /**
    * @brief Instance structure for the floating-point matrix structure.

--- a/CMSIS/DSP/PrivateInclude/arm_sorting.h
+++ b/CMSIS/DSP/PrivateInclude/arm_sorting.h
@@ -74,18 +74,6 @@ extern "C"
    * @param[out] pDst       points to the block of output data
    * @param[in]  blockSize  number of samples to process.
    */
-  void arm_merge_sort_f32(
-    const arm_sort_instance_f32 * S, 
-          float32_t *pSrc, 
-          float32_t *pDst, 
-    uint32_t blockSize);
-
-  /**
-   * @param[in]  S          points to an instance of the sorting structure.
-   * @param[in]  pSrc       points to the block of input data.
-   * @param[out] pDst       points to the block of output data
-   * @param[in]  blockSize  number of samples to process.
-   */
   void arm_quick_sort_f32(
     const arm_sort_instance_f32 * S, 
           float32_t * pSrc, 

--- a/CMSIS/DSP/Source/SupportFunctions/arm_merge_sort_f32.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_merge_sort_f32.c
@@ -92,24 +92,35 @@ static void arm_merge_sort_core_f32(float32_t * pB, uint32_t begin, uint32_t end
    *               divide the input array in sublists and merge them to produce
    *               longer sorted sublists until there is only one list remaining.
    *
-   * @par          A work array is always needed, hence pSrc and pDst cannot be
-   *               equal and the results will be stored in pDst.
+   * @par          A work array is always needed. It must be allocated by the user 
+   *               linked to the instance at initialization time.
+   *
+   * @par          It's an in-place algorithm. In order to obtain an out-of-place
+   *               function, a memcpy of the source vector is performed
    */
 
 
 void arm_merge_sort_f32(
-  const arm_sort_instance_f32 * S, 
+  const arm_merge_sort_instance_f32 * S, 
         float32_t *pSrc, 
         float32_t *pDst, 
         uint32_t blockSize)
 {
-    // A work array is needed: pDst
-    if(pSrc != pDst) // out-of-place only
-    {
-	memcpy(pDst, pSrc, blockSize*sizeof(float32_t));
+    float32_t * pA;
 
-	arm_merge_sort_core_f32(pSrc, 0, blockSize, pDst, S->dir);
+    /* Out-of-place */ 
+    if(pSrc != pDst)
+    {
+        memcpy(pDst, pSrc, blockSize*sizeof(float32_t));
+        pA = pDst;
     }
+    else
+        pA = pSrc;
+
+    /* A working buffer is needed */
+    memcpy(S->buffer, pSrc, blockSize*sizeof(float32_t));
+
+    arm_merge_sort_core_f32(S->buffer, 0, blockSize, pA, S->dir);
 }
 /**
   @} end of Sorting group

--- a/CMSIS/DSP/Source/SupportFunctions/arm_merge_sort_init_f32.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_merge_sort_init_f32.c
@@ -1,0 +1,35 @@
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS DSP Library
+ * Title:        arm_merge_sort_init_f32.c
+ * Description:  Floating point merge sort initialization function
+ *
+ * $Date:        2019
+ * $Revision:    V1.6.0
+ *
+ * Target Processor: Cortex-M and Cortex-A cores
+ * -------------------------------------------------------------------- */
+/*
+ * Copyright (C) 2010-2019 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "arm_math.h"
+
+void arm_merge_sort_init_f32(arm_merge_sort_instance_f32 * S, arm_sort_dir dir, float32_t * buffer)
+{
+    S->dir    = dir;
+    S->buffer = buffer;
+}

--- a/CMSIS/DSP/Source/SupportFunctions/arm_sort_f32.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_sort_f32.c
@@ -66,10 +66,6 @@ void arm_sort_f32(
         arm_insertion_sort_f32(S, pSrc, pDst, blockSize);
         break;
 
-        case ARM_SORT_MERGE:
-        arm_merge_sort_f32(S, pSrc, pDst, blockSize);
-        break;
-
         case ARM_SORT_QUICK:
         arm_quick_sort_f32(S, pSrc, pDst, blockSize);
         break;

--- a/CMSIS/DSP/Source/SupportFunctions/arm_spline_interp_init_f32.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_spline_interp_init_f32.c
@@ -47,15 +47,16 @@
 void arm_spline_init_f32(
     arm_spline_instance_f32 * S, 
     uint32_t n, 
-    arm_spline_type type)
+    arm_spline_type type,
+    float32_t * buffer)
 {
-    S->n_x    = n;
-    S->type   = type;
-
+    S->n_x  = n;
+    S->type = type;
     /* Type (boundary conditions):
-     *   0: Natural spline          ( S1''(x1)=0 ; Sn''(xn)=0 )
-     *   1: Parabolic runout spline ( S1''(x1)=S2''(x2) ; Sn-1''(xn-1)=Sn''(xn) )
+     *  - Natural spline          ( S1''(x1)=0 ; Sn''(xn)=0 )
+     *  - Parabolic runout spline ( S1''(x1)=S2''(x2) ; Sn-1''(xn-1)=Sn''(xn) )
      */
+    S->buffer = buffer;
 }
 
 /**

--- a/CMSIS/DSP/Testing/Include/Tests/SupportTestsF32.h
+++ b/CMSIS/DSP/Testing/Include/Tests/SupportTestsF32.h
@@ -12,9 +12,10 @@ class SupportTestsF32:public Client::Suite
             Client::Pattern<float32_t> input;
             Client::Pattern<float32_t> coefs;
 
-	    Client::Pattern<float32_t> inputX;
-	    Client::Pattern<float32_t> inputY;
-	    Client::Pattern<float32_t> outputX;
+            Client::Pattern<float32_t> inputX;
+            Client::Pattern<float32_t> inputY;
+            Client::Pattern<float32_t> outputX;
+            Client::Pattern<float32_t> buffer;
 
             Client::LocalPattern<float32_t> output;
             Client::LocalPattern<q15_t> outputQ15;

--- a/CMSIS/DSP/Testing/Source/Tests/SupportTestsF32.cpp
+++ b/CMSIS/DSP/Testing/Source/Tests/SupportTestsF32.cpp
@@ -297,11 +297,12 @@
     {
        float32_t *inp = input.ptr();
        float32_t *outp = output.ptr();
-       arm_sort_instance_f32 S;
+       float32_t *buf = buffer.ptr();
+       buf = (float32_t *)malloc((this->nbSamples)*sizeof(float32_t) );
+       arm_merge_sort_instance_f32 S;
 
-       arm_sort_init_f32(&S, ARM_SORT_MERGE, ARM_SORT_ASCENDING);
-
-       arm_sort_f32(&S,inp,outp,this->nbSamples);
+       arm_merge_sort_init_f32(&S, ARM_SORT_ASCENDING, buf);
+       arm_merge_sort_f32(&S,inp,outp,this->nbSamples);
         
        ASSERT_EMPTY_TAIL(output);
 
@@ -313,11 +314,12 @@
     {
        float32_t *inp = input.ptr();
        float32_t *outp = output.ptr();
-       arm_sort_instance_f32 S;
+       float32_t *buf = buffer.ptr();
+       buf = (float32_t *)malloc((this->nbSamples)*sizeof(float32_t) );
+       arm_merge_sort_instance_f32 S;
 
-       arm_sort_init_f32(&S, ARM_SORT_MERGE, ARM_SORT_ASCENDING);
-
-       arm_sort_f32(&S,inp,outp,this->nbSamples);
+       arm_merge_sort_init_f32(&S, ARM_SORT_ASCENDING, buf);
+       arm_merge_sort_f32(&S,inp,outp,this->nbSamples);
         
        ASSERT_EMPTY_TAIL(output);
 
@@ -424,10 +426,11 @@
        const float32_t *inpY = inputY.ptr();
        const float32_t *outX = outputX.ptr();
        float32_t *outp = output.ptr();
-
+       float32_t *buf = buffer.ptr();
+       buf=(float32_t*)malloc((3*4-1)*sizeof(float32_t));
        arm_spline_instance_f32 S;
 
-       arm_spline_init_f32(&S, 4, ARM_SPLINE_PARABOLIC_RUNOUT);
+       arm_spline_init_f32(&S, 4, ARM_SPLINE_PARABOLIC_RUNOUT, buf);
        arm_spline_f32(&S, inpX, inpY, outX, outp, 20);
 
        ASSERT_EMPTY_TAIL(output);
@@ -440,10 +443,11 @@
        const float32_t *inpY = inputY.ptr();
        const float32_t *outX = outputX.ptr();
        float32_t *outp = output.ptr();
-
+       float32_t *buf = buffer.ptr();
+       buf=(float32_t*)malloc((3*9-1)*sizeof(float32_t));
        arm_spline_instance_f32 S;
 
-       arm_spline_init_f32(&S, 9, ARM_SPLINE_NATURAL);
+       arm_spline_init_f32(&S, 9, ARM_SPLINE_NATURAL, buf);
        arm_spline_f32(&S, inpX, inpY, outX, outp, 33);
 
        ASSERT_EMPTY_TAIL(output);
@@ -456,10 +460,11 @@
        const float32_t *inpY = inputY.ptr();
        const float32_t *outX = outputX.ptr();
        float32_t *outp = output.ptr();
-
+       float32_t *buf = buffer.ptr();
+       buf=(float32_t*)malloc((3*3-1)*sizeof(float32_t));
        arm_spline_instance_f32 S;
 
-       arm_spline_init_f32(&S, 3, ARM_SPLINE_PARABOLIC_RUNOUT);
+       arm_spline_init_f32(&S, 3, ARM_SPLINE_PARABOLIC_RUNOUT, buf);
        arm_spline_f32(&S, inpX, inpY, outX, outp, 30);
 
        ASSERT_EMPTY_TAIL(output);


### PR DESCRIPTION
- Added working buffer for spline interpolation f32 that must be allocated by the user
- Added working buffer for merge sort f32 (and removed function from arm_sort_f32 since the instance has different fields) that must be allocated by the user