### PR TITLE
core: add SPDX identifier

### DIFF
--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -10,6 +10,8 @@
 // Copyright (c) 2017-2019 IAR Systems
 // Copyright (c) 2017-2019 Arm Limited. All rights reserved. 
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/CMSIS/Core_A/Include/cmsis_iccarm.h
+++ b/CMSIS/Core_A/Include/cmsis_iccarm.h
@@ -10,6 +10,8 @@
 // Copyright (c) 2017-2018 IAR Systems
 // Copyright (c) 2018-2019 Arm Limited 
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Small fix to add SPDX id to 2 files that we found during the scan in core files.