### PR TITLE
Core-A: interrupt mode model on Cortex-A9

### DIFF
--- a/CMSIS/Core_A/Include/irq_ctrl.h
+++ b/CMSIS/Core_A/Include/irq_ctrl.h
@@ -78,6 +78,12 @@ typedef int32_t IRQn_ID_t;
 #define IRQ_MODE_CPU_6              (0x40UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 6
 #define IRQ_MODE_CPU_7              (0x80UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 7
 
+// Encoding in some early GIC implementations
+#define IRQ_MODE_MODEL_Pos          (13U)
+#define IRQ_MODE_MODEL_Msk          (0x1UL << IRQ_MODE_MODEL_Pos)
+#define IRQ_MODE_MODEL_NN			(0x0UL << IRQ_MODE_MODEL_Pos)	  ///< Corresponding interrupt is handled using the N-N model.
+#define IRQ_MODE_MODEL_1N			(0x1UL << IRQ_MODE_MODEL_Pos)	  ///< Corresponding interrupt is handled using the 1-N model.
+
 #define IRQ_MODE_ERROR              (0x80000000UL)                    ///< Bit indicating mode value error
 
 /* Interrupt priority bit-masks */

--- a/CMSIS/Core_A/Include/irq_ctrl.h
+++ b/CMSIS/Core_A/Include/irq_ctrl.h
@@ -81,8 +81,8 @@ typedef int32_t IRQn_ID_t;
 // Encoding in some early GIC implementations
 #define IRQ_MODE_MODEL_Pos          (13U)
 #define IRQ_MODE_MODEL_Msk          (0x1UL << IRQ_MODE_MODEL_Pos)
-#define IRQ_MODE_MODEL_NN           (0x0UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the N-N model.
-#define IRQ_MODE_MODEL_1N           (0x1UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the 1-N model.
+#define IRQ_MODE_MODEL_NN           (0x0UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the N-N model
+#define IRQ_MODE_MODEL_1N           (0x1UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the 1-N model
 
 #define IRQ_MODE_ERROR              (0x80000000UL)                    ///< Bit indicating mode value error
 

--- a/CMSIS/Core_A/Include/irq_ctrl.h
+++ b/CMSIS/Core_A/Include/irq_ctrl.h
@@ -81,8 +81,8 @@ typedef int32_t IRQn_ID_t;
 // Encoding in some early GIC implementations
 #define IRQ_MODE_MODEL_Pos          (13U)
 #define IRQ_MODE_MODEL_Msk          (0x1UL << IRQ_MODE_MODEL_Pos)
-#define IRQ_MODE_MODEL_NN			(0x0UL << IRQ_MODE_MODEL_Pos)	  ///< Corresponding interrupt is handled using the N-N model.
-#define IRQ_MODE_MODEL_1N			(0x1UL << IRQ_MODE_MODEL_Pos)	  ///< Corresponding interrupt is handled using the 1-N model.
+#define IRQ_MODE_MODEL_NN           (0x0UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the N-N model.
+#define IRQ_MODE_MODEL_1N           (0x1UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the 1-N model.
 
 #define IRQ_MODE_ERROR              (0x80000000UL)                    ///< Bit indicating mode value error
 

--- a/CMSIS/Core_A/Source/irq_ctrl_gic.c
+++ b/CMSIS/Core_A/Source/irq_ctrl_gic.c
@@ -130,7 +130,6 @@ __WEAK uint32_t IRQ_GetEnableState (IRQn_ID_t irqn) {
 /// Configure interrupt request mode.
 __WEAK int32_t IRQ_SetMode (IRQn_ID_t irqn, uint32_t mode) {
   uint32_t val;
-  uint32_t valnn;
   uint8_t cfg;
   uint8_t secure;
   uint8_t cpu;
@@ -149,9 +148,9 @@ __WEAK int32_t IRQ_SetMode (IRQn_ID_t irqn, uint32_t mode) {
       status = -1;
     }
 
-    valnn = (mode & IRQ_MODE_MODEL_Msk);
-    if (valnn == IRQ_MODE_MODEL_1N) {
-    	cfg |= 1;   // 1-N model
+    val = (mode & IRQ_MODE_MODEL_Msk);
+    if (val == IRQ_MODE_MODEL_1N) {
+    	 cfg |= 1;   // 1-N model
     }
 
     // Check interrupt type

--- a/CMSIS/Core_A/Source/irq_ctrl_gic.c
+++ b/CMSIS/Core_A/Source/irq_ctrl_gic.c
@@ -222,7 +222,7 @@ __WEAK uint32_t IRQ_GetMode (IRQn_ID_t irqn) {
     }
 
     if (val & 1U) {
-    	mode |= IRQ_MODE_MODEL_1N;
+    	 mode |= IRQ_MODE_MODEL_1N;
     }
     // Get interrupt CPU targets
     mode |= GIC_GetTarget ((IRQn_Type)irqn) << IRQ_MODE_CPU_Pos;

--- a/CMSIS/Core_A/Source/irq_ctrl_gic.c
+++ b/CMSIS/Core_A/Source/irq_ctrl_gic.c
@@ -222,8 +222,9 @@ __WEAK uint32_t IRQ_GetMode (IRQn_ID_t irqn) {
       mode |= IRQ_MODE_TRIG_LEVEL;
     }
 
-    if (val & 1U)
+    if (val & 1U) {
     	mode |= IRQ_MODE_MODEL_1N;
+    }
     // Get interrupt CPU targets
     mode |= GIC_GetTarget ((IRQn_Type)irqn) << IRQ_MODE_CPU_Pos;
 

--- a/CMSIS/Core_A/Source/irq_ctrl_gic.c
+++ b/CMSIS/Core_A/Source/irq_ctrl_gic.c
@@ -150,8 +150,9 @@ __WEAK int32_t IRQ_SetMode (IRQn_ID_t irqn, uint32_t mode) {
     }
 
     valnn = (mode & IRQ_MODE_MODEL_Msk);
-    if (valnn == IRQ_MODE_MODEL_1N)
+    if (valnn == IRQ_MODE_MODEL_1N) {
     	cfg |= 1;   // 1-N model
+    }
 
     // Check interrupt type
     val = mode & IRQ_MODE_TYPE_Msk;

--- a/CMSIS/Core_A/Source/irq_ctrl_gic.c
+++ b/CMSIS/Core_A/Source/irq_ctrl_gic.c
@@ -130,6 +130,7 @@ __WEAK uint32_t IRQ_GetEnableState (IRQn_ID_t irqn) {
 /// Configure interrupt request mode.
 __WEAK int32_t IRQ_SetMode (IRQn_ID_t irqn, uint32_t mode) {
   uint32_t val;
+  uint32_t valnn;
   uint8_t cfg;
   uint8_t secure;
   uint8_t cpu;
@@ -147,6 +148,10 @@ __WEAK int32_t IRQ_SetMode (IRQn_ID_t irqn, uint32_t mode) {
       cfg = 0x00U;
       status = -1;
     }
+
+    valnn = (mode & IRQ_MODE_MODEL_Msk);
+    if (valnn == IRQ_MODE_MODEL_1N)
+    	cfg |= 1;   // 1-N model
 
     // Check interrupt type
     val = mode & IRQ_MODE_TYPE_Msk;
@@ -216,6 +221,8 @@ __WEAK uint32_t IRQ_GetMode (IRQn_ID_t irqn) {
       mode |= IRQ_MODE_TRIG_LEVEL;
     }
 
+    if (val & 1U)
+    	mode |= IRQ_MODE_MODEL_1N;
     // Get interrupt CPU targets
     mode |= GIC_GetTarget ((IRQn_Type)irqn) << IRQ_MODE_CPU_Pos;
 


### PR DESCRIPTION
Core-A: modifications for representation interrupt mode model on Renesas Cortex-A9 RZA1x CPUs