### PR TITLE
CMSIS-NN: 1xN conv support for MVE

### DIFF
--- a/CMSIS/DoxyGen/NN/src/history.txt
+++ b/CMSIS/DoxyGen/NN/src/history.txt
@@ -39,6 +39,7 @@
         <li>arm_nn_depthwise_conv_s8_core/li>
         <li>arm_nn_mat_mul_core_4x_s8/li>
         <li>arm_nn_mat_mul_core_1x_s8/li>
+        <li>arm_convolve_1_x_n_s8/li>
       </ul>
     </td>
   </tr>

--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        15 January 2020
- * $Revision:    V.2.0.1
+ * $Date:        20 January 2020
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -261,6 +261,8 @@ arm_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
 /**
  * @brief General Matrix-multiplication without requantization for four rows and one column
  * @param[in]       row_elements  number of row elements
+ * @param[in]       offset        offset between rows. Can be the same as row_elements.
+ *                                For e.g, in a 1x1 conv scenario with stride as 1.
  * @param[in]       row_base      pointer to row operand
  * @param[in]       col_base      pointer to col operand
  * @param[out]      sum_col       pointer to store sum of column elements
@@ -279,6 +281,7 @@ arm_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
  *          sum_col += col_base[i]
 */
 arm_status arm_nn_mat_mul_core_4x_s8(const int32_t row_elements,
+                                     const int32_t offset,
                                      const int8_t *row_base,
                                      const int8_t *col_base,
                                      int32_t *const sum_col,

--- a/CMSIS/NN/README.md
+++ b/CMSIS/NN/README.md
@@ -10,23 +10,24 @@ Group | API | Base Operator | Input Constraints | Additional memory required for
 |:----| :---| :------------ | :---------------- | :--------------------------------------------------------| :-------------| :------------- | :------------- |
 |[Conv](https://arm-software.github.io/CMSIS_5/NN/html/group__NNConv.html)||||| |  ||
 ||arm_convolve_s8()|CONV|dilation = 1|4 * ker_x * ker_y * input_ch| Yes | Yes ||
-||arm_convolve_1x1_s8_fast() | CONV | dilation = 1 <br/> ker_x = 1, ker_y = 1 <br/> pad = 0<br/> stride = 1<br/> input_ch % 4 = 0| 4 * input_ch | Yes |No ||
+||arm_convolve_1x1_s8_fast() | CONV | dilation = 1 <br/> ker_x = 1, ker_y = 1 <br/> pad = 0<br/> stride = 1<br/> input_ch % 4 = 0| 4 * input_ch | Yes |Yes ||
+||arm_convolve_1_n_s8() | CONV | dilation = 1 <br/> output_y % 4 = 0 | No |Yes ||
 | | arm_depthwise_conv_s8() | DEPTHWISE_CONV | dilation = 1  | No|No|No||
 || arm_depthwise_conv_s8_opt()| DEPTHWISE_CONV | dilation = 1 <br/> depth_multiplier = 1 | DSP: 2 * ker_x * ker_y * input_ch <br/> MVE: 2 * DSP | Yes| Yes| Best case is when channels are multiple of 4 or <br/>at the least >= 4 |
 |[Fully Connected](https://arm-software.github.io/CMSIS_5/NN/html/group__FC.html)||||| |  | |
 || arm_fully_connected_s8() |FULLY CONNECTED & <br/> MAT MUL  | None | DSP: column length * 2 <br/> MVE: None | Yes | Yes | |
 |[Pooling](https://arm-software.github.io/CMSIS_5/NN/html/group__Pooling.html)||||| |  ||
-|| arm_avgpool_s8() | AVERAGE POOL | None | input_ch * output_x * 2 | Yes| No| Best case case is when channels are multiple of 4 or <br/> at the least >= 4 |
+|| arm_avgpool_s8() | AVERAGE POOL | None | input_ch * output_x * 2 | Yes| Yes| Best case case is when channels are multiple of 4 or <br/> at the least >= 4 |
 || arm_maxpool_s8() | MAX POOL | None | None | No| No|  |
-|| arm_maxpool_s8_opt() | MAX POOL | None | input_ch * output_x * 2 | Yes| No| Best case case is when channels are multiple of 4 or <br/> at the least >= 4 |
+|| arm_maxpool_s8_opt() | MAX POOL | None | input_ch * output_x * 2 | Yes|Yes| Best case case is when channels are multiple of 4 or <br/> at the least >= 4 |
 |[Softmax](https://arm-software.github.io/CMSIS_5/NN/html/group__Softmax.html)||||| |  ||
 ||arm_softmax_q7()| SOFTMAX | None | None | Yes | No | Not bit exact to TFLu but can be up to 70x faster |
-||arm_softmax_s8()| SOFTMAX | None | None | No | No | Bit exact to TFLu |
+||arm_softmax_s8()| SOFTMAX | None | None | No | Yes | Bit exact to TFLu |
 ||arm_softmax_u8()| SOFTMAX | None | None | No | No | Bit exact to TFLu |
 |[Misc](https://arm-software.github.io/CMSIS_5/NN/html/group__groupNN.html)||||| |  ||
 ||arm_reshape_s8()| SOFTMAX | None | None | No | No | |
-||arm_elementwise_add_s8()| ELEMENTWISE ADD | None | None | Yes| No| Reshape is not done in this function <br/> Only minor improvements are expected |
-||arm_elementwise_mul_s8()| ELEMENTWISE MUL | None | None | Yes| No| Reshape is not done in this function <br/> Only minor improvements are expected |
+||arm_elementwise_add_s8()| ELEMENTWISE ADD | None | None | Yes| Yes| Reshape is not done in this function <br/> Only minor improvements are expected |
+||arm_elementwise_mul_s8()| ELEMENTWISE MUL | None | None | Yes| Yes| Reshape is not done in this function <br/> Only minor improvements are expected |
 ||arm_relu_q7() | RELU | None | None | Yes| No|
 ||arm_relu6_s8() | RELU | None | None | Yes| No|
 |[Concat](https://arm-software.github.io/CMSIS_5/NN/html/group__groupNN.html)||||| |  ||

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_convolve_1_x_n_s8.c
+ * Description:  s8 version of 1xN convolution using symmetric quantization.
+ *
+ * $Date:        January 20 2020
+ * $Revision:    V.1.0.0
+ *
+ * Target Processor:  Cortex-M cores
+ *
+ * -------------------------------------------------------------------- */
+#include "arm_math.h"
+#include "arm_nnfunctions.h"
+#include "arm_nnsupportfunctions.h"
+
+/**
+ *  @ingroup groupNN
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+/*
+   * 1xN s8 convolution function.
+   *
+   * Refer header file for details.
+   *
+   */
+
+arm_status arm_convolve_1_x_n_s8(const q7_t *input,
+                                 const uint16_t input_x,
+                                 const uint16_t input_ch,
+                                 const uint16_t input_batches,
+                                 const q7_t *kernel,
+                                 const uint16_t output_ch,
+                                 const uint16_t kernel_x,
+                                 const uint16_t pad_x,
+                                 const uint16_t stride_x,
+                                 const int32_t *bias,
+                                 q7_t *output,
+                                 const int32_t *output_shift,
+                                 const int32_t *output_mult,
+                                 const int32_t out_offset,
+                                 const int32_t input_offset,
+                                 const int32_t out_activation_min,
+                                 const int32_t out_activation_max,
+                                 const uint16_t output_x,
+                                 q15_t *buffer_a)
+{
+    (void)input_batches;
+
+    arm_status status = ARM_MATH_SUCCESS;
+    if (output_x % 4 != 0)
+    {
+        status = ARM_MATH_SIZE_MISMATCH;
+        goto out;
+    }
+
+#if defined(ARM_MATH_MVEI)
+    for (int i_out_x = 0; i_out_x <= (output_x - 4); i_out_x += 4)
+    {
+        int32_t input_begin_idx[4];
+        int32_t ker_begin_idx[4];
+        int32_t ker_end_idx[4];
+
+        for (int i = 0; i < 4; i++)
+        {
+            const int32_t est_input_x_idx = stride_x * (i_out_x + i) - pad_x;
+            input_begin_idx[i] = MAX(0, est_input_x_idx);
+            ker_begin_idx[i] = MAX(0, -est_input_x_idx);
+            ker_end_idx[i] = MIN(kernel_x, input_x - est_input_x_idx);
+        }
+
+        for (int i_out_ch = 0; i_out_ch < output_ch; i_out_ch++)
+        {
+            int32x4_t s_offset;
+            int32_t acc[4];
+            if ((ker_begin_idx[0] != 0) || (ker_end_idx[3] != kernel_x))
+            {
+                int32_t sum_row[4];
+
+                (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[0] - ker_begin_idx[0]) * input_ch,
+                                                input + input_begin_idx[0] * input_ch,
+                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[0] * input_ch),
+                                                &sum_row[0],
+                                                &acc[0]);
+                (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[1] - ker_begin_idx[1]) * input_ch,
+                                                input + input_begin_idx[1] * input_ch,
+                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[1] * input_ch),
+                                                &sum_row[1],
+                                                &acc[1]);
+
+                (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[2] - ker_begin_idx[2]) * input_ch,
+                                                input + input_begin_idx[2] * input_ch,
+                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[2] * input_ch),
+                                                &sum_row[2],
+                                                &acc[2]);
+
+                (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[3] - ker_begin_idx[3]) * input_ch,
+                                                input + input_begin_idx[3] * input_ch,
+                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[3] * input_ch),
+                                                &sum_row[3],
+                                                &acc[3]);
+
+                s_offset = vldrwq_s32(sum_row);
+            }
+            else
+            {
+                int32_t sum_row;
+                (void)arm_nn_mat_mul_core_4x_s8(kernel_x * input_ch,
+                                                stride_x * input_ch,
+                                                input + input_begin_idx[0] * input_ch,
+                                                kernel + (input_ch * kernel_x * i_out_ch),
+                                                &sum_row,
+                                                acc);
+
+                s_offset = vdupq_n_s32(sum_row);
+            }
+            int32x4_t res = vldrwq_s32(acc);
+            s_offset = vmulq_n_s32(s_offset, input_offset);
+
+            res = vaddq_n_s32(res, bias[i_out_ch]);
+            res = vaddq_s32(res, s_offset);
+            res = arm_requantize_mve(res, output_mult[i_out_ch], output_shift[i_out_ch]);
+            res = vaddq_n_s32(res, out_offset);
+
+            res = vmaxq_s32(res, vdupq_n_s32(out_activation_min));
+            res = vminq_s32(res, vdupq_n_s32(out_activation_max));
+
+            const uint32x4_t scatter_offset = {0, output_ch, output_ch * 2, output_ch * 3};
+            vstrbq_scatter_offset_s32(output, scatter_offset, res);
+            output++;
+        }
+        output += (3 * output_ch);
+    }
+
+#else
+#define DIM_Y (1)
+    status = arm_convolve_s8(input, input_x, DIM_Y,
+                             input_ch, 1, kernel, output_ch,
+                             kernel_x, DIM_Y,
+                             pad_x, 0,
+                             stride_x, DIM_Y,
+                             bias, output,
+                             output_shift, output_mult,
+                             out_offset, input_offset,
+                             out_activation_min, out_activation_max,
+                             output_x, DIM_Y,
+                             buffer_a);
+#endif
+
+out:
+    /* Return to application */
+    return status;
+}
+
+int32_t arm_convolve_1_x_n_s8_get_buffer_size(const uint16_t input_ch,
+                                              const uint16_t kernel_x,
+                                              const uint16_t kernel_y)
+{
+#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    return (2 * input_ch * kernel_x * kernel_y) * sizeof(int16_t);
+#else
+    (void)input_ch;
+    (void)kernel_x;
+    (void)kernel_y;
+    return 0;
+#endif
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -91,6 +91,7 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
             int32_t temp_out[4];
 
             (void)arm_nn_mat_mul_core_4x_s8(input_ch,
+                                            input_ch,
                                             input + i_items * input_ch,
                                             kernel + i_out_ch * input_ch,
                                             &sum_row,

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mul_core_1x_s8.c
  * Description:  General Matrix-multiplication function
  *
- * $Date:        January 15, 2020
- * $Revision:    V.1.0.0
+ * $Date:        January 20, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -55,7 +55,7 @@ arm_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
     int32_t acc_n0 = 0;
     int32_t sum_tmp = 0;
 
-#if defined(ARM_MATH_MVEI)
+#if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
 
         __asm volatile (
            "   vldrb.8         q0, [%[col]], 16     \n"

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_4x_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_4x_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mul_core_4x_s8.c
  * Description:  General matrix multiplication function for MVE extension
  *
- * $Date:        January 15, 2020
- * $Revision:    V.1.0.0
+ * $Date:        January 20, 2020
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -46,6 +46,7 @@
    *
    */
 arm_status arm_nn_mat_mul_core_4x_s8(const int32_t row_elements,
+                                     const int32_t offset,
                                      const int8_t *row_base,
                                      const int8_t *col_base,
                                      int32_t *const sum_col,
@@ -57,40 +58,40 @@ arm_status arm_nn_mat_mul_core_4x_s8(const int32_t row_elements,
     int32_t acc_n3 = 0;
 
     const int8_t *ip_row_0 = row_base;
-    const int8_t *ip_row_1 = row_base + row_elements;
-    const int8_t *ip_row_2 = row_base + (2 * row_elements);
-    const int8_t *ip_row_3 = row_base + (3 * row_elements);
+    const int8_t *ip_row_1 = row_base + offset;
+    const int8_t *ip_row_2 = row_base + (2 * offset);
+    const int8_t *ip_row_3 = row_base + (3 * offset);
     int32_t sum_tmp = 0;
 
-#if defined(ARM_MATH_MVEI)
-        __asm volatile (
-           "   vldrb.8         q0, [%[col]], 16     \n"
-           "   wlstp.8         lr, %[cnt], 1f       \n"
-           "2:                                      \n"
-           "   vaddva.s8      %[sum], q0            \n"
-           "   vldrb.8         q1, [%[row0]], 16    \n"
-           "   vmladava.s8    %[out0], q0, q1       \n"
-           "   vldrb.8         q2, [%[row1]], 16    \n"
-           "   vmladava.s8     %[out1], q0, q2      \n"
-           "   vldrb.8         q3, [%[row2]], 16    \n"
-           "   vmladava.s8     %[out2], q0, q3      \n"
-           "   vldrb.8         q4, [%[row3]], 16    \n"
-           "   vmladava.s8     %[out3], q0, q4      \n"
-           "   vldrb.8         q0, [%[col]], 16     \n"
-           "   letp            lr, 2b               \n"
-           "1:                                      \n"
-           :[col] "+r"(col_base)
-           ,[sum] "+Te"(sum_tmp)
-           ,[row0] "+r"(ip_row_0)
-           ,[row1] "+r"(ip_row_1)
-           ,[row2] "+r"(ip_row_2)
-           ,[row3] "+r"(ip_row_3)
-           ,[out0] "+Te"(acc_n0)
-           ,[out1] "+Te"(acc_n1)
-           ,[out2] "+Te"(acc_n2)
-           ,[out3] "+Te"(acc_n3)
-           :[cnt] "r"(row_elements)
-           :"q0","q1", "q2","q3","q4", "memory", "r14");
+#if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
+    __asm volatile(
+        "   vldrb.8         q0, [%[col]], 16     \n"
+        "   wlstp.8         lr, %[cnt], 1f       \n"
+        "2:                                      \n"
+        "   vaddva.s8      %[sum], q0            \n"
+        "   vldrb.8         q1, [%[row0]], 16    \n"
+        "   vmladava.s8    %[out0], q0, q1       \n"
+        "   vldrb.8         q2, [%[row1]], 16    \n"
+        "   vmladava.s8     %[out1], q0, q2      \n"
+        "   vldrb.8         q3, [%[row2]], 16    \n"
+        "   vmladava.s8     %[out2], q0, q3      \n"
+        "   vldrb.8         q4, [%[row3]], 16    \n"
+        "   vmladava.s8     %[out3], q0, q4      \n"
+        "   vldrb.8         q0, [%[col]], 16     \n"
+        "   letp            lr, 2b               \n"
+        "1:                                      \n"
+        :[col] "+r"(col_base)
+        ,[sum] "+Te"(sum_tmp)
+        ,[row0] "+r"(ip_row_0)
+        ,[row1] "+r"(ip_row_1)
+        ,[row2] "+r"(ip_row_2)
+        ,[row3] "+r"(ip_row_3)
+        ,[out0] "+Te"(acc_n0)
+        ,[out1] "+Te"(acc_n1)
+        ,[out2] "+Te"(acc_n2)
+        ,[out3] "+Te"(acc_n3)
+        : [cnt] "r"(row_elements)
+        : "q0", "q1", "q2", "q3", "q4", "memory", "r14");
 #else
     for (int i = 0; i < row_elements; i++)
     {


### PR DESCRIPTION
1. MVE specific function for 1xN convolution.
2. Updated use of macro ARM_MATH_AUTOVECTORIZE
3. Updated history for new function that is added.

