### PR TITLE
CMSIS-NN: Use int for loop variables

### DIFF
--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c
@@ -162,9 +162,9 @@ arm_convolve_HWC_q15_basic(const q15_t * Im_in,
 
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-    uint16_t  i, j, k, l, m, n;
+    int  i, j, k, l, m, n;
     int       conv_out;
-    signed char in_row, in_col;
+    int in_row, in_col;
 
     for (i = 0; i < ch_im_out; i++)
     {

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c
@@ -204,9 +204,9 @@ arm_convolve_HWC_q15_fast(const q15_t * Im_in,
 
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-    uint16_t  i, j, k, l, m, n;
+    int  i, j, k, l, m, n;
     int       conv_out;
-    signed char in_row, in_col;
+    int in_row, in_col;
 
     if (ch_im_in % 2 != 0 || ch_im_out % 2 != 0)
     {

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c
@@ -214,9 +214,9 @@ arm_convolve_HWC_q15_fast_nonsquare(const q15_t * Im_in,
 
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
-    uint16_t  i, j, k, l, m, n;
+    int  i, j, k, l, m, n;
     int       conv_out;
-    signed char in_row, in_col;
+    int in_row, in_col;
 
     if (ch_im_in % 2 != 0 || ch_im_out % 2 != 0)
     {

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c
@@ -227,9 +227,9 @@ arm_convolve_HWC_q7_RGB(const q7_t * Im_in,
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
 
-    uint16_t  i, j, k, l, m, n;
+    int  i, j, k, l, m, n;
     int       conv_out;
-    signed char in_row, in_col;
+    int in_row, in_col;
 
     // check if number of input channels is 3
     if (ch_im_in != 3)

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c
@@ -185,9 +185,9 @@ arm_convolve_HWC_q7_basic(const q7_t * Im_in,
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
 
-    uint16_t  i, j, k, l, m, n;
+    int  i, j, k, l, m, n;
     int       conv_out;
-    signed char in_row, in_col;
+    int in_row, in_col;
 
     for (i = 0; i < ch_im_out; i++)
     {

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c
@@ -183,9 +183,9 @@ arm_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t * Im_in,
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
 
-    uint16_t  i, j, k, l, m, n;
+    int  i, j, k, l, m, n;
     int       conv_out;
-    signed char in_row, in_col;
+    int in_row, in_col;
 
     for (i = 0; i < ch_im_out; i++)
     {

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c
@@ -356,9 +356,9 @@ arm_convolve_HWC_q7_fast(const q7_t * Im_in,
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
 
-    uint16_t  i, j, k, l, m, n;
+    int  i, j, k, l, m, n;
     int       conv_out;
-    signed char in_row, in_col;
+    int in_row, in_col;
 
     if (ch_im_in % 4 != 0 || ch_im_out % 2 != 0)
     {


### PR DESCRIPTION
Parts of the legacy APIs for non-DSP extension
Cortex-M CPUs have uint16 or signed chars for some
loop related variables. They are chagned to int.

Note: This does not affect TFLu compatible APIs

