### PR TITLE
CMSIS-DSP: Improved arm_quick_sort_f32

### DIFF
--- a/CMSIS/DSP/Testing/desc.txt
+++ b/CMSIS/DSP/Testing/desc.txt
@@ -325,9 +325,9 @@ group Root {
                 test_insertion_sort_f32 nb=16 const:test_insertion_sort_const_f32 
                 test_merge_sort_f32 nb=11 outofplace:test_merge_sort_out_f32 
                 test_merge_sort_f32 nb=16 const:test_merge_sort_const_f32 
-                disabled{test_quick_sort_f32 nb=11 outofplace:test_quick_sort_out_f32}
-                disabled{test_quick_sort_f32 nb=11 inplace:test_quick_sort_in_f32} 
-                disabled{test_quick_sort_f32 nb=16 const:test_quick_sort_const_f32}
+                test_quick_sort_f32 nb=11 outofplace:test_quick_sort_out_f32
+                test_quick_sort_f32 nb=11 inplace:test_quick_sort_in_f32 
+                test_quick_sort_f32 nb=16 const:test_quick_sort_const_f32
                 test_selection_sort_f32 nb=11 outofplace:test_selection_sort_out_f32 
                 test_selection_sort_f32 nb=11 inplace:test_selection_sort_in_f32
                 test_selection_sort_f32 nb=16 const:test_selection_sort_const_f32


### PR DESCRIPTION
Added function that return a computed pivot as soon as in the array there is not anything remaining to swap. In this way the computed value can be used to create correctly the sub-arrays and avoid infinite recursion in the case of a constant signal.

Improved documentation too.