### PR TITLE
CMSIS_NN: Remove DSP extension optimization for avg pool

### DIFF
--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnfunctions.h
  * Description:  Public header file for CMSIS NN Library
  *
- * $Date:        February 27, 2020
- * $Revision:    V.1.0.4
+ * $Date:        March 4, 2020
+ * $Revision:    V.1.1.4
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -979,7 +979,7 @@ extern    "C"
                                        const int32_t dilation_x,
                                        const int32_t dilation_y,
                                        int16_t *buffer_a);
-    
+
 /**
    * @brief Optimized s8 depthwise convolution function with constraint that in_channel equals out_channel
    * @param[in]       input      pointer to input tensor. Range: int8, format: [H,W,in_ch]
@@ -1640,10 +1640,7 @@ extern    "C"
    *                                     <code>ARM_MATH_SUCCESS</code> - Successful operation
    *                                     <code>ARM_MATH_ARGUMENT_ERROR</code> - Implementation not available
    *
-   * @note This pooling function is input-destructive. Input data is undefined after calling this function.
-   *
    * @details
-   *    - The pooling function is implemented as split x-pooling then y-pooling.
    *    - Supported Framework: TensorFlow Lite
    *
    */

--- a/CMSIS/NN/README.md
+++ b/CMSIS/NN/README.md
@@ -29,7 +29,7 @@ Group | API | Base Operator | Input Constraints | Additional memory required for
 |[Fully Connected](https://arm-software.github.io/CMSIS_5/NN/html/group__FC.html)||||| |  | |
 || arm_fully_connected_s8() |FULLY CONNECTED & <br/> MAT MUL  | None | 0 | Yes | Yes | |
 |[Pooling](https://arm-software.github.io/CMSIS_5/NN/html/group__Pooling.html)||||| |  ||
-|| arm_avgpool_s8() | AVERAGE POOL | None | input_ch * output_x * 2 | Yes| Yes| Best case case is when channels are multiple of 4 or <br/> at the least >= 4 |
+|| arm_avgpool_s8() | AVERAGE POOL | None | None | No| Yes| Best case case is when channels are multiple of 4 or <br/> at the least >= 4 |
 || arm_maxpool_s8() | MAX POOL | None | None | No| No|  |
 || arm_maxpool_s8_opt() | MAX POOL | None | input_ch * output_x * 2 | Yes|Yes| Best case case is when channels are multiple of 4 or <br/> at the least >= 4 |
 |[Softmax](https://arm-software.github.io/CMSIS_5/NN/html/group__Softmax.html)||||| |  ||


### PR DESCRIPTION
The existing optimization(partial x and y) for DSP extension
is found not to be bit exact. As a first step, the optimization
is removed and will be replaced by a new optimization in the second
step.

