### PR TITLE
Core(M): #undef IAR standard definition of __WEAK

### DIFF
--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -7,8 +7,8 @@
 
 //------------------------------------------------------------------------------
 //
-// Copyright (c) 2017-2019 IAR Systems
-// Copyright (c) 2017-2019 Arm Limited. All rights reserved. 
+// Copyright (c) 2017-2020 IAR Systems
+// Copyright (c) 2017-2019 Arm Limited. All rights reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -238,6 +238,7 @@ __packed struct  __iar_u32 { uint32_t v; };
   #endif
 #endif
 
+#undef __WEAK                           /* undo the definition from DLib_Defaults.h */
 #ifndef   __WEAK
   #if __ICCARM_V8
     #define __WEAK __attribute__((weak))


### PR DESCRIPTION
The IAR standard definition of __WEAK is incompatible with the
normal CMSIS definition. This fix #undef:s this definition

Signed-off-by: TTornblom <thomas.tornblom@iar.com>