### PR TITLE
CMSIS-NN: Fix warnings

### DIFF
--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q7.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_add_q7.c
@@ -1,15 +1,5 @@
-/* ----------------------------------------------------------------------
- * Project:      CMSIS DSP Library
- * Title:        arm_add_q7.c
- * Description:  Q7 vector addition
- *
- * $Date:        18. March 2019
- * $Revision:    V1.6.0
- *
- * Target Processor: Cortex-M cores
- * -------------------------------------------------------------------- */
 /*
- * Copyright (C) 2010-2019 ARM Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 ARM Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,6 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS DSP Library
+ * Title:        arm_add_q7.c
+ * Description:  Q7 vector addition
+ *
+ * $Date:        May 29, 2020
+ * $Revision:    V1.6.1
+ *
+ * Target Processor: Cortex-M cores
+ * -------------------------------------------------------------------- */
 
 #include "arm_math.h"
 

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -21,10 +21,10 @@
  * Title:        arm_nnfunctions.h
  * Description:  Public header file for CMSIS NN Library
  *
- * $Date:        May 25, 2020
- * $Revision:    V.5.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.5.0.1
  *
- * Target Processor:  Cortex-M cores
+ * Target Processor:  Cortex-M CPUs
  * -------------------------------------------------------------------- */
 
 /**
@@ -913,7 +913,7 @@ extern    "C"
    *
    * @param[in, out] ctx            Function context (e.g. temporary buffer). Check the function
    *                                definition file to see if an additional buffer is required.
-   *                                Optional function <API>_get_buffer_size() provides the buffer
+   *                                Optional function {API}_get_buffer_size() provides the buffer
    *                                size if required.
    * @param[in]      dw_conv_params Depthwise convolution parameters (e.g. strides, dilations, pads,...)
    *                                dw_conv_params->dilation is not used.
@@ -947,13 +947,13 @@ extern    "C"
                                             const cmsis_nn_dw_conv_params *dw_conv_params,
                                             const cmsis_nn_per_channel_quant_params *quant_params,
                                             const cmsis_nn_dims *input_dims,
-                                            const q7_t *input,
+                                            const q7_t *input_data,
                                             const cmsis_nn_dims *filter_dims,
-                                            const q7_t *kernel,
+                                            const q7_t *filter_data,
                                             const cmsis_nn_dims *bias_dims,
-                                            const int32_t *bias,
+                                            const int32_t *bias_data,
                                             const cmsis_nn_dims *output_dims,
-                                            q7_t *output);
+                                            q7_t *output_data);
 
    /**
    * @brief Get size of additional buffer required by arm_depthwise_conv_wrapper_s8()
@@ -979,7 +979,7 @@ extern    "C"
    *
    * @param[in, out] ctx            Function context (e.g. temporary buffer). Check the function
    *                                definition file to see if an additional buffer is required.
-   *                                Optional function <API>_get_buffer_size() provides the buffer
+   *                                Optional function {API}_get_buffer_size() provides the buffer
    *                                size if an additional buffer is required.
    *                                exists if additional memory is.
    * @param[in]      dw_conv_params Depthwise convolution parameters (e.g. strides, dilations, pads,...)
@@ -1139,7 +1139,7 @@ extern    "C"
    *
    * @param[in, out] ctx            Function context (e.g. temporary buffer). Check the function
    *                                definition file to see if an additional buffer is required.
-   *                                Optional function <API>_get_buffer_size() provides the buffer
+   *                                Optional function {API}_get_buffer_size() provides the buffer
    *                                size if an additional buffer is required.
    * @param[in]      fc_params      Fully Connected layer parameters (e.g. strides, dilations, pads,...)
    *                                Range of fc_params->input_offset  : [-127, 128]
@@ -1156,6 +1156,7 @@ extern    "C"
    *                                H & W : Not used
    * @param[in]      filter_data    Filter data pointer. Data type: int8
    * @param[in]      bias_dims      Bias tensor dimensions. Format: [C_OUT]
+   *                                N, H, W : Not used
    * @param[in]      bias_data      Bias data pointer. Data type: int32
    * @param[in]      output_dims    Output tensor dimensions. Format: [N, C_OUT]
    *                                N : Batches
@@ -1645,7 +1646,7 @@ extern    "C"
    *
    * @param[in, out] ctx            Function context (e.g. temporary buffer). Check the function
    *                                definition file to see if an additional buffer is required.
-   *                                Optional function <API>_get_buffer_size() provides the buffer
+   *                                Optional function {API}_get_buffer_size() provides the buffer
    *                                size if an additional buffer is required.
    * @param[in]      pool_params    Pooling parameters
    * @param[in]      input_dims     Input (activation) tensor dimensions. Format: [H, W, C_IN]

--- a/CMSIS/NN/Source/ActivationFunctions/arm_relu_q7.c
+++ b/CMSIS/NN/Source/ActivationFunctions/arm_relu_q7.c
@@ -21,8 +21,8 @@
  * Title:        arm_relu_q7.c
  * Description:  Q7 version of ReLU
  *
- * $Date:        February 27, 2020
- * $Revision:    V.1.0.1
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.2
  *
  * Target Processor:  Cortex-M cores
  *
@@ -69,7 +69,7 @@ void arm_relu_q7(q7_t *data, uint16_t size)
         in = read_q7x4_ia(&input);
 
         /* extract the first bit */
-        buf = __ROR(in & 0x80808080, 7);
+        buf = (int32_t)__ROR((uint32_t)in & 0x80808080, 7);
 
         /* if MSB=1, mask will be 0xFF, 0x0 otherwise */
         mask = __QSUB8(0x00000000, buf);

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_mul_s8
  * Description:  Element wise multiplication
  *
- * $Date:        February 27, 2020
- * $Revision:    V.1.0.2
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.3
  *
  * Target Processor:  Cortex-M cores
  *
@@ -62,7 +62,7 @@ arm_elementwise_mul_s8(const int8_t *input_1_vect,
                        const uint32_t block_size)
 {
 
-  uint32_t loop_count;
+  int32_t loop_count;
 #if defined(ARM_MATH_MVEI)
 
   loop_count = (block_size + 3) / 4;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -60,6 +60,7 @@ arm_status arm_convolve_1_x_n_s8(const cmsis_nn_context* ctx,
                                  const cmsis_nn_dims* output_dims,
                                  q7_t *output_data)
 {
+    (void)bias_dims;
     arm_status status = ARM_MATH_SUCCESS;
     if (output_dims->w % 4 != 0)
     {

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast q7 version of 1x1 convolution (non-square shape)
  *
- * $Date:        May 18 2020
- * $Revision:    V.2.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -50,16 +50,16 @@
    *
    */
 
-arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context* ctx,
-                                    const cmsis_nn_conv_params* conv_params,
-                                    const cmsis_nn_per_channel_quant_params* quant_params,
-                                    const cmsis_nn_dims* input_dims,
+arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
+                                    const cmsis_nn_conv_params *conv_params,
+                                    const cmsis_nn_per_channel_quant_params *quant_params,
+                                    const cmsis_nn_dims *input_dims,
                                     const q7_t *input_data,
-                                    const cmsis_nn_dims* filter_dims,
+                                    const cmsis_nn_dims *filter_dims,
                                     const q7_t *filter_data,
-                                    const cmsis_nn_dims* bias_dims,
+                                    const cmsis_nn_dims *bias_dims,
                                     const int32_t *bias_data,
-                                    const cmsis_nn_dims* output_dims,
+                                    const cmsis_nn_dims *output_dims,
                                     q7_t *output_data)
 {
     if (input_dims->c % 4 != 0 ||
@@ -75,15 +75,15 @@ arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context* ctx,
 
 #if defined(ARM_MATH_MVEI)
 
-    const int32_t col_len            = input_dims->w * input_dims->h * input_dims->n;
-    const int32_t output_ch          = output_dims->c;
-    const int32_t input_ch           = input_dims->c;
-    const int32_t input_offset       = conv_params->input_offset;
-    const int32_t out_offset         = conv_params->output_offset;
+    const int32_t col_len       = input_dims->w * input_dims->h * input_dims->n;
+    const int32_t output_ch     = output_dims->c;
+    const int32_t input_ch      = input_dims->c;
+    const int32_t input_offset  = conv_params->input_offset;
+    const int32_t out_offset    = conv_params->output_offset;
     const int32_t out_activation_min = conv_params->activation.min;
     const int32_t out_activation_max = conv_params->activation.max;
-    int32_t *output_mult             = quant_params->multiplier;
-    int32_t *output_shift            = quant_params->shift;
+    int32_t *output_mult        = quant_params->multiplier;
+    int32_t *output_shift       = quant_params->shift;
 
     for (int i_items = 0; i_items <= (col_len - 4); i_items += 4)
     {
@@ -109,7 +109,9 @@ arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context* ctx,
             res = vmaxq_s32(res, vdupq_n_s32(out_activation_min));
             res = vminq_s32(res, vdupq_n_s32(out_activation_max));
 
-            const uint32x4_t scatter_offset = {0, output_ch, output_ch * 2, output_ch * 3};
+            const uint32x4_t scatter_offset = {0, (uint32_t)output_ch,
+                                               (uint32_t)output_ch * 2,
+                                               (uint32_t)output_ch * 3};
             vstrbq_scatter_offset_s32(output_data, scatter_offset, res);
             output_data++;
         }
@@ -169,7 +171,7 @@ arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context* ctx,
     return ARM_MATH_SUCCESS;
 }
 
-int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims* input_dims)
+int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims *input_dims)
 {
     (void)input_dims;
     return 0;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_s8.c
  * Description:  s8 version of convolution using symmetric quantization.
  *
- * $Date:        May 18, 2020
- * $Revision:    V.2.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -89,6 +89,7 @@ arm_status arm_convolve_s8(const cmsis_nn_context* ctx,
     for (i_batch = 0; i_batch < input_batches; i_batch++)
     {
 #if defined(ARM_MATH_MVEI)
+        (void)bias_dims;
         /* Generate upto four columns from the input tensor a GEMM computation */
         q7_t *im2col_buf = (q7_t *)buffer_a;
         q7_t *out = output_data;
@@ -198,6 +199,7 @@ arm_status arm_convolve_s8(const cmsis_nn_context* ctx,
         }
 
 #elif defined(ARM_MATH_DSP)
+        (void)bias_dims;
         int32_t i_out_y, i_out_x, i_ker_y, i_ker_x;
 
         /* Generate two columns from the input tensor a GEMM computation */
@@ -357,7 +359,7 @@ int32_t arm_convolve_s8_get_buffer_size(const cmsis_nn_dims* input_dims,
                                         const cmsis_nn_dims* filter_dims)
 {
 #if defined(ARM_MATH_DSP)
-    return (2 * input_dims->c * filter_dims->w * filter_dims->h) * sizeof(int16_t);
+    return (2 * input_dims->c * filter_dims->w * filter_dims->h) * (int32_t)sizeof(int16_t);
 #else
     (void)input_dims;
     (void)filter_dims;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c
@@ -63,6 +63,7 @@ arm_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
                                      q7_t *output)
 {
     (void)ctx;
+    (void)bias_dims;
 
     const int32_t input_x = input_dims->w;
     const int32_t input_y = input_dims->h;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_conv_u8_basic_ver1.c
  * Description:  u8 depthwise convolution function
  *
- * $Date:        May 8, 2020
- * $Revision:    V.1.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.1.0
  *
  * Target :  Cortex-M CPUs
  *
@@ -128,24 +128,24 @@ static void depthwise_conv_u8_mult_4(const uint8_t *input,
 }
 
 static void depthwise_conv_u8_generic(const uint8_t *input,
-                                      const uint16_t input_x,
-                                      const uint16_t input_y,
-                                      const uint16_t input_ch,
+                                      const int32_t input_x,
+                                      const int32_t input_y,
+                                      const int32_t input_ch,
                                       const uint8_t *kernel,
-                                      const uint16_t output_ch,
-                                      const uint16_t ch_mult,
-                                      const uint16_t kernel_x,
-                                      const uint16_t kernel_y,
-                                      const uint16_t pad_x,
-                                      const uint16_t pad_y,
-                                      const uint16_t stride_x,
-                                      const uint16_t stride_y,
+                                      const int32_t output_ch,
+                                      const int32_t ch_mult,
+                                      const int32_t kernel_x,
+                                      const int32_t kernel_y,
+                                      const int32_t pad_x,
+                                      const int32_t pad_y,
+                                      const int32_t stride_x,
+                                      const int32_t stride_y,
                                       const int32_t *bias,
                                       uint8_t *output,
                                       const int32_t output_shift,
                                       const int32_t output_mult,
-                                      const uint16_t output_x,
-                                      const uint16_t output_y,
+                                      const int32_t output_x,
+                                      const int32_t output_y,
                                       const int32_t output_offset,
                                       const int32_t input_offset,
                                       const int32_t filter_offset,
@@ -231,8 +231,8 @@ static void depthwise_conv_u8_generic(const uint8_t *input,
  * @param[in]     output_y  Height of output tensor
  * @param[in]     output_activation_min   Minimum value to clamp the output to. Range : {0, 255}
  * @param[in]     output_activation_max   Minimum value to clamp the output to. Range : {0, 255}
- * @param[in]     out_shift  Amount of right-shift for output
- * @param[in]     out_mult   Output multiplier for requantization
+ * @param[in]     output_shift  Amount of right-shift for output
+ * @param[in]     output_mult   Output multiplier for requantization
  * @return        The function returns one of the following
  *                <code>ARM_MATH_SIZE_MISMATCH</code> - Not supported dimension of tensors
  *                <code>ARM_MATH_SUCCESS</code> - Successful operation

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c
@@ -22,8 +22,8 @@
  * Description:  Wrapper API to select appropriate depthwise conv API based
  *               on dimensions.
  *
- * $Date:        May 14, 2020
- * $Revision:    V.1.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -53,7 +53,7 @@ arm_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
                                          const cmsis_nn_dims *input_dims,
                                          const q7_t *input,
                                          const cmsis_nn_dims *filter_dims,
-                                         const q7_t *kernel,
+                                         const q7_t *filter,
                                          const cmsis_nn_dims *bias_dims,
                                          const int32_t *bias,
                                          const cmsis_nn_dims *output_dims,
@@ -71,7 +71,7 @@ arm_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
                                                input_dims,
                                                input,
                                                filter_dims,
-                                               kernel,
+                                               filter,
                                                bias_dims,
                                                bias,
                                                output_dims,
@@ -86,7 +86,7 @@ arm_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
                                                input_dims,
                                                input,
                                                filter_dims,
-                                               kernel,
+                                               filter,
                                                bias_dims,
                                                bias,
                                                output_dims,
@@ -101,7 +101,7 @@ arm_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
                                        input_dims,
                                        input,
                                        filter_dims,
-                                       kernel,
+                                       filter,
                                        bias_dims,
                                        bias,
                                        output_dims,

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_depthwise_conv_s8_core.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_depthwise_conv_s8_core.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_depthwise_conv_s8_core.c
  * Description:  Depthwise convolution on im2col buffers.
  *
- * $Date:        March 3, 2020
- * $Revision:    V.1.0.2
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.3
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -181,7 +181,7 @@ q7_t *arm_nn_depthwise_conv_s8_core(const q7_t *row,
 
             ch_idx++;
         }
-        const mve_pred16_t p = vctp32q(tail_ch);
+        const mve_pred16_t p = vctp32q((uint32_t)tail_ch);
         const int32x4_t mult = vldrwq_z_s32(out_mult, p);
         const int32x4_t shift = vldrwq_z_s32(out_shift, p);
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_kernel_s8_s16.c
  * Description:  Matrix-multiplication function for convolution
  *
- * $Date:        February 27, 2020
- * $Revision:    V.1.0.1
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.2
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -173,7 +173,7 @@ q7_t *arm_nn_mat_mult_kernel_s8_s16(const q7_t *input_a,
     if (row_count)
     {
         ip_a0_s8 = input_a + num_col_a * (output_ch & ~3);
-        const mve_pred16_t p = vctp32q(row_count);
+        const mve_pred16_t p = vctp32q((uint32_t)row_count);
         int32x4_t out_vec_0 = vdupq_n_s32(0);
         int32x4_t out_vec_1 = vdupq_n_s32(0);
         int32x4_t mult_tail;

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_s8.c
  * Description:  General Matrix-multiplication function
  *
- * $Date:        March 6, 2020
- * $Revision:    V.2.0.2
+ * $Date:        May 29, 2020
+ * $Revision:    V.2.0.3
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -73,7 +73,7 @@ q7_t *arm_nn_mat_mult_s8(const q7_t *input_row,
 
             for (int i_row_loop = 0; i_row_loop < row_loop_cnt; i_row_loop++)
             {
-                mve_pred16_t p = vctp16q(row_len_tmp);
+                mve_pred16_t p = vctp16q((uint32_t)row_len_tmp);
                 const int16x8_t offset = vdupq_m_n_s16(vuninitializedq_s16(), col_offset, p);
                 row_len_tmp -= 8;
 
@@ -129,7 +129,7 @@ q7_t *arm_nn_mat_mult_s8(const q7_t *input_row,
 
                 for (int i_row_loop = 0; i_row_loop < row_loop_cnt; i_row_loop++)
                 {
-                    const mve_pred16_t p = vctp16q(row_len_tmp);
+                    const mve_pred16_t p = vctp16q((uint32_t)row_len_tmp);
                     const int16x8_t offset = vdupq_m_n_s16(vuninitializedq_s16(), col_offset, p);
                     row_len_tmp -= 8;
 

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
@@ -60,7 +60,7 @@ arm_fully_connected_s8(const cmsis_nn_context *ctx,
                        const cmsis_nn_dims *output_dims,
                        q7_t *output)
 {
-
+    (void)bias_dims;
     (void)ctx;
     int32_t batch_cnt = input_dims->n;
 

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_accumulate_q7_to_q15.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_accumulate_q7_to_q15.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nn_accumulate_q7_to_q15.c
  * Description:  Accumulate q7 vector into q15 one.
  *
- * $Date:        July 2019
- * $Revision:    V.1.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.1
  *
- * pSrc Processor:  Cortex-M cores
+ * pSrc Processor:  Cortex-M CPUs
  *
  * -------------------------------------------------------------------- */
 #include "arm_math.h"
@@ -50,18 +50,14 @@ void arm_nn_accumulate_q7_to_q15(q15_t *pDst, const q7_t *pSrc, uint32_t length)
     while (cnt > 0l)
     {
         q31_t value = arm_nn_read_q7x4_ia(&pV);
-        v1 = __SXTB16(__ROR(value, 8));
+        v1 = __SXTB16(__ROR((uint32_t)value, 8));
         v2 = __SXTB16(value);
 #ifndef ARM_MATH_BIG_ENDIAN
-
-        vo2 = __PKHTB(v1, v2, 16);
-        vo1 = __PKHBT(v2, v1, 16);
-
+        vo2 = (q31_t)__PKHTB(v1, v2, 16);
+        vo1 = (q31_t)__PKHBT(v2, v1, 16);
 #else
-
-        vo1 = __PKHTB(v1, v2, 16);
-        vo2 = __PKHBT(v2, v1, 16);
-
+        vo1 = (q31_t)__PKHTB(v1, v2, 16);
+        vo2 = (q31_t)__PKHBT(v2, v1, 16);
 #endif
 
         in = arm_nn_read_q15x2(pCnt);

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_add_q7.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_add_q7.c
@@ -51,7 +51,8 @@ void arm_nn_add_q7(const q7_t *input, q31_t *output, uint32_t block_size)
     {
         const int32_t mult_q15x2 = (1UL << 16) | 1UL;
         q31_t in_q7x4 = arm_nn_read_q7x4_ia(&input);
-        q31_t temp_q15x2 = __SXTAB16(__SXTB16(in_q7x4), __ROR(in_q7x4, 8));
+        q31_t temp_q15x2 = __SXTAB16(__SXTB16(in_q7x4),
+                                     __ROR((uint32_t)in_q7x4, 8));
 
         result = __SMLAD(temp_q15x2, mult_q15x2, result);
 

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c
@@ -21,8 +21,8 @@
  * Title:        arm_q7_to_q15_no_shift.c
  * Description:  Converts the elements of the Q7 vector to Q15 vector without left-shift
  *
- * $Date:        February 27, 2020
- * $Revision:    V.1.0.1
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.2
  *
  * Target Processor:  Cortex-M cores
  *
@@ -74,17 +74,17 @@ void arm_q7_to_q15_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t blockSize)
         in = arm_nn_read_q7x4_ia(&pIn);
 
         /* rotatate in by 8 and extend two q7_t values to q15_t values */
-        in1 = __SXTB16(__ROR(in, 8));
+        in1 = __SXTB16(__ROR((uint32_t)in, 8));
 
         /* extend remaining two q7_t values to q15_t values */
         in2 = __SXTB16(in);
 
 #ifndef ARM_MATH_BIG_ENDIAN
-        out2 = __PKHTB(in1, in2, 16);
-        out1 = __PKHBT(in2, in1, 16);
+        out2 = (int32_t)__PKHTB(in1, in2, 16);
+        out1 = (int32_t)__PKHBT(in2, in1, 16);
 #else
-        out1 = __PKHTB(in1, in2, 16);
-        out2 = __PKHBT(in2, in1, 16);
+        out1 = (int32_t)__PKHTB(in1, in2, 16);
+        out2 = (int32_t)__PKHBT(in2, in1, 16);
 #endif
         write_q15x2_ia(&pDst, out1);
         write_q15x2_ia(&pDst, out2);

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_no_shift.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_no_shift.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_q7_to_q15_reordered_no_shift.c
  * Description:  Converts the elements of the Q7 vector to reordered Q15 vector without left-shift
  *
- * $Date:        17. January 2018
- * $Revision:    V.1.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -97,7 +97,7 @@ void arm_q7_to_q15_reordered_no_shift(const q7_t * pSrc, q15_t * pDst, uint32_t 
         in = arm_nn_read_q7x4_ia(&pIn);
 
         /* rotatate in by 8 and extend two q7_t values to q15_t values */
-        in1 = __SXTB16(__ROR(in, 8));
+        in1 = __SXTB16(__ROR((uint32_t)in, 8));
 
         /* extend remainig two q7_t values to q15_t values */
         in2 = __SXTB16(in);

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c
@@ -22,8 +22,8 @@
  * Description:  Converts the elements of the Q7 vector to a reordered Q15 vector with an added offset. The re-ordering
  *               is a signature of sign extension intrinsic(DSP extension).
  *
- * $Date:        March 3, 2020
- * $Revision:    V.2.0.2
+ * $Date:        May 29, 2020
+ * $Revision:    V.2.0.3
  *
  * Target Processor:  Cortex-M cores
  *
@@ -61,14 +61,14 @@ void arm_q7_to_q15_reordered_with_offset(const q7_t *src, q15_t *dst, uint32_t b
     block_cnt = block_size >> 2u;
 
     /* First part of the processing with loop unrolling. Compute 4 outputs at a time. */
-    const q31_t offset_q15x2 = __PKHBT(offset, offset, 16);
+    const q31_t offset_q15x2 = (q31_t)__PKHBT(offset, offset, 16);
     while (block_cnt > 0u)
     {
         /* convert from q7 to q15 and then store the results in the destination buffer */
         in_q7x4 = arm_nn_read_q7x4_ia(&src);
 
         /* Extract and sign extend each of the four q7 values to q15 */
-        out_q15x2_1 = __SXTAB16(offset_q15x2, __ROR(in_q7x4, 8));
+        out_q15x2_1 = __SXTAB16(offset_q15x2, __ROR((uint32_t)in_q7x4, 8));
         out_q15x2_2 = __SXTAB16(offset_q15x2, in_q7x4);
 
         write_q15x2_ia(&dst, out_q15x2_2);

--- a/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_avgpool_s8.c
  * Description:  Pooling function implementations
  *
- * $Date:        May 19,2020
- * $Revision:    V.2.0.0
+ * $Date:        May 29,2020
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -104,7 +104,7 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
       int32_t   k_y_start,k_y_end;
       int32_t   k_x_start,k_x_end;
       int32_t   chCnt;
-      int8_t    *pTmp,*pTmpInner;
+      const int8_t    *pTmp, *pTmpInner;
       int8_t    *pDst;
 
       k_y_start = MAX(0, i_y * stride_height - padding_height);

--- a/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_u8.c
+++ b/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_u8.c
@@ -21,10 +21,10 @@
  * Title:        arm_softmax_u8.c
  * Description:  U8 softmax function
  *
- * $Date:        March 31, 2020
- * $Revision:    V.1.0.0
+ * $Date:        May 29, 2020
+ * $Revision:    V.1.0.1
  *
- * Target Processor:  Cortex-M cores
+ * Target Processor:  Cortex-M CPUs
  *
  * -------------------------------------------------------------------- */
 
@@ -85,7 +85,7 @@ void arm_softmax_u8(const uint8_t *input,
             if (diff >= diff_min)
             {
                 const int32_t res = DIV_POW2(MUL_SAT(shifted_scale, EXP_ON_NEG(MUL_SAT(diff * mask, mult))), bits_over_unit);
-                output[col] = (int8_t) CLAMP(res, (int32_t)255, (int32_t)0);
+                output[col] = (uint8_t) CLAMP(res, (int32_t)255, (int32_t)0);
             }
             else
             {


### PR DESCRIPTION
1. Doxygen warnings are fixed

2. Sign conversion warnings(-Wsign-conversion) and -Wextra warnings
   are fixed for TFLu compliant MVE APIs

