### PR TITLE
Update ARMv81MML_DSP_DP_MVE_FP.h

### DIFF
--- a/Device/ARM/ARMv81MML/Include/ARMv81MML_DSP_DP_MVE_FP.h
+++ b/Device/ARM/ARMv81MML/Include/ARMv81MML_DSP_DP_MVE_FP.h
@@ -92,6 +92,8 @@ typedef enum IRQn
 #define __ARMv81MML_REV           0x0001U   /* Core revision r0p1 */
 #define __SAUREGION_PRESENT       1U        /* SAU regions present */
 #define __MPU_PRESENT             1U        /* MPU present */
+#define __PMU_PRESENT             1U        /* PMU present */
+#define __PMU_NUM_EVENTCNT        31U       /* Number of PMU event counters */  
 #define __VTOR_PRESENT            1U        /* VTOR present */
 #define __NVIC_PRIO_BITS          3U        /* Number of Bits used for Priority Levels */
 #define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */


### PR DESCRIPTION
Added macros for:
__PMU_PRESENT (set to 1 by default)
__PMU_NUM_EVENTCNT (set to 31 by default - max for Armv8.1-M)