### PR TITLE
Fixed macro error

### DIFF
--- a/CMSIS/DoxyGen/Driver/src/Driver_SAI.c
+++ b/CMSIS/DoxyGen/Driver/src/Driver_SAI.c
@@ -281,6 +281,9 @@ The <b>MCLK pin</b> setting requested with the function \ref ARM_SAI_Control is 
 \def ARM_SAI_ERROR_MCLK_PRESCALER       
 The <b>MCLK prescaler</b> requested with the function \ref ARM_SAI_Control is not supported.
 
+\def ARM_SAI_ERROR_FRAME_LENGTH
+The <b>frame length</b> requested with the function \ref ARM_SAI_Control is not supported.
+
 \def ARM_SAI_ERROR_FRAME_LENGHT
 The <b>frame length</b> requested with the function \ref ARM_SAI_Control is not supported.
 

--- a/CMSIS/Driver/Include/Driver_SAI.h
+++ b/CMSIS/Driver/Include/Driver_SAI.h
@@ -173,7 +173,8 @@ extern "C"
 #define ARM_SAI_ERROR_AUDIO_FREQ            (ARM_DRIVER_ERROR_SPECIFIC - 8)     ///< Specified Audio frequency not supported
 #define ARM_SAI_ERROR_MCLK_PIN              (ARM_DRIVER_ERROR_SPECIFIC - 9)     ///< Specified MCLK Pin setting not supported
 #define ARM_SAI_ERROR_MCLK_PRESCALER        (ARM_DRIVER_ERROR_SPECIFIC - 10)    ///< Specified MCLK Prescaler not supported
-#define ARM_SAI_ERROR_FRAME_LENGHT          (ARM_DRIVER_ERROR_SPECIFIC - 11)    ///< Specified Frame length not supported
+#define ARM_SAI_ERROR_FRAME_LENGTH          (ARM_DRIVER_ERROR_SPECIFIC - 11)    ///< Specified Frame length not supported
+#define ARM_SAI_ERROR_FRAME_LENGHT          (ARM_DRIVER_ERROR_SPECIFIC - 11)    ///< Specified Frame length not supported (@deprecated)
 #define ARM_SAI_ERROR_FRAME_SYNC_WIDTH      (ARM_DRIVER_ERROR_SPECIFIC - 12)    ///< Specified Frame Sync width not supported
 #define ARM_SAI_ERROR_FRAME_SYNC_POLARITY   (ARM_DRIVER_ERROR_SPECIFIC - 13)    ///< Specified Frame Sync polarity not supported
 #define ARM_SAI_ERROR_FRAME_SYNC_EARLY      (ARM_DRIVER_ERROR_SPECIFIC - 14)    ///< Specified Frame Sync early not supported

--- a/CMSIS/Pack/Example/CMSIS_Driver/I2S_LPC18xx.c
+++ b/CMSIS/Pack/Example/CMSIS_Driver/I2S_LPC18xx.c
@@ -1313,7 +1313,7 @@ static int32_t I2S_Control (uint32_t control, uint32_t arg1, uint32_t arg2, I2S_
 
   // Frame length
   val = ((arg1 & ARM_SAI_FRAME_LENGTH_Msk) >> ARM_SAI_FRAME_LENGTH_Pos) + 1;
-  if ((val != 0U) && (val != (data_bits * 2))) { return ARM_SAI_ERROR_FRAME_LENGHT; }
+  if ((val != 0U) && (val != (data_bits * 2))) { return ARM_SAI_ERROR_FRAME_LENGTH; }
 
   // Audio Frequency
   if (master == 1U) {


### PR DESCRIPTION
Using @deprecated to notice the wrong one, and added the new .(View PR#873).