### PR TITLE
CMSIS-NN: Use arithmetic shifting in arm_nn_mult

### DIFF
--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q15.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q15.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mult_q15.c
  * Description:  Q15 vector multiplication with variable output shifts
  *
- * $Date:        13. July 2018
- * $Revision:    V.1.0.0
+ * $Date:        29. April 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -93,10 +93,10 @@ void arm_nn_mult_q15(
     mul4 = (q31_t) ((q15_t) inA2 * (q15_t) inB2);
 
     /* saturate result to 16 bit */
-    out1 = (q15_t) __SSAT((mul1 + NN_ROUND(out_shift)) >> out_shift, 16);
-    out2 = (q15_t) __SSAT((mul2 + NN_ROUND(out_shift)) >> out_shift, 16);
-    out3 = (q15_t) __SSAT((mul3 + NN_ROUND(out_shift)) >> out_shift, 16);
-    out4 = (q15_t) __SSAT((mul4 + NN_ROUND(out_shift)) >> out_shift, 16);
+    out1 = (q15_t) __SSAT((q31_t) (mul1 + NN_ROUND(out_shift)) >> out_shift, 16);
+    out2 = (q15_t) __SSAT((q31_t) (mul2 + NN_ROUND(out_shift)) >> out_shift, 16);
+    out3 = (q15_t) __SSAT((q31_t) (mul3 + NN_ROUND(out_shift)) >> out_shift, 16);
+    out4 = (q15_t) __SSAT((q31_t) (mul4 + NN_ROUND(out_shift)) >> out_shift, 16);
 
     /* store the result */
 #ifndef ARM_MATH_BIG_ENDIAN
@@ -133,7 +133,7 @@ void arm_nn_mult_q15(
   {
     /* C = A * B */
     /* Multiply the inputs and store the result in the destination buffer */
-    *pDst++ = (q15_t) __SSAT((((q31_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 16);
+    *pDst++ = (q15_t) __SSAT(((q31_t) ((q31_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 16);
 
     /* Decrement the blockSize loop counter */
     blkCnt--;

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q7.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q7.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mult_q7.c
  * Description:  Q7 vector multiplication with variable output shifts
  *
- * $Date:        13. July 2018
- * $Revision:    V.1.0.0
+ * $Date:        29. April 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -76,10 +76,10 @@ void arm_nn_mult_q7(
   {
     /* C = A * B */
     /* Multiply the inputs and store the results in temporary variables */
-    out1 = (q7_t) __SSAT((((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
-    out2 = (q7_t) __SSAT((((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
-    out3 = (q7_t) __SSAT((((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
-    out4 = (q7_t) __SSAT((((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
+    out1 = (q7_t) __SSAT(((q15_t) ((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
+    out2 = (q7_t) __SSAT(((q15_t) ((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
+    out3 = (q7_t) __SSAT(((q15_t) ((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
+    out4 = (q7_t) __SSAT(((q15_t) ((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
 
     /* Store the results of 4 inputs in the destination buffer in single cycle by packing */
     *__SIMD32(pDst)++ = __PACKq7(out1, out2, out3, out4);
@@ -106,7 +106,7 @@ void arm_nn_mult_q7(
   {
     /* C = A * B */
     /* Multiply the inputs and store the result in the destination buffer */
-    *pDst++ = (q7_t) __SSAT((((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
+    *pDst++ = (q7_t) __SSAT(((q15_t) ((q15_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 8);
 
     /* Decrement the blockSize loop counter */
     blkCnt--;


### PR DESCRIPTION
Fixes #896.

I have not tested this directly. Let me know if a unit test is needed (I see some examples/instructions in the [UnitTest](https://github.com/ARM-software/CMSIS_5/tree/develop/CMSIS/NN/Tests/UnitTest) directory that I could follow). I've tested it indirectly through an example in the issue:

```C
#include <stdio.h>

int main() {
  int x = -32;
  printf("%d\n", (x >> 1));  // arithmetic shift
  printf("%d\n", (((int) x + 0u) >> 1));  // logical shift (becomes unsigned before shift)
  printf("%d\n", ((int) (x + 0u) >> 1));  // arithmetic shift (cast back to signed before shift)
  return 0;
}
```

Using `gcc` (version 7.5.0) this outputs:
```
-16
2147483632
-16
```

The middle line corresponds to the old code. The last line corresponds to the updated code. 

One question:

1. (see commit in PR)
```
(q15_t) __SSAT(((q31_t) ((q31_t) (*pSrcA++) * (*pSrcB++) + NN_ROUND(out_shift)) >> out_shift), 16);
```

2. (alternative)
```
(q15_t) __SSAT((((q31_t) (*pSrcA++) * (*pSrcB++) + (q31_t) NN_ROUND(out_shift)) >> out_shift), 16);
```

Is the second option better in any way? I think it is equivalent, and maybe clearer?