### PR TITLE
CMSIS-NN: Add bias null check for convolution functions

### DIFF
--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnfunctions.h
  * Description:  Public header file for CMSIS NN Library
  *
- * $Date:        June 11, 2020
- * $Revision:    V.6.0.1
+ * $Date:        July 27, 2020
+ * $Revision:    V.6.0.2
  *
  * Target Processor:  Cortex-M CPUs
  * -------------------------------------------------------------------- */
@@ -258,7 +258,7 @@ extern    "C"
    * @param[in]      filter_dims    Filter tensor dimensions. Format: [C_OUT, HK, WK, C_IN] where HK and WK are the spatial filter dimensions
    * @param[in]      filter_data    Filter data pointer. Data type: int8
    * @param[in]      bias_dims      Bias tensor dimensions. Format: [C_OUT]
-   * @param[in]      bias_data      Bias data pointer. Data type: int32
+   * @param[in]      bias_data      Optional bias data pointer. Data type: int32
    * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
    * @param[out]     output_data    Output data pointer. Data type: int8
 
@@ -574,7 +574,7 @@ extern    "C"
    * @param[in]      filter_dims    Filter tensor dimensions. Format: [C_OUT, 1, 1, C_IN]
    * @param[in]      filter_data    Filter data pointer. Data type: int8
    * @param[in]      bias_dims      Bias tensor dimensions. Format: [C_OUT]
-   * @param[in]      bias_data      Bias data pointer. Data type: int32
+   * @param[in]      bias_data      Optional bias data pointer. Data type: int32
    * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
    * @param[out]     output_data    Output data pointer. Data type: int8
    *
@@ -626,7 +626,7 @@ extern    "C"
    * @param[in]      filter_dims    Filter tensor dimensions. Format: [C_OUT, 1, WK, C_IN] where WK is the horizontal spatial filter dimension
    * @param[in]      filter_data    Filter data pointer. Data type: int8
    * @param[in]      bias_dims      Bias tensor dimensions. Format: [C_OUT]
-   * @param[in]      bias_data      Bias data pointer. Data type: int32
+   * @param[in]      bias_data      Optional bias data pointer. Data type: int32
    * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
    * @param[out]     output_data    Output data pointer. Data type: int8
    *

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1_x_n_s8.c
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
- * $Date:        May 18, 2020
- * $Revision:    V.2.0.0
+ * $Date:        July 27, 2020
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M cores
  *
@@ -147,9 +147,11 @@ arm_status arm_convolve_1_x_n_s8(const cmsis_nn_context* ctx,
             }
             int32x4_t res = vldrwq_s32(acc);
             s_offset = vmulq_n_s32(s_offset, input_offset);
-
-            res = vaddq_n_s32(res, bias_data[i_out_ch]);
             res = vaddq_s32(res, s_offset);
+            if (bias_data)
+            {
+                res = vaddq_n_s32(res, bias_data[i_out_ch]);
+            }
             res = arm_requantize_mve(res, output_mult[i_out_ch], output_shift[i_out_ch]);
             res = vaddq_n_s32(res, out_offset);
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast q7 version of 1x1 convolution (non-square shape)
  *
- * $Date:        May 29, 2020
- * $Revision:    V.2.0.1
+ * $Date:        July 27, 2020
+ * $Revision:    V.2.0.2
  *
  * Target Processor:  Cortex-M cores
  *
@@ -99,8 +99,10 @@ arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
                                             &sum_row,
                                             temp_out);
             int32x4_t res = vldrwq_s32(temp_out);
-
-            res = vaddq_n_s32(res, bias_data[i_out_ch]);
+            if (bias_data)
+            {
+                res = vaddq_n_s32(res, bias_data[i_out_ch]);
+            }
             sum_row = sum_row * input_offset;
             res = vaddq_n_s32(res, sum_row);
             res = arm_requantize_mve(res, output_mult[i_out_ch], output_shift[i_out_ch]);
@@ -131,8 +133,10 @@ arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
                                             filter_data + i_out_ch * input_ch,
                                             &sum_row,
                                             &acc);
-
-            acc += bias_data[i_out_ch];
+            if (bias_data)
+            {
+                acc += bias_data[i_out_ch];
+            }
             sum_row = (sum_row * input_offset);
             acc += sum_row;
             acc = arm_nn_requantize(acc, output_mult[i_out_ch], output_shift[i_out_ch]);

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_s8.c
  * Description:  s8 version of convolution using symmetric quantization.
  *
- * $Date:        May 29, 2020
- * $Revision:    V.2.0.1
+ * $Date:        July 27, 2020
+ * $Revision:    V.2.0.2
  *
  * Target Processor:  Cortex-M cores
  *
@@ -140,8 +140,10 @@ arm_status arm_convolve_s8(const cmsis_nn_context* ctx,
 
                         int32x4_t res = vldrwq_s32(acc);
                         s_offset = vmulq_n_s32(s_offset, input_offset);
-
-                        res = vaddq_n_s32(res, bias_data[i_out_ch]);
+                        if (bias_data)
+                        {
+                            res = vaddq_n_s32(res, bias_data[i_out_ch]);
+                        }
                         res = vaddq_s32(res, s_offset);
                         res = arm_requantize_mve(res, output_mult[i_out_ch], output_shift[i_out_ch]);
                         res = vaddq_n_s32(res, out_offset);
@@ -260,7 +262,11 @@ arm_status arm_convolve_s8(const cmsis_nn_context* ctx,
             for (i = 0; i < output_ch; i++)
             {
                 /* Load the accumulator with bias first */
-                q31_t sum = bias_data[i];
+                q31_t sum = 0;
+                if (bias_data)
+                {
+                    sum = bias_data[i];
+                }
 
                 /* Point to the beginning of the im2col buffer where the input is available as a rearranged column */
                 const q15_t *ip_as_col = buffer_a;
@@ -311,7 +317,7 @@ arm_status arm_convolve_s8(const cmsis_nn_context* ctx,
             {
                 for (i_out_x = 0; i_out_x < output_x; i_out_x++)
                 {
-                    conv_out = bias_data[i_out_ch];
+                    conv_out = 0;
 
                     const int32_t base_idx_y = stride_y * i_out_y - pad_y;
                     const int32_t base_idx_x = stride_x * i_out_x - pad_x;
@@ -336,6 +342,10 @@ arm_status arm_convolve_s8(const cmsis_nn_context* ctx,
                                            (i_ker_y * kernel_x + i_ker_x) * input_ch + i_input_ch];
                             }
                         }
+                    }
+                    if (bias_data)
+                    {
+                        conv_out += bias_data[i_out_ch];
                     }
                     conv_out = arm_nn_requantize(conv_out, output_mult[i_out_ch], output_shift[i_out_ch]);
                     conv_out += out_offset;

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_s8_nt_t_s8
  * Description:  Matrix multiplication support function with the right-hand-side (rhs) matrix transposed
  *
- * $Date:        March 17 2020
- * $Revision:    V.1.0.1
+ * $Date:        July 27 2020
+ * $Revision:    V.1.0.2
  *
  * Target Processor:  Cortex-M
  *
@@ -80,9 +80,11 @@ arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
 
         lhs_offset_contribution0 *= lhs_offset;
         lhs_offset_contribution1 *= lhs_offset;
-
-        lhs_offset_contribution0 += bias[rhs_rows_idx];
-        lhs_offset_contribution1 += bias[rhs_rows_idx + 1];
+        if (bias)
+        {
+            lhs_offset_contribution0 += bias[rhs_rows_idx];
+            lhs_offset_contribution1 += bias[rhs_rows_idx + 1];
+        }
 
         int32_t lhs_rows_idx = lhs_rows >> 1;
 
@@ -375,7 +377,11 @@ arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
         for (int32_t lhs_rows_idx = 0; lhs_rows_idx < lhs_rows; ++lhs_rows_idx)
         {
             const q7_t *rhs_ptr = &rhs[0];
-            q31_t res00 = bias[rhs_rows - 1];
+            q31_t res00 = 0;
+            if (bias)
+            {
+                res00 = bias[rhs_rows - 1];
+            }
 
             for (int32_t rhs_cols_idx = 0; rhs_cols_idx < rhs_cols; ++rhs_cols_idx)
             {
@@ -419,9 +425,11 @@ arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
 
         lhs_offset_contribution0 *= lhs_offset;
         lhs_offset_contribution1 *= lhs_offset;
-
-        lhs_offset_contribution0 += bias[rhs_rows_idx];
-        lhs_offset_contribution1 += bias[rhs_rows_idx + 1];
+        if (bias)
+        {
+            lhs_offset_contribution0 += bias[rhs_rows_idx];
+            lhs_offset_contribution1 += bias[rhs_rows_idx + 1];
+        }
 
         int32_t lhs_rows_idx = lhs_rows >> 1;
 
@@ -536,7 +544,11 @@ arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
         for (int32_t lhs_rows_idx = 0; lhs_rows_idx < lhs_rows; ++lhs_rows_idx)
         {
             const q7_t *rhs_ptr = &rhs[0];
-            q31_t res00 = bias[rhs_rows - 1];
+            q31_t res00 = 0;
+            if (bias)
+            {
+                res00 = bias[rhs_rows - 1];
+            }
 
             for (int32_t rhs_cols_idx = 0; rhs_cols_idx < rhs_cols; ++rhs_cols_idx)
             {


### PR DESCRIPTION
NULL check is done for optional bias parameter

