### PR TITLE
CMSIS-NN: Adopted the new API interface in convolution functions

### DIFF
--- a/CMSIS/NN/README.md
+++ b/CMSIS/NN/README.md
@@ -20,6 +20,7 @@ Fused Activation | No | Yes
 Group | API | Base Operator | Input Constraints | Additional memory required for <br/> optimizations (bytes) | DSP Optimized |  MVE Optimized | Other comments |
 |:----| :---| :------------ | :---------------- | :--------------------------------------------------------| :-------------| :------------- | :------------- |
 |[Conv](https://arm-software.github.io/CMSIS_5/NN/html/group__NNConv.html)||||| |  ||
+||arm_convolve_wrapper_s8()|CONV|dilation = 1|n.a.| Yes | Yes |The additional memory required depends on the optimal convolution function called|
 ||arm_convolve_s8()|CONV|dilation = 1|4 * ker_x * ker_y * input_ch| Yes | Yes ||
 ||arm_convolve_1x1_s8_fast() | CONV | dilation = 1 <br/> ker_x = 1, ker_y = 1 <br/> pad = 0<br/> stride = 1<br/> input_ch % 4 = 0| 0 | Yes |Yes ||
 ||arm_convolve_1_n_s8() | CONV | dilation = 1 <br/> output_y % 4 = 0 | No |Yes ||

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -21,13 +21,14 @@
  * Title:        arm_convolve_1_x_n_s8.c
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
- * $Date:        February 27, 2020
- * $Revision:    V.1.0.1
+ * $Date:        May 18, 2020
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
  * -------------------------------------------------------------------- */
 #include "arm_math.h"
+#include "arm_nn_types.h"
 #include "arm_nnfunctions.h"
 #include "arm_nnsupportfunctions.h"
 
@@ -47,36 +48,43 @@
    *
    */
 
-arm_status arm_convolve_1_x_n_s8(const q7_t *input,
-                                 const uint16_t input_x,
-                                 const uint16_t input_ch,
-                                 const uint16_t input_batches,
-                                 const q7_t *kernel,
-                                 const uint16_t output_ch,
-                                 const uint16_t kernel_x,
-                                 const uint16_t pad_x,
-                                 const uint16_t stride_x,
-                                 const int32_t *bias,
-                                 q7_t *output,
-                                 const int32_t *output_shift,
-                                 const int32_t *output_mult,
-                                 const int32_t out_offset,
-                                 const int32_t input_offset,
-                                 const int32_t out_activation_min,
-                                 const int32_t out_activation_max,
-                                 const uint16_t output_x,
-                                 q15_t *buffer_a)
+arm_status arm_convolve_1_x_n_s8(const cmsis_nn_context* ctx,
+                                 const cmsis_nn_conv_params* conv_params,
+                                 const cmsis_nn_per_channel_quant_params* quant_params,
+                                 const cmsis_nn_dims* input_dims,
+                                 const q7_t *input_data,
+                                 const cmsis_nn_dims* filter_dims,
+                                 const q7_t *filter_data,
+                                 const cmsis_nn_dims* bias_dims,
+                                 const int32_t *bias_data,
+                                 const cmsis_nn_dims* output_dims,
+                                 q7_t *output_data)
 {
-    (void)input_batches;
-
     arm_status status = ARM_MATH_SUCCESS;
-    if (output_x % 4 != 0)
+    if (output_dims->w % 4 != 0)
     {
         status = ARM_MATH_SIZE_MISMATCH;
         goto out;
     }
 
 #if defined(ARM_MATH_MVEI)
+    q15_t *buffer_a = (q15_t *)ctx->buf;
+
+    const uint16_t input_x   = input_dims->w;
+    const uint16_t kernel_x  = filter_dims->w;
+    const uint16_t output_x  = output_dims->w;
+    const uint16_t output_ch = output_dims->c;
+    const uint16_t input_ch  = input_dims->c;
+    const uint16_t pad_x     = conv_params->padding.w;
+    const uint16_t stride_x  = conv_params->stride.w;
+
+    const int32_t input_offset       = conv_params->input_offset;
+    const int32_t out_offset         = conv_params->output_offset;
+    const int32_t out_activation_min = conv_params->activation.min;
+    const int32_t out_activation_max = conv_params->activation.max;
+    int32_t *output_mult             = quant_params->multiplier;
+    int32_t *output_shift            = quant_params->shift;
+
     for (int i_out_x = 0; i_out_x <= (output_x - 4); i_out_x += 4)
     {
         int32_t input_begin_idx[4];
@@ -100,25 +108,25 @@ arm_status arm_convolve_1_x_n_s8(const q7_t *input,
                 int32_t sum_row[4];
 
                 (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[0] - ker_begin_idx[0]) * input_ch,
-                                                input + input_begin_idx[0] * input_ch,
-                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[0] * input_ch),
+                                                input_data + input_begin_idx[0] * input_ch,
+                                                filter_data + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[0] * input_ch),
                                                 &sum_row[0],
                                                 &acc[0]);
                 (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[1] - ker_begin_idx[1]) * input_ch,
-                                                input + input_begin_idx[1] * input_ch,
-                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[1] * input_ch),
+                                                input_data + input_begin_idx[1] * input_ch,
+                                                filter_data + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[1] * input_ch),
                                                 &sum_row[1],
                                                 &acc[1]);
 
                 (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[2] - ker_begin_idx[2]) * input_ch,
-                                                input + input_begin_idx[2] * input_ch,
-                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[2] * input_ch),
+                                                input_data + input_begin_idx[2] * input_ch,
+                                                filter_data + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[2] * input_ch),
                                                 &sum_row[2],
                                                 &acc[2]);
 
                 (void)arm_nn_mat_mul_core_1x_s8((ker_end_idx[3] - ker_begin_idx[3]) * input_ch,
-                                                input + input_begin_idx[3] * input_ch,
-                                                kernel + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[3] * input_ch),
+                                                input_data + input_begin_idx[3] * input_ch,
+                                                filter_data + (input_ch * kernel_x * i_out_ch) + (ker_begin_idx[3] * input_ch),
                                                 &sum_row[3],
                                                 &acc[3]);
 
@@ -129,8 +137,8 @@ arm_status arm_convolve_1_x_n_s8(const q7_t *input,
                 int32_t sum_row;
                 (void)arm_nn_mat_mul_core_4x_s8(kernel_x * input_ch,
                                                 stride_x * input_ch,
-                                                input + input_begin_idx[0] * input_ch,
-                                                kernel + (input_ch * kernel_x * i_out_ch),
+                                                input_data + input_begin_idx[0] * input_ch,
+                                                filter_data + (input_ch * kernel_x * i_out_ch),
                                                 &sum_row,
                                                 acc);
 
@@ -139,7 +147,7 @@ arm_status arm_convolve_1_x_n_s8(const q7_t *input,
             int32x4_t res = vldrwq_s32(acc);
             s_offset = vmulq_n_s32(s_offset, input_offset);
 
-            res = vaddq_n_s32(res, bias[i_out_ch]);
+            res = vaddq_n_s32(res, bias_data[i_out_ch]);
             res = vaddq_s32(res, s_offset);
             res = arm_requantize_mve(res, output_mult[i_out_ch], output_shift[i_out_ch]);
             res = vaddq_n_s32(res, out_offset);
@@ -148,25 +156,24 @@ arm_status arm_convolve_1_x_n_s8(const q7_t *input,
             res = vminq_s32(res, vdupq_n_s32(out_activation_max));
 
             const uint32x4_t scatter_offset = {0, output_ch, output_ch * 2, output_ch * 3};
-            vstrbq_scatter_offset_s32(output, scatter_offset, res);
-            output++;
+            vstrbq_scatter_offset_s32(output_data, scatter_offset, res);
+            output_data++;
         }
-        output += (3 * output_ch);
+        output_data += (3 * output_ch);
     }
 
 #else
-#define DIM_Y (1)
-    status = arm_convolve_s8(input, input_x, DIM_Y,
-                             input_ch, 1, kernel, output_ch,
-                             kernel_x, DIM_Y,
-                             pad_x, 0,
-                             stride_x, DIM_Y,
-                             bias, output,
-                             output_shift, output_mult,
-                             out_offset, input_offset,
-                             out_activation_min, out_activation_max,
-                             output_x, DIM_Y,
-                             buffer_a);
+    status = arm_convolve_s8(ctx,
+                             conv_params,
+                             quant_params,
+                             input_dims,
+                             input_data,
+                             filter_dims,
+                             filter_data,
+                             bias_dims,
+                             bias_data,
+                             output_dims,
+                             output_data);
 #endif
 
 out:
@@ -174,16 +181,14 @@ out:
     return status;
 }
 
-int32_t arm_convolve_1_x_n_s8_get_buffer_size(const uint16_t input_ch,
-                                              const uint16_t kernel_x,
-                                              const uint16_t kernel_y)
+int32_t arm_convolve_1_x_n_s8_get_buffer_size(const cmsis_nn_dims* input_dims,
+                                              const cmsis_nn_dims* filter_dims)
 {
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
-    return (2 * input_ch * kernel_x * kernel_y) * sizeof(int16_t);
+    return (2 * input_dims->c * filter_dims->w * filter_dims->h) * sizeof(int16_t);
 #else
-    (void)input_ch;
-    (void)kernel_x;
-    (void)kernel_y;
+    (void)input_dims;
+    (void)filter_dims;
     return 0;
 #endif
 }

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -21,14 +21,15 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast q7 version of 1x1 convolution (non-square shape)
  *
- * $Date:        7 February 2020
- * $Revision:    V.1.0.2
+ * $Date:        May 18 2020
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
  * -------------------------------------------------------------------- */
 
 #include "arm_nnfunctions.h"
+#include "arm_nn_types.h"
 
 #define DIM_KER_X (1U)
 #define DIM_KER_Y (1U)
@@ -49,39 +50,40 @@
    *
    */
 
-arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
-                                    const uint16_t input_x,
-                                    const uint16_t input_y,
-                                    const uint16_t input_ch,
-                                    const uint16_t input_batches,
-                                    const q7_t *kernel,
-                                    const uint16_t output_ch,
-                                    const uint16_t pad_x,
-                                    const uint16_t pad_y,
-                                    const uint16_t stride_x,
-                                    const uint16_t stride_y,
-                                    const int32_t *bias,
-                                    q7_t *output,
-                                    const int32_t *output_shift,
-                                    const int32_t *output_mult,
-                                    const int32_t out_offset,
-                                    const int32_t input_offset,
-                                    const int32_t out_activation_min,
-                                    const int32_t out_activation_max,
-                                    const uint16_t output_x,
-                                    const uint16_t output_y,
-                                    q15_t *buffer_a)
+arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context* ctx,
+                                    const cmsis_nn_conv_params* conv_params,
+                                    const cmsis_nn_per_channel_quant_params* quant_params,
+                                    const cmsis_nn_dims* input_dims,
+                                    const q7_t *input_data,
+                                    const cmsis_nn_dims* filter_dims,
+                                    const q7_t *filter_data,
+                                    const cmsis_nn_dims* bias_dims,
+                                    const int32_t *bias_data,
+                                    const cmsis_nn_dims* output_dims,
+                                    q7_t *output_data)
 {
-    if (input_ch % 4 != 0 ||
-        pad_x != 0 || pad_y != 0 ||
-        stride_x != 1 || stride_y != 1)
+    if (input_dims->c % 4 != 0 ||
+        conv_params->padding.w != 0 || conv_params->padding.h != 0 ||
+        conv_params->stride.w != 1 || conv_params->stride.h != 1)
     {
         return ARM_MATH_SIZE_MISMATCH;
     }
-#if defined(ARM_MATH_MVEI)
-    (void)buffer_a;
 
-    int32_t col_len = input_x * input_y * input_batches;
+    (void)ctx;
+    (void)filter_dims;
+    (void)bias_dims;
+
+#if defined(ARM_MATH_MVEI)
+
+    const int32_t col_len            = input_dims->w * input_dims->h * input_dims->n;
+    const int32_t output_ch          = output_dims->c;
+    const int32_t input_ch           = input_dims->c;
+    const int32_t input_offset       = conv_params->input_offset;
+    const int32_t out_offset         = conv_params->output_offset;
+    const int32_t out_activation_min = conv_params->activation.min;
+    const int32_t out_activation_max = conv_params->activation.max;
+    int32_t *output_mult             = quant_params->multiplier;
+    int32_t *output_shift            = quant_params->shift;
 
     for (int i_items = 0; i_items <= (col_len - 4); i_items += 4)
     {
@@ -92,13 +94,13 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
 
             (void)arm_nn_mat_mul_core_4x_s8(input_ch,
                                             input_ch,
-                                            input + i_items * input_ch,
-                                            kernel + i_out_ch * input_ch,
+                                            input_data + i_items * input_ch,
+                                            filter_data + i_out_ch * input_ch,
                                             &sum_row,
                                             temp_out);
             int32x4_t res = vldrwq_s32(temp_out);
 
-            res = vaddq_n_s32(res, bias[i_out_ch]);
+            res = vaddq_n_s32(res, bias_data[i_out_ch]);
             sum_row = sum_row * input_offset;
             res = vaddq_n_s32(res, sum_row);
             res = arm_requantize_mve(res, output_mult[i_out_ch], output_shift[i_out_ch]);
@@ -108,10 +110,10 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
             res = vminq_s32(res, vdupq_n_s32(out_activation_max));
 
             const uint32x4_t scatter_offset = {0, output_ch, output_ch * 2, output_ch * 3};
-            vstrbq_scatter_offset_s32(output, scatter_offset, res);
-            output++;
+            vstrbq_scatter_offset_s32(output_data, scatter_offset, res);
+            output_data++;
         }
-        output += (3 * output_ch);
+        output_data += (3 * output_ch);
     }
 
     /* Handle left over elements */
@@ -123,12 +125,12 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
 
             int32_t acc;
             (void)arm_nn_mat_mul_core_1x_s8(input_ch,
-                                            input + i_items * input_ch,
-                                            kernel + i_out_ch * input_ch,
+                                            input_data + i_items * input_ch,
+                                            filter_data + i_out_ch * input_ch,
                                             &sum_row,
                                             &acc);
 
-            acc += bias[i_out_ch];
+            acc += bias_data[i_out_ch];
             sum_row = (sum_row * input_offset);
             acc += sum_row;
             acc = arm_nn_requantize(acc, output_mult[i_out_ch], output_shift[i_out_ch]);
@@ -136,36 +138,30 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
 
             acc = MAX(acc, out_activation_min);
             acc = MIN(acc, out_activation_max);
-            *output++ = acc;
+            *output_data++ = acc;
         }
     }
 
 #else
     /* Run the following code as reference implementation for Cortex-M processors with or without DSP extension */
 
-    (void)input_x;
-    (void)input_y;
-    (void)output_x;
-    (void)output_y;
-    (void)buffer_a;
+    const int32_t lhs_rows = input_dims->w * input_dims->h * input_dims->n;
+    const int32_t rhs_rows = output_dims->c;
+    const int32_t rhs_cols = input_dims->c;
 
-    const int32_t lhs_rows = input_x * input_y * input_batches;
-    const int32_t rhs_rows = output_ch;
-    const int32_t rhs_cols = input_ch;
-
-    arm_nn_mat_mult_nt_t_s8(input,
-                            kernel,
-                            bias,
-                            output,
-                            output_mult,
-                            output_shift,
+    arm_nn_mat_mult_nt_t_s8(input_data,
+                            filter_data,
+                            bias_data,
+                            output_data,
+                            quant_params->multiplier,
+                            quant_params->shift,
                             lhs_rows,
                             rhs_rows,
                             rhs_cols,
-                            input_offset,
-                            out_offset,
-                            out_activation_min,
-                            out_activation_max);
+                            conv_params->input_offset,
+                            conv_params->output_offset,
+                            conv_params->activation.min,
+                            conv_params->activation.max);
 
 #endif
 
@@ -173,10 +169,9 @@ arm_status arm_convolve_1x1_s8_fast(const q7_t *input,
     return ARM_MATH_SUCCESS;
 }
 
-
-int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const uint16_t input_ch)
+int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims* input_dims)
 {
-    (void)input_ch;
+    (void)input_dims;
     return 0;
 }
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2020 Arm Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_convolve_wrapper_s8.c
+ * Description:  s8 convolution layer wrapper function with the main purpose to call the optimal kernel available in cmsis-nn to perform the convolution.
+ *
+ * $Date:        May 18, 2020
+ * $Revision:    V.1.0.0
+ *
+ * Target Processor:  Cortex-M cores
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnfunctions.h"
+#include "arm_nn_types.h"
+
+/**
+ *  @ingroup groupNN
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+/*
+   * Convolution layer
+   *
+   * Refer header file for details.
+   *
+   */
+
+arm_status arm_convolve_wrapper_s8(const cmsis_nn_context* ctx,
+                                   const cmsis_nn_conv_params* conv_params,
+                                   const cmsis_nn_per_channel_quant_params* quant_params,
+                                   const cmsis_nn_dims* input_dims,
+                                   const q7_t *input_data,
+                                   const cmsis_nn_dims* filter_dims,
+                                   const q7_t *filter_data,
+                                   const cmsis_nn_dims* bias_dims,
+                                   const int32_t *bias_data,
+                                   const cmsis_nn_dims* output_dims,
+                                   q7_t *output_data)
+{
+    if ((conv_params->padding.w == 0) &&
+        (conv_params->padding.h == 0) &&
+        (input_dims->c % 4 == 0) &&
+        (conv_params->stride.w == 1) &&
+        (conv_params->stride.h == 1) &&
+        (filter_dims->w == 1) &&
+        (filter_dims->h == 1))
+    {
+        return arm_convolve_1x1_s8_fast(ctx,
+                                        conv_params,
+                                        quant_params,
+                                        input_dims,
+                                        input_data,
+                                        filter_dims,
+                                        filter_data,
+                                        bias_dims,
+                                        bias_data,
+                                        output_dims,
+                                        output_data);
+    }
+    else if ((output_dims->h == 1) &&
+             (input_dims->h == 1) &&
+             (filter_dims->h == 1) &&
+             (output_dims->w % 4 == 0) &&
+             (input_dims->n == 1))
+    {
+        return arm_convolve_1_x_n_s8(ctx,
+                                     conv_params,
+                                     quant_params,
+                                     input_dims,
+                                     input_data,
+                                     filter_dims,
+                                     filter_data,
+                                     bias_dims,
+                                     bias_data,
+                                     output_dims,
+                                     output_data);
+    }
+    else
+    {
+        return arm_convolve_s8(ctx,
+                               conv_params,
+                               quant_params,
+                               input_dims,
+                               input_data,
+                               filter_dims,
+                               filter_data,
+                               bias_dims,
+                               bias_data,
+                               output_dims,
+                               output_data);
+    }
+}
+
+int32_t arm_convolve_wrapper_s8_get_buffer_size(const cmsis_nn_conv_params* conv_params,
+                                                const cmsis_nn_dims* input_dims,
+                                                const cmsis_nn_dims* filter_dims,
+                                                const cmsis_nn_dims* output_dims)
+{
+    if ((conv_params->padding.w == 0) &&
+        (conv_params->padding.h == 0) &&
+        (input_dims->c % 4 == 0) &&
+        (conv_params->stride.w == 1) &&
+        (conv_params->stride.h == 1) &&
+        (filter_dims->w == 1) &&
+        (filter_dims->h == 1))
+    {
+        return arm_convolve_1x1_s8_fast_get_buffer_size(input_dims);
+    }
+    else if ((output_dims->h == 1) &&
+             (input_dims->h == 1) &&
+             (filter_dims->h == 1) &&
+             (output_dims->w % 4 == 0) &&
+             (input_dims->n == 1))
+    {
+        return arm_convolve_1_x_n_s8_get_buffer_size(input_dims, filter_dims);
+    }
+    else
+    {
+        return arm_convolve_s8_get_buffer_size(input_dims, filter_dims);
+    }
+}
+
+/**
+ * @} end of NNConv group
+ */
+


### PR DESCRIPTION
The following functions have been ported to use the new API interface:
- arm_convolve_1_x_n_s8
- arm_convolve_1x1_s8_fast
- arm_convolve_s8

A wrapper function has been also created to make the integration of
those functions easier