### PR TITLE
CMSIS-DSP: Optimize Q15 radix4 FFT for GCC with PKHBT for Cortex-M4

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -2135,7 +2135,7 @@ __STATIC_FORCEINLINE  int32_t __QSUB( int32_t op1,  int32_t op2)
   return(result);
 }
 
-#if 0
+#if 1
 #define __PKHBT(ARG1,ARG2,ARG3) \
 ({                          \
   uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
@@ -2152,13 +2152,13 @@ __STATIC_FORCEINLINE  int32_t __QSUB( int32_t op1,  int32_t op2)
     __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
   __RES; \
  })
-#endif
-
+#else
 #define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
                                            ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
 
 #define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
                                            ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+#endif
 
 __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
 {

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
@@ -794,7 +794,7 @@ void arm_cfft_radix4by2_q15(
       out2 = __SMUAD(coeff, R);
 #endif /* #ifndef ARM_MATH_BIG_ENDIAN */
 
-      write_q15x2_ia (&pSl, (q31_t) ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+      write_q15x2_ia (&pSl, (q31_t)__PKHBT( out1, out2, 0 ) );
   }
 
 #else /* #if defined (ARM_MATH_DSP) */
@@ -893,7 +893,7 @@ void arm_cfft_radix4by2_inverse_q15(
      out2 = __SMUSD(__QSUB(0, coeff), R);
 #endif /* #ifndef ARM_MATH_BIG_ENDIAN */
 
-     write_q15x2_ia (&pSl, (q31_t) ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+     write_q15x2_ia (&pSl, (q31_t)__PKHBT( out1, out2, 0 ));
   }
 
 #else /* #if defined (ARM_MATH_DSP) */

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q15.c
@@ -260,7 +260,7 @@ void arm_radix4_butterfly_q15(
 
     /* writing the butterfly processed i0 + fftLen/4 sample */
     /* writing output(xc', yc') in little endian format */
-    write_q15x2_ia (&pSi1, (q31_t) ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+    write_q15x2_ia (&pSi1, (q31_t) __PKHBT( out1, out2, 0 ));
 
     /*  Butterfly calculations */
     /* U = packed(yd, xd) */
@@ -300,7 +300,7 @@ void arm_radix4_butterfly_q15(
 #endif /* #ifndef ARM_MATH_BIG_ENDIAN */
 
     /* writing output(xb', yb') in little endian format */
-    write_q15x2_ia (&pSi2, ((out2) & 0xFFFF0000) | ((out1) & 0x0000FFFF));
+    write_q15x2_ia (&pSi2, __PKHBT( out1, out2, 0 ));
 
     /* co3 & si3 are read from SIMD Coefficient pointer */
     C3 = read_q15x2 ((q15_t *) pCoef16 + (6U * ic));
@@ -319,7 +319,7 @@ void arm_radix4_butterfly_q15(
 #endif /* #ifndef ARM_MATH_BIG_ENDIAN */
 
     /* writing output(xd', yd') in little endian format */
-    write_q15x2_ia (&pSi3, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+    write_q15x2_ia (&pSi3, __PKHBT( out1, out2, 0 ));
 
     /*  Twiddle coefficients index modifier */
     ic = ic + twidCoefModifier;
@@ -417,7 +417,7 @@ void arm_radix4_butterfly_q15(
         /*  writing the butterfly processed i0 + fftLen/4 sample */
         /* xc' = (xa-xb+xc-xd)* co2 + (ya-yb+yc-yd)* (si2) */
         /* yc' = (ya-yb+yc-yd)* co2 - (xa-xb+xc-xd)* (si2) */
-        write_q15x2 (pSi1, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+        write_q15x2 (pSi1, __PKHBT( out1, out2, 0 ));
         pSi1 += 2 * n1;
 
         /*  Butterfly calculations */
@@ -454,7 +454,7 @@ void arm_radix4_butterfly_q15(
 
         /* xb' = (xa+yb-xc-yd)* co1 + (ya-xb-yc+xd)* (si1) */
         /* yb' = (ya-xb-yc+xd)* co1 - (xa+yb-xc-yd)* (si1) */
-        write_q15x2 (pSi2, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+        write_q15x2 (pSi2, __PKHBT( out1, out2, 0 ));
         pSi2 += 2 * n1;
 
         /*  Butterfly process for the i0+3fftLen/4 sample */
@@ -469,7 +469,7 @@ void arm_radix4_butterfly_q15(
 
         /* xd' = (xa-yb-xc+yd)* co3 + (ya+xb-yc-xd)* (si3) */
         /* yd' = (ya+xb-yc-xd)* co3 - (xa-yb-xc+yd)* (si3) */
-        write_q15x2 (pSi3, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+        write_q15x2 (pSi3, __PKHBT( out1, out2, 0 ));
         pSi3 += 2 * n1;
       }
     }
@@ -1126,7 +1126,7 @@ void arm_radix4_butterfly_inverse_q15(
 
     /* writing the butterfly processed i0 + fftLen/4 sample */
     /* writing output(xc', yc') in little endian format */
-    write_q15x2_ia (&pSi1, (q31_t) ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+    write_q15x2_ia (&pSi1, (q31_t) __PKHBT( out1, out2, 0 ));
 
     /*  Butterfly calculations */
     /* U = packed(yd, xd) */
@@ -1166,7 +1166,7 @@ void arm_radix4_butterfly_inverse_q15(
 #endif /* #ifndef ARM_MATH_BIG_ENDIAN */
 
     /* writing output(xb', yb') in little endian format */
-    write_q15x2_ia (&pSi2, ((out2) & 0xFFFF0000) | ((out1) & 0x0000FFFF));
+    write_q15x2_ia (&pSi2, __PKHBT( out1, out2, 0 ));
 
     /* co3 & si3 are read from SIMD Coefficient pointer */
     C3 = read_q15x2 ((q15_t *) pCoef16 + (6U * ic));
@@ -1185,7 +1185,7 @@ void arm_radix4_butterfly_inverse_q15(
 #endif /* #ifndef ARM_MATH_BIG_ENDIAN */
 
     /* writing output(xd', yd') in little endian format */
-    write_q15x2_ia (&pSi3, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+    write_q15x2_ia (&pSi3, __PKHBT( out1, out2, 0 ));
 
     /*  Twiddle coefficients index modifier */
     ic = ic + twidCoefModifier;
@@ -1283,7 +1283,7 @@ void arm_radix4_butterfly_inverse_q15(
         /*  writing the butterfly processed i0 + fftLen/4 sample */
         /* xc' = (xa-xb+xc-xd)* co2 + (ya-yb+yc-yd)* (si2) */
         /* yc' = (ya-yb+yc-yd)* co2 - (xa-xb+xc-xd)* (si2) */
-        write_q15x2 (pSi1, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+        write_q15x2 (pSi1, __PKHBT( out1, out2, 0 ));
         pSi1 += 2 * n1;
 
         /*  Butterfly calculations */
@@ -1318,7 +1318,7 @@ void arm_radix4_butterfly_inverse_q15(
 
         /* xb' = (xa+yb-xc-yd)* co1 + (ya-xb-yc+xd)* (si1) */
         /* yb' = (ya-xb-yc+xd)* co1 - (xa+yb-xc-yd)* (si1) */
-        write_q15x2 (pSi2, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+        write_q15x2 (pSi2, __PKHBT( out1, out2, 0 ));
         pSi2 += 2 * n1;
 
         /*  Butterfly process for the i0+3fftLen/4 sample */
@@ -1333,7 +1333,7 @@ void arm_radix4_butterfly_inverse_q15(
 
         /* xd' = (xa-yb-xc+yd)* co3 + (ya+xb-yc-xd)* (si3) */
         /* yd' = (ya+xb-yc-xd)* co3 - (xa-yb-xc+yd)* (si3) */
-        write_q15x2 (pSi3, ((out2) & 0xFFFF0000) | (out1 & 0x0000FFFF));
+        write_q15x2 (pSi3, __PKHBT( out1, out2, 0 ));
         pSi3 += 2 * n1;
       }
     }


### PR DESCRIPTION
Update the radix4 Q15 FFTs to explicitly use the __PKHBT macros, and update the GCC header to implement it.

This makes Q15 FFT execution time a few percent shorter depending on FFT size when targeting Cortex-M4.