### PR TITLE
Suggested solution to #925 (DelayStarted and DelayUntilStarted event update)

### DIFF
--- a/CMSIS/RTOS2/RTX/Include/rtx_evr.h
+++ b/CMSIS/RTOS2/RTX/Include/rtx_evr.h
@@ -872,9 +872,9 @@ extern void EvrRtxDelayUntil (uint32_t ticks);
   \param[in]  ticks         \ref CMSIS_RTOS_TimeOutValue "time ticks" value.
 */
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_WAIT != 0) && !defined(EVR_RTX_DELAY_STARTED_DISABLE))
-extern void EvrRtxDelayStarted (uint32_t ticks);
+extern void EvrRtxDelayStarted (uint32_t ticks, osThreadId_t thread_id);
 #else
-#define EvrRtxDelayStarted(ticks)
+#define EvrRtxDelayStarted(ticks, thread_id)
 #endif
 
 /**
@@ -882,9 +882,9 @@ extern void EvrRtxDelayStarted (uint32_t ticks);
   \param[in]  ticks         \ref CMSIS_RTOS_TimeOutValue "time ticks" value.
 */
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_WAIT != 0) && !defined(EVR_RTX_DELAY_UNTIL_STARTED_DISABLE))
-extern void EvrRtxDelayUntilStarted (uint32_t ticks);
+extern void EvrRtxDelayUntilStarted (uint32_t ticks, osThreadId_t thread_id);
 #else
-#define EvrRtxDelayUntilStarted(ticks)
+#define EvrRtxDelayUntilStarted(ticks, thread_id)
 #endif
 
 /**

--- a/CMSIS/RTOS2/RTX/RTX5.scvd
+++ b/CMSIS/RTOS2/RTX/RTX5.scvd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component_viewer schemaVersion="1.2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="Component_Viewer.xsd">
-  <component name="CMSIS:RTOS2:Keil RTX5" shortname="RTX5" version="5.5.2"/>    <!-- name and version of the component -->
+  <component name="CMSIS:RTOS2:Keil RTX5" shortname="RTX5" version="5.5.3"/>    <!-- name and version of the component -->
 
   <typedefs>
     <!-- Attributes structure for thread -->
@@ -1468,8 +1468,8 @@
     <event id="0xF300 + 0x00" level="Error"  property="DelayError"         value="status=%E[val1, rtx_t:status]" info="osDelay/osDelayUntil error occurred."/>
     <event id="0xF300 + 0x01" level="API"    property="Delay"              value="ticks=%d[val1]" info="osDelay function was called."/>
     <event id="0xF300 + 0x02" level="API"    property="DelayUntil"         value="ticks=%d[val1]" info="osDelayUntil function was called."/>
-    <event id="0xF300 + 0x03" level="Op"     property="DelayStarted"       value="ticks=%d[val1]" info="osDelay started."/>
-    <event id="0xF300 + 0x04" level="Op"     property="DelayUntilStarted"  value="ticks=%d[val1]" info="osDelayUntil started."/>
+    <event id="0xF300 + 0x03" level="Op"     property="DelayStarted"       value="ticks=%d[val1], thread_id=%x[val2]" info="osDelay started."/>
+    <event id="0xF300 + 0x04" level="Op"     property="DelayUntilStarted"  value="ticks=%d[val1], thread_id=%x[val2]" info="osDelayUntil started."/>
     <event id="0xF300 + 0x05" level="Op"     property="DelayCompleted"     value="thread_id=%x[val1]" info="osDelay/osDelayUntil completed."/>
 
     <event id="0xF600 + 0x00" level="Error"  property="TimerError"     value="timer_id=%x[val1], status=%E[val2, rtx_t:status]" info="Timer error occurred."/>

--- a/CMSIS/RTOS2/RTX/Source/rtx_delay.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_delay.c
@@ -31,10 +31,14 @@
 /// Wait for Timeout (Time Delay).
 /// \note API identical to osDelay
 static osStatus_t svcRtxDelay (uint32_t ticks) {
+  os_thread_t *thread;
 
   if (ticks != 0U) {
+    // Get running thread
+    thread = osRtxThreadGetRunning();
+  	
     if (osRtxThreadWaitEnter(osRtxThreadWaitingDelay, ticks)) {
-      EvrRtxDelayStarted(ticks);
+      EvrRtxDelayStarted(ticks, thread);
     } else {
       EvrRtxDelayCompleted(osRtxThreadGetRunning());
     }
@@ -46,6 +50,7 @@ static osStatus_t svcRtxDelay (uint32_t ticks) {
 /// Wait until specified time.
 /// \note API identical to osDelayUntil
 static osStatus_t svcRtxDelayUntil (uint32_t ticks) {
+  os_thread_t *thread;
 
   ticks -= osRtxInfo.kernel.tick;
   if ((ticks == 0U) || (ticks > 0x7FFFFFFFU)) {
@@ -54,8 +59,11 @@ static osStatus_t svcRtxDelayUntil (uint32_t ticks) {
     return osErrorParameter;
   }
 
+  // Get running thread
+  thread = osRtxThreadGetRunning();
+
   if (osRtxThreadWaitEnter(osRtxThreadWaitingDelay, ticks)) {
-    EvrRtxDelayUntilStarted(ticks);
+    EvrRtxDelayUntilStarted(ticks, thread);
   } else {
     EvrRtxDelayCompleted(osRtxThreadGetRunning());
   }

--- a/CMSIS/RTOS2/RTX/Source/rtx_evr.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_evr.c
@@ -1011,9 +1011,9 @@ __WEAK void EvrRtxDelayUntil (uint32_t ticks) {
 #endif
 
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_WAIT != 0) && !defined(EVR_RTX_DELAY_STARTED_DISABLE))
-__WEAK void EvrRtxDelayStarted (uint32_t ticks) {
+__WEAK void EvrRtxDelayStarted (uint32_t ticks, osThreadId_t thread_id) {
 #if defined(RTE_Compiler_EventRecorder)
-  (void)EventRecord2(EvtRtxDelayStarted, ticks, 0U);
+  (void)EventRecord2(EvtRtxDelayStarted, ticks, thread_id);
 #else
   (void)ticks;
 #endif
@@ -1021,9 +1021,9 @@ __WEAK void EvrRtxDelayStarted (uint32_t ticks) {
 #endif
 
 #if (!defined(EVR_RTX_DISABLE) && (OS_EVR_WAIT != 0) && !defined(EVR_RTX_DELAY_UNTIL_STARTED_DISABLE))
-__WEAK void EvrRtxDelayUntilStarted (uint32_t ticks) {
+__WEAK void EvrRtxDelayUntilStarted (uint32_t ticks, osThreadId_t thread_id) {
 #if defined(RTE_Compiler_EventRecorder)
-  (void)EventRecord2(EvtRtxDelayUntilStarted, ticks, 0U);
+  (void)EventRecord2(EvtRtxDelayUntilStarted, ticks, thread_id);
 #else
   (void)ticks;
 #endif


### PR DESCRIPTION
Here is a suggestion on updating DelayStarted and DelayUntilStarted to have them reference the thread they are referring to, since they occur after the thread is switched out.

Not sure if pull request should include updated version number of RTX5.scvd, but it is included.