### PR TITLE
CMSIS-NN/DSP: Remove ARM_MATH_LOOPUNROLL

### DIFF
--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnfunctions.h
  * Description:  Public header file for CMSIS NN Library
  *
- * $Date:        February 26, 2020
- * $Revision:    V.1.0.3
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.4
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -173,7 +173,7 @@ extern    "C"
    * @param[in]       output_x    output tensor width
    * @param[in]       output_y    output tensor height
    * @param[in]       buffer_a    pointer to buffer space used for input optimization(partial im2col) and is necessary
-   *                              when both ARM_MATH_LOOPUNROLL and ARM_MATH_DSP are defined.
+   *                              when ARM_MATH_DSP is defined.
    *                              Required space: (2 * input_ch * kernel_x * kernel_y) * sizeof(q15_t) bytes
    *                              Use arm_convolve_s8_get_buffer_size() to get the size.
    * @return     The function returns <code>ARM_MATH_SUCCESS</code>
@@ -569,7 +569,7 @@ extern    "C"
    * @param[in]      out_activation_max   Minimum value to clamp the output to. Range: int8
    * @param[in]      output_x             output tensor width
    * @param[in]      buffer_a             pointer to buffer space used for input optimization and is necessary
-   *                                      when both ARM_MATH_LOOPUNROLL and ARM_MATH_DSP are defined , but not ARM_MATH_MVEI.
+   *                                      when ARM_MATH_DSP is defined but not ARM_MATH_MVEI.
    *                                      Required space: 2 * input_ch * sizeof(q15_t) bytes
    *                                      Use arm_convolve_1_x_n_s8_get_buffer_size() to get the size
    * @return     The function returns either
@@ -1006,8 +1006,8 @@ extern    "C"
    * @param[in]       output_activation_max   Minimum value to clamp the output to. Range: int8
    * @param[in]       dilation_x   dilation along x. Not used. Dilation factor of 1 is used.
    * @param[in]       dilation_y   dilation along y. Not used. Dilation factor of 1 is used.
-   * @param[in]       buffer_a     Buffer for partial im2col optimization. This is mandatory when ARM_MATH_LOOPUNROLL and
-   *                               ARM_MATH_DSP are defined.
+   * @param[in]       buffer_a     Buffer for partial im2col optimization. This is mandatory when
+   *                               ARM_MATH_DSP is defined.
    *                               Required space: (2 * input_ch * kernel_x * kernel_y) * sizeof(q15_t) bytes
    *                               Use arm_depthwise_conv_s8_opt_get_buffer_size() to get the size.
    *
@@ -1118,7 +1118,7 @@ int32_t arm_depthwise_conv_s8_opt_get_buffer_size(const uint16_t input_ch,
    * @param[in]       output_activation_min        for clamping
    * @param[in]       output_activation_max        for clamping
    * @param[in]       vec_buffer                   pointer to buffer space used for optimization and is necessary
-   *                                               when both ARM_MATH_LOOPUNROLL and ARM_MATH_DSP are defined but not
+   *                                               when ARM_MATH_DSP is defined but not
    *                                               ARM_MATH_MVEI.
    *                                               Required space: col_dim * sizeof(q15_t) bytes
    *                                               Use arm_fully_connected_s8_get_buffer_size() to get the size.
@@ -1630,8 +1630,8 @@ extern    "C"
    * @param[in]       act_max            Max clamping
    * @param[in]       ch_src             number of input tensor channels
    * @param[in,out]   src                pointer to input tensor
-   * @param[in]       bufferA            temporary buffer used for optimization and is necessary  when both
-   *                                     ARM_MATH_LOOPUNROLL and ARM_MATH_DSP are defined.
+   * @param[in]       bufferA            temporary buffer used for optimization and is necessary when
+   *                                     ARM_MATH_DSP is defined.
    *                                     Required space: (ch_src * dim_dst_width) * sizeof(q15_t) bytes
    *                                     Use arm_avgpool_s8_get_buffer_size() to get the size
    * @param[in,out]   dst                pointer to output tensor

--- a/CMSIS/NN/Source/ActivationFunctions/arm_relu_q15.c
+++ b/CMSIS/NN/Source/ActivationFunctions/arm_relu_q15.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_relu_q15.c
  * Description:  Q15 version of ReLU
  *
- * $Date:        August 2019
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -54,7 +54,7 @@
 void arm_relu_q15(q15_t *data, uint16_t size)
 {
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
     /* Run the following code for M cores with DSP extension */
 
     uint16_t i = size >> 1;

--- a/CMSIS/NN/Source/ActivationFunctions/arm_relu_q7.c
+++ b/CMSIS/NN/Source/ActivationFunctions/arm_relu_q7.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_relu_q7.c
  * Description:  Q7 version of ReLU
  *
- * $Date:        August 2019
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -54,7 +54,7 @@
 void arm_relu_q7(q7_t *data, uint16_t size)
 {
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
     /* Run the following code for M cores with DSP extension */
 
     uint16_t i = size >> 2;

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s8.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_add_s8
  * Description:  Element wise add
  *
- * $Date:        October 2019
- * $Revision:    V.2.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -125,7 +125,7 @@ arm_elementwise_add_s8(const int8_t *input_1_vect,
   int32_t input_2;
   int32_t sum;
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
   int32_t a_1, b_1, a_2, b_2;
 
   int32_t offset_1_packed, offset_2_packed;

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_mul_s8
  * Description:  Element wise multiplication
  *
- * $Date:        December 16 2019
- * $Revision:    V.1.0.1
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.2
  *
  * Target Processor:  Cortex-M cores
  *
@@ -99,7 +99,7 @@ arm_elementwise_mul_s8(const int8_t *input_1_vect,
   int32_t input_2;
   int32_t mul_res;
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
   int32_t a_1, b_1, a_2, b_2;
 
   int32_t offset_1_packed, offset_2_packed;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1_x_n_s8.c
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
- * $Date:        January 20 2020
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -178,7 +178,7 @@ int32_t arm_convolve_1_x_n_s8_get_buffer_size(const uint16_t input_ch,
                                               const uint16_t kernel_x,
                                               const uint16_t kernel_y)
 {
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
     return (2 * input_ch * kernel_x * kernel_y) * sizeof(int16_t);
 #else
     (void)input_ch;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -19,10 +19,10 @@
 /* ----------------------------------------------------------------------
  * Project:      CMSIS NN Library
  * Title:        arm_convolve_s8.c
- * Description:	 s8 version of convolution using symmetric quantization.
+ * Description:  s8 version of convolution using symmetric quantization.
  *
- * $Date:        July 2019
- * $Revision:    V.0.0.1
+ * $Date:        February 27, 2020
+ * $Revision:    V.0.0.2
  *
  * Target Processor:  Cortex-M cores
  *
@@ -78,7 +78,7 @@ arm_status arm_convolve_s8(const q7_t *input,
     {
         input += i_batch * (input_x * input_y * input_ch);
         output += i_batch * (output_x * output_y * output_ch);
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
         int16_t i_out_y, i_out_x, i_ker_y, i_ker_x;
 
         /* Generate two columns from the input tensor a GEMM computation */
@@ -235,7 +235,7 @@ int32_t arm_convolve_s8_get_buffer_size(const uint16_t input_ch,
                                         const uint16_t kernel_x,
                                         const uint16_t kernel_y)
 {
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
     return (2 * input_ch * kernel_x * kernel_y) * sizeof(int16_t);
 #else
     (void)input_ch;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
@@ -22,8 +22,8 @@
  * Description:  Optimized s8 depthwise separable convolution function for
  *               channel multiplier of 1.
  *
- * $Date:        January 21, 2020
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -179,7 +179,7 @@ arm_status arm_depthwise_conv_s8_opt(const q7_t *input,
         }
     }
 
-#elif defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#elif defined(ARM_MATH_DSP)
     /* Run the following code in cores using DSP extension */
     (void)dilation_x;
     (void)dilation_y;
@@ -391,7 +391,7 @@ arm_status arm_depthwise_conv_s8_opt(const q7_t *input,
                                  dilation_x,
                                  dilation_y,
                                  NULL);
-#endif /* ARM_MATH_MVEI | (ARM_MATH_DSP & ARM_MATH_LOOPUNROLL) */
+#endif /* ARM_MATH_MVEI | ARM_MATH_DSP */
 
     /* Return to application */
     return ARM_MATH_SUCCESS;
@@ -403,7 +403,7 @@ int32_t arm_depthwise_conv_s8_opt_get_buffer_size(const uint16_t input_ch,
 {
 #if defined(ARM_MATH_MVEI)
     return (2 * input_ch * kernel_x * kernel_y) * sizeof(int16_t);
-#elif defined(ARM_MATH_LOOPUNROLL) && defined (ARM_MATH_DSP)
+#elif defined (ARM_MATH_DSP)
     return (input_ch * kernel_x * kernel_y) * sizeof(int16_t);
 #else
     (void)input_ch;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_kernel_s8_s16.c
  * Description:  Matrix-multiplication function for convolution
  *
- * $Date:        January 26 2020
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -216,7 +216,7 @@ q7_t *arm_nn_mat_mult_kernel_s8_s16(const q7_t *input_a,
 
     return out_1;
 
-#elif defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#elif defined(ARM_MATH_DSP)
     /* set up the second output pointers */
     q7_t *out_1 = out_0 + output_ch;
     const int32_t *bias = output_bias;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16_reordered.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16_reordered.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_kernel_s8_s16_reordered.c
  * Description:  Matrix-multiplication function for convolution with reordered columns
  *
- * $Date:        January 20, 2020
- * $Revision:    V.1.0.1
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.2
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -52,7 +52,7 @@ q7_t *arm_nn_mat_mult_kernel_s8_s16_reordered(const q7_t *input_a,
                                               const int32_t *const output_bias,
                                               q7_t *out_0)
 {
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
     /* set up the second output pointers */
     q7_t *out_1 = out_0 + output_ch;
     const int32_t *bias = output_bias;

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_q7_to_q15_no_shift.c
  * Description:  Converts the elements of the Q7 vector to Q15 vector without left-shift
  *
- * $Date:        17. January 2018
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -60,7 +60,7 @@ void arm_q7_to_q15_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t blockSize)
     const q7_t *pIn = pSrc;
     uint32_t  blkCnt;
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
     q31_t     in;
     q31_t     in1, in2;
     q31_t     out1, out2;

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,8 +22,8 @@
  * Description:  Converts the elements of the Q7 vector to a reordered Q15 vector with an added offset. The re-ordering
  *               is a signature of sign extension intrinsic(DSP extension).
  *
- * $Date:        18 December 2019
- * $Revision:    V.2.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -50,7 +50,7 @@
 void arm_q7_to_q15_reordered_with_offset(const q7_t *src, q15_t *dst, uint32_t block_size, q15_t offset)
 {
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
     uint32_t block_cnt;
     /* Run the below code for cores that support SIMD instructions  */
     q31_t in_q7x4;

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_q7_to_q15_with_offset.c
  * Description:  Converts the elements of the Q7 vector to Q15 vector with an added offset
  *
- * $Date:        18 December 2019
- * $Revision:    V.2.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -64,7 +64,7 @@ void arm_q7_to_q15_with_offset(const q7_t *src,
 
     block_cnt = block_size & 0x7;
 
-#elif defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#elif defined(ARM_MATH_DSP)
     /* Run the below code for cores that support SIMD instructions  */
     q31_t in_q7x4;
     q31_t in_q15x2_1;

--- a/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_avgpool_s8.c
  * Description:  Pooling function implementations
  *
- * $Date:        29. July 2019
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M and Cortex-A cores
  *
@@ -32,7 +32,7 @@
 #include "arm_nnfunctions.h"
 
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined (ARM_MATH_DSP) && !defined (ARM_MATH_MVEI)
+#if defined (ARM_MATH_DSP) && !defined (ARM_MATH_MVEI)
 
 static void buffer_scale_back_q15_to_q7(q15_t * buffer, q7_t * target, uint16_t length, uint16_t scale)
 {
@@ -260,7 +260,7 @@ arm_status arm_avgpool_s8(const int dim_src_height,
                           int8_t *dst)
 {
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined (ARM_MATH_DSP)
+#if defined (ARM_MATH_DSP)
 
     /* Run the following code for Cortex-M4 and Cortex-M7 */
 
@@ -393,7 +393,7 @@ arm_status arm_avgpool_s8(const int dim_src_height,
 int32_t arm_avgpool_s8_get_buffer_size(const int dim_dst_width,
                                        const int ch_src)
 {
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
     return (ch_src * dim_dst_width) * sizeof(int16_t);
 #else
     (void)dim_dst_width;

--- a/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8_opt.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8_opt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0dim_dst_width
  *
@@ -21,8 +21,8 @@
  * Title:        arm_max_pool_s8_opt.c
  * Description:  Pooling function implementations
  *
- * $Date:        25 November 2019
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M
  *
@@ -31,7 +31,7 @@
 #include "arm_math.h"
 #include "arm_nnfunctions.h"
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
 
 static void compare_and_replace_if_larger_q7(q7_t *base,
                                              const q7_t *target,
@@ -220,7 +220,7 @@ arm_status arm_max_pool_s8_opt(const uint16_t input_y,
                                int8_t *dst)
 {
 
-#if defined(ARM_MATH_LOOPUNROLL) && defined(ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
 
     /* Run the following code for Cortex-M4 and Cortex-M7 */
     (void)tmp_buffer;

--- a/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_q7.c
+++ b/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_q7.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_softmax_q7.c
  * Description:  Q7 softmax function
  *
- * $Date:        20. February 2018
- * $Revision:    V.1.0.0
+ * $Date:        February 27, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -80,7 +80,7 @@
 
 void arm_softmax_q7(const q7_t * vec_in, const uint16_t dim_vec, q7_t * p_out )
 {
-#if defined(ARM_MATH_LOOPUNROLL) && defined (ARM_MATH_DSP)
+#if defined (ARM_MATH_DSP)
     q31_t     sum;
     int16_t   i;
     uint8_t   shift;


### PR DESCRIPTION
This macro must be supplied via build system, which might be hard for an end user to know, hence creating a non-optimal user experience.