### PR TITLE
Fix - arm_math.h: Use the float suffix in arm_clarke_f32

### DIFF
--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -6061,7 +6061,7 @@ __STATIC_FORCEINLINE q15_t arm_pid_q15(
     *pIalpha = Ia;
 
     /* Calculate pIbeta using the equation, pIbeta = (1/sqrt(3)) * Ia + (2/sqrt(3)) * Ib */
-    *pIbeta = ((float32_t) 0.57735026919 * Ia + (float32_t) 1.15470053838 * Ib);
+    *pIbeta = (0.57735026919f * Ia + 1.15470053838f * Ib);
   }
 
 


### PR DESCRIPTION
The float suffix replaces the need for a float cast in arm_clarke_f32.
This change is necessary to avoid large amount of warnings by arm_math.h when the -Wunsuffixed-float-constants flag is used. And using this compile flag is very reasonable on a processor with 32bit FPU.