### PR TITLE
Issue #617, compiling error fix in local structure declarations.

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -132,22 +132,17 @@ __STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
 {
   extern void _start(void) __NO_RETURN;
   
-  typedef struct {
+  struct __copy_table_t{
     uint32_t const* src;
     uint32_t* dest;
     uint32_t  wlen;
-  } __copy_table_t;
+  } __copy_table_start__, __copy_table_end__;
   
-  typedef struct {
+  struct __zero_table_t{
     uint32_t* dest;
     uint32_t  wlen;
-  } __zero_table_t;
+  } __zero_table_start__, __zero_table_end__;
   
-  extern const __copy_table_t __copy_table_start__;
-  extern const __copy_table_t __copy_table_end__;
-  extern const __zero_table_t __zero_table_start__;
-  extern const __zero_table_t __zero_table_end__;
-
   for (__copy_table_t const* pTable = &__copy_table_start__; pTable < &__copy_table_end__; ++pTable) {
     for(uint32_t i=0u; i<pTable->wlen; ++i) {
       pTable->dest[i] = pTable->src[i];


### PR DESCRIPTION
Avoids global scope of the structures, as discussed in https://github.com/ARM-software/CMSIS_5/issues/617 