### PR TITLE
arm_max_pool_s8.c: use quotes instead of <> for arm_math.h include

### DIFF
--- a/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8.c
@@ -29,7 +29,7 @@
  * -------------------------------------------------------------------- */
 
 #include "arm_nnfunctions.h"
-#include <arm_math.h>
+#include "arm_math.h"
 
 /**
  *  @ingroup groupNN


### PR DESCRIPTION
This makes the `arm_math.h` include consistent with the rest of the files in CMSIS-NN, where `#include "arm_math.h` is used instead of `#include <arm_math.h>`.