### PR TITLE
CMSIS-NN Add MVE support in requantization for a variant of DWC

### DIFF
--- a/ARM.CMSIS.pdsc
+++ b/ARM.CMSIS.pdsc
@@ -44,7 +44,7 @@
       CMSIS-Driver: 2.8.0
         - removed volatile from status related typedefs in APIs
         - enhanced WiFi Interface API with support for polling Socket Receive/Send
-      CMSIS-Pack: 
+      CMSIS-Pack:
         - added custom attribute to components that require custom implementation
       Devices:
         - ARMv81MML startup code recognizing __MVE_USED macro
@@ -3176,7 +3176,7 @@ and 8-bit Java bytecodes in Jazelle state.
         <file category="source"   name="CMSIS/DSP/Source/SupportFunctions/SupportFunctions.c"/>
         <file category="source"   name="CMSIS/DSP/Source/SVMFunctions/SVMFunctions.c"/>
         <file category="source"   name="CMSIS/DSP/Source/TransformFunctions/TransformFunctions.c"/>
-        
+
         <!-- Compute Library for Cortex-A -->
         <file category="header"   name="CMSIS/DSP/ComputeLibrary/Include/NEMath.h"        condition="ARMv7-A Device"/>
         <file category="source"   name="CMSIS/DSP/ComputeLibrary/Source/arm_cl_tables.c"  condition="ARMv7-A Device"/>
@@ -3184,7 +3184,7 @@ and 8-bit Java bytecodes in Jazelle state.
     </component>
 
     <!-- CMSIS-NN component -->
-    <component Cclass="CMSIS" Cgroup="NN Lib" Cversion="1.2.0" condition="CMSIS NN">
+    <component Cclass="CMSIS" Cgroup="NN Lib" Cversion="1.3.0" condition="CMSIS NN">
       <description>CMSIS-NN Neural Network Library</description>
       <files>
         <file category="doc" name="CMSIS/Documentation/NN/html/index.html"/>


### PR DESCRIPTION
1. MVE support is added to depthwise_conv_s8_mult_4() for requantization.
2. CMSIS version is bumped up in ARM.CMSIS.pdsc

