### PR TITLE
CMSIS-DAP: DAP_Info documentation clarifications

### DIFF
--- a/CMSIS/DoxyGen/DAP/src/dap_USB_cmds.txt
+++ b/CMSIS/DoxyGen/DAP/src/dap_USB_cmds.txt
@@ -7,11 +7,11 @@ Commands between Debug Unit and host computer.
 This section explains each command that is exchanged between the Debug Unit and the host computer.
 Every Command starts with a Command-ID and optional data.
 Depending on the Command, the CMSIS-DAP firmware replies with a Response that repeats the Command-ID and
-delivers additional data. 
+delivers additional data.
 
 Command and Response data have a package size limitation that is defined with \ref DAP_PACKET_SIZE.
 This configuration setting can be obtained with the command \ref DAP_Info and is used to
-optimize the performance for Full-Speed or High-Speed USB. The debugger must ensure that each 
+optimize the performance for Full-Speed or High-Speed USB. The debugger must ensure that each
 data package fits within the limitations of the configured \ref DAP_PACKET_SIZE.
 
 \note
@@ -38,16 +38,16 @@ The following conventions describe the command semantic used in the following do
  //////// | The field above is repeated and may appear 0..n times.
 
 
-The commands are described in a structure consisting of three lines. 
-  - The first line indicates the field type. 
+The commands are described in a structure consisting of three lines.
+  - The first line indicates the field type.
   - The second line indicates the communication direction and the command structure.
   - The third line indicates the occurrence of the field.
-  
+
 \b Examples:
 \code
  | BYTE | SHORT *| WORD ***|
  > 0x99 | RecLen | Data    |
- |******|********|+++++++++| 
+ |******|********|+++++++++|
 \endcode
 
 The Command with the Command-ID <em>0x99</em> is sent from the host computer to the Debug Unit.
@@ -64,13 +64,13 @@ Depending on the Command the Debug Unit may send a <b>Response</b>.
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_genCommands_gr General Commands
 \ingroup DAP_Commands_gr
 Information and Control commands for the CMSIS-DAP Debug Unit.
 
 The General Commands allow to:
- - Connect, disconnect, and identify the Debug Unit. 
+ - Connect, disconnect, and identify the Debug Unit.
  - Control the Status LEDs of the Debug Unit.
  - Issue and hardware reset to the connected Device.
  - Terminate previous CMSIS-DAP Commands.
@@ -78,7 +78,7 @@ The General Commands allow to:
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_swj_gr Common SWD/JTAG Commands
 \ingroup DAP_Commands_gr
 \brief Set SWD/JTAG clock and control/monitor SWD/JTAG I/O pins.
@@ -90,7 +90,7 @@ The Common SWD/JTAG Commands allow to:
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_swd_gr SWD Commands
 \ingroup DAP_Commands_gr
 \brief Configure the parameters for SWD mode.
@@ -99,7 +99,7 @@ The SWD Commands allow you to configure the parameters for the Serial Wire Debug
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_swo_gr SWO Commands
 \ingroup DAP_Commands_gr
 \brief Configure the parameters for SWO mode.
@@ -128,13 +128,13 @@ The following new commands are added:
 
 Format of the new commands is specified below using CMSIS-DAP documentation style.
 Note: 16-bit values (SHORT) and 32-bit values (WORD) are encoded as little-endian.
- 
+
 The following existing commands are extended:
  - \ref DAP_Info
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_jtag_gr JTAG Commands
 \ingroup DAP_Commands_gr
 \brief Detect and configure the JTAG device chain.
@@ -146,7 +146,7 @@ The JTAG Commands allow to:
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_transfer_gr Transfer Commands
 \ingroup DAP_Commands_gr
 \brief Read and Writes to CoreSight registers.
@@ -159,7 +159,7 @@ The Transfer Commands allow to:
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_atomic_gr Atomic Commands
 \ingroup DAP_Commands_gr
 \brief Execute atomic commands.
@@ -169,7 +169,7 @@ Executing multiple CMSIS-DAP commands is typically a requirement at the reset ti
 critical and any USB communication would violate the available time window.
  - \ref DAP_ExecuteCommands_gr : execute multiple DAP commands from a single command request
  - \ref DAP_QueueCommands_gr : queue of multiple DAP commands before execution
- 
+
 These two DAP commands are used to collect several other DAP commands before execution.
 Packet Size and Packet Count limitation (as reported via \ref DAP_Info) must be respected by the debugger.
 
@@ -179,7 +179,7 @@ The \ref DAP_atomic_gr are only available when \ref DAP_Info with ID=0xF0 (Capab
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_uart_gr UART COM Commands
 \ingroup DAP_Commands_gr
 \brief Target communication via extra UART.
@@ -195,11 +195,11 @@ The following CMSIS-DAP commands are added to support UART communication:
  - \ref DAP_UART_Control : \copybrief DAP_UART_Control
  - \ref DAP_UART_Status : \copybrief DAP_UART_Status
  - \ref DAP_UART_Transfer : \copybrief DAP_UART_Transfer
- 
+
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_Response_Status Response Status
 \ingroup DAP_Commands_gr
 \brief Status Information in Response Data
@@ -212,25 +212,25 @@ command failures.  Currently the following Status codes are returned:
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_Info DAP_Info
 \ingroup DAP_genCommands_gr
 \brief Get Information about CMSIS-DAP Debug Unit.
 \details
 The <b>DAP_Info Command</b> provides configuration information about the Debug Unit itself and the capabilities.
-  
+
 <b>DAP_Info Command:</b>
 \code
 | BYTE | BYTE |
 > 0x00 | ID   |
-|******|******| 
+|******|******|
 \endcode
 
 - \b ID: Request Identifier to obtain information in the Response:
   - \b 0x01 = Get the <b>Vendor ID</b> (string).
   - \b 0x02 = Get the <b>Product ID</b> (string).
   - \b 0x03 = Get the <b>Serial Number</b> (string).
-  - \b 0x04 = Get the <b>CMSIS-DAP Firmware Version</b> (string).
+  - \b 0x04 = Get the <b>CMSIS-DAP Protocol Version</b> (string).
   - \b 0x05 = Get the <b>Target Device Vendor</b> (string).
   - \b 0x06 = Get the <b>Target Device Name</b> (string).
   - \b 0x07 = Get the <b>Target Board Vendor</b> (string).
@@ -252,15 +252,21 @@ The <b>DAP_Info Command</b> provides configuration information about the Debug U
 \endcode
 
 - \b Len:  Info length in bytes.
-- \b Info: 
-  - a \b string encoded in US ASCII. Len is the string length including the \\x00 terminator. Len = 0 indicates no information.
+- \b Info:
+  - a \b string encoded in US ASCII. Len is the string length including the \\x00 terminator. Len = 0 indicates no information, and is distinct from an empty string indicated by Len = 1.
   - a \b BYTE value (indicated with Len = 1).
   - a \b SHORT value (indicated with Len = 2).
   - a \b WORD value (indicated with Len = 4).
 
 \note
-The ID for <b>Vendor ID</b>, <b>Product ID</b>, and <b>Serial Number</b> may return no string (indicated by Len = 0). 
-In this case the USB Device Information is used to obtain Vendor, Product, and Serial Number.
+An unrecognized ID returns no value (indicated by Len = 0).
+
+\note
+The ID for <b>Vendor ID</b>, <b>Product ID</b>, and <b>Serial Number</b> may return no string (indicated by Len = 0).
+In this case the USB Device Information is used to obtain Vendor, Product, and Serial Number. The <b>Vendor ID</b> and <b>Product ID</b> are the vendor and product names, not the USB VID and PID.
+
+\note
+The value of <b>CMSIS-DAP Protocol Version</b> must be one of the versions from the \ref dap_revisionHistory "CMSIS-DAP revision history", such as "2.1.0".
 
 \note
 <b>Target Device Vendor</b>, <b>Target Device Name</b>, <b>Target Board Vendor</b> and <b>Target Board Name</b> are only available on On-Board Debug Units with known
@@ -268,13 +274,19 @@ Target. Refer to \ref TARGET_FIXED for more information. If the Target is not kn
 no string is returned (indicated by Len = 0).
 
 \note
+<b>Target Device Vendor</b> should match the <tt>Dvendor</tt> attribute value from the corresponding CMSIS Device Family Pack, taken from the <a href="../../Pack/html/pdsc_family_pg.html#DeviceVendorEnum">Device Vendor</a> table, and must include the the colon and vendor code suffix.
+
+\note
+<b>Target Device Name</b> should match the <tt>Dname</tt> or <tt>Dvariant</tt> attribute value from the corresponding CMSIS Device Family Pack. Only alphabetical characters, decimal digits, '-' and '_' are allowed.
+
+\note
 <b>Product Firmware Version</b> may return no string (indicated by Len = 0).
 
 <hr>
-  
+
 <b>DAP_Info Response (for ID=0xF0):</b>
 
-The ID=0xF0 <b>Capabilities</b> obtains information about the available interface to the Device. 
+The ID=0xF0 <b>Capabilities</b> obtains information about the available interface to the Device.
 The reply consists of one or two \b Info bytes with bits that indicate the features of the <b>Debug Unit</b>.
 The features indicate the command scope of the CMSIS-DAP firmware. If certain features are not available, the debugger should not call the related commands as the may not be implemented. Commands that are not implemented reply with 0xFF instead of repeating the command byte.
 
@@ -288,30 +300,30 @@ The features indicate the command scope of the CMSIS-DAP firmware. If certain fe
 - \b Len:  <b>1 = Info0</b> present, <b>2 = Info0, Info1</b> present.
 
 Available transfer protocols to target:
- - Info0 - Bit 0: <b>1 = SWD</b> Serial Wire Debug communication is implemented (0 = \ref DAP_swd_gr not implemented).  
+ - Info0 - Bit 0: <b>1 = SWD</b> Serial Wire Debug communication is implemented (0 = \ref DAP_swd_gr not implemented).
  - Info0 - Bit 1: <b>1 = JTAG</b> communication is implemented (0 = \ref DAP_jtag_gr not implemented).
- 
-Serial Wire Trace (SWO) support: 
+
+Serial Wire Trace (SWO) support:
  - Info0 - Bit 2: <b>1 = SWO UART</b> - UART Serial Wire Output is implemented (0 = not implemented).
  - Info0 - Bit 3: <b>1 = SWO Manchester</b> - Manchester Serial Wire Output is implemented (0 = not implemented).
- 
-Command extensions for transfer protocol: 
+
+Command extensions for transfer protocol:
  - Info0 - Bit 4: <b>1 = Atomic Commands</b> - \ref DAP_atomic_gr support is implemented (0 = \ref DAP_atomic_gr not implemented).
- 
+
 Time synchronisation via Test Domain Timer:
  - Info0 - Bit 5: <b>1 = Test Domain Timer</b> - debug unit support for Test Domain Timer is implemented (0 = not implemented).
- 
+
 SWO Streaming Trace support:
  - Info0 - Bit 6: <b>1 = SWO Streaming Trace</b> is implemented (0 = not implemented).
- 
+
 UART Communication Port support:
  - Info0 - Bit 7: <b>1 = UART Communication Port</b> is implemented (0 = not implemented).
 
 UART Communication via USB COM Port support:
- - Info1 - Bit 0: <b>1 = USB COM Port</b> is implemented (0 = not implemented). 
- 
+ - Info1 - Bit 0: <b>1 = USB COM Port</b> is implemented (0 = not implemented).
+
 <hr>
- 
+
 <b>DAP_Info Response (for ID=0xF1):</b>
 
 The ID=0xF1 <b>Test Domain Timer</b> obtains the parameter information about an optional 32-bit Test Domain Timer that may be used for various time measurements.
@@ -329,23 +341,23 @@ The ID=0xF1 <b>Test Domain Timer</b> obtains the parameter information about an 
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_HostStatus DAP_HostStatus
 \ingroup DAP_genCommands_gr
 Sent status information of the debugger to Debug Unit.
 
 The <b>DAP_HostStatus Command</b> is used to sent the status information about the debugger to the Debug Unit.
-This status information may be displayed on the Debug Unit. Therefore a Debug Unit may provide optional Status LEDs: 
+This status information may be displayed on the Debug Unit. Therefore a Debug Unit may provide optional Status LEDs:
  - Connect LED: is active when the DAP hardware is connected to a debugger.
  - Running LED: is active when the debugger has put the target device into running state.
-  
+
 <b>DAP_HostStatus Command:</b>
 \code
 | BYTE | BYTE **| BYTE **|
-> 0x01 | Type   | Status | 
+> 0x01 | Type   | Status |
 |******|********|********|
 \endcode
-- \b Type: specifies the type of the information that is sent in \b Status: 
+- \b Type: specifies the type of the information that is sent in \b Status:
   - \b 0 = Connect: Status indicates that the debugger is connected to the Debug Unit.
   - \b 1 = Running: Status indicates that the target hardware is executing application code.
 - \b Status: contains the actual status information:
@@ -362,20 +374,20 @@ This status information may be displayed on the Debug Unit. Therefore a Debug Un
 
 
 /**************************************************************************************************/
-/** 
-\defgroup DAP_Connect DAP_Connect 
+/**
+\defgroup DAP_Connect DAP_Connect
 \ingroup DAP_genCommands_gr
 \brief Connect to Device and selected DAP mode.
 \details
 The <b>DAP_Connect Command</b> initializes the DAP I/O pins for the specified DAP mode (JTAG or
-SWD). This command calls the function \ref PORT_SWD_SETUP or \ref PORT_JTAG_SETUP which prepares the 
+SWD). This command calls the function \ref PORT_SWD_SETUP or \ref PORT_JTAG_SETUP which prepares the
 connection to the Target Device.
- 
+
 <b>DAP_Connect Command:</b>
 \code
 | BYTE | BYTE |
 > 0x02 | Port |
-|******|******| 
+|******|******|
 \endcode
 
 - \b Port: Selects the DAP port mode and configures the DAP I/O pins. The possible values are:
@@ -399,8 +411,8 @@ connection to the Target Device.
 
 
 /**************************************************************************************************/
-/** 
-\defgroup DAP_Disconnect DAP_Disconnect 
+/**
+\defgroup DAP_Disconnect DAP_Disconnect
 \ingroup DAP_genCommands_gr
 \brief Disconnect from active Debug Port
 \details
@@ -410,7 +422,7 @@ The <b>DAP_Disconnect Command</b> de-initializes the DAP I/O pins by calling the
 \code
 | BYTE |
 > 0x03 |
-|******| 
+|******|
 \endcode
 
 <b>DAP_Disconnect Response</b>:
@@ -425,12 +437,12 @@ The <b>DAP_Disconnect Command</b> de-initializes the DAP I/O pins by calling the
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_WriteABORT DAP_WriteABORT
 \ingroup DAP_genCommands_gr
 \brief Write ABORT Register
 \details
-The <b>DAP_WriteABORT Command</b> writes an abort request to the CoreSight ABORT register of 
+The <b>DAP_WriteABORT Command</b> writes an abort request to the CoreSight ABORT register of
 the Target Device.
 
 <b>DAP_WriteABORT Command</b>:
@@ -455,18 +467,18 @@ the Target Device.
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_Delay DAP_Delay
 \ingroup  DAP_genCommands_gr
-\brief    Wait for specified delay 
+\brief    Wait for specified delay
 \details
 The <b>DAP_Delay< Command</b> waits for a time period specified in micro-seconds.
-  
+
 <b>DAP_Delay Command</b>:
 \code
 | BYTE | SHORT |
 > 0x09 | Delay |
-|******|*******| 
+|******|*******|
 \endcode
 
 - \b Delay: wait time in µs.
@@ -483,7 +495,7 @@ The <b>DAP_Delay< Command</b> waits for a time period specified in micro-seconds
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_ResetTarget DAP_ResetTarget
 \ingroup  DAP_genCommands_gr
 \brief    Reset Target with Device specific sequence.
@@ -495,7 +507,7 @@ This command calls the user configurable function \ref RESET_TARGET.
 \code
 | BYTE |
 > 0x0A |
-|******| 
+|******|
 \endcode
 
 <b>DAP_ResetTarget Response</b>:
@@ -513,18 +525,18 @@ This command calls the user configurable function \ref RESET_TARGET.
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWJ_Pins DAP_SWJ_Pins
 \ingroup DAP_swj_gr
-\brief Control and monitor SWD/JTAG Pins 
+\brief Control and monitor SWD/JTAG Pins
 \details
 
 The <b>DAP_SWJ_Pins Command</b> is used to monitor and control the I/O Pins including the nRESET Device reset line.
 
 The <b>Pin Wait</b> time is useful in systems where the nRESET pin is implemented as open-drain output.
-After nRESET is de-asserted by the debugger, external circuit may still hold the target Device 
-under reset for a time. Using the <b>Pin Wait</b> time, the debugger may monitor 
-selected I/O Pins and wait until they the expected value appears or a timeout expires. 
+After nRESET is de-asserted by the debugger, external circuit may still hold the target Device
+under reset for a time. Using the <b>Pin Wait</b> time, the debugger may monitor
+selected I/O Pins and wait until they the expected value appears or a timeout expires.
 
 <b>I/O Pin Mapping</b> for the fields <b>Pin Output</b>, <b>Pin Select</b>, and <b>Pin Input</b>:
   - Bit 0: SWCLK/TCK
@@ -534,7 +546,7 @@ selected I/O Pins and wait until they the expected value appears or a timeout ex
   - Bit 5: nTRST
   - Bit 7: nRESET
 
-  
+
 <b>DAP_SWJ_Pins Command</b>:
 \code
 | BYTE | BYTE ******| BYTE ******| Word ****|
@@ -559,10 +571,10 @@ selected I/O Pins and wait until they the expected value appears or a timeout ex
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWJ_Clock DAP_SWJ_Clock
 \ingroup DAP_swj_gr
-\brief Select SWD/JTAG Clock 
+\brief Select SWD/JTAG Clock
 \details
 The <b>DAP_SWJ_Clock Command</b> sets the clock frequency for JTAG and SWD communication mode.
 
@@ -587,13 +599,13 @@ The <b>DAP_SWJ_Clock Command</b> sets the clock frequency for JTAG and SWD commu
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWJ_Sequence DAP_SWJ_Sequence
 \ingroup DAP_swj_gr
-\brief Generate SWJ sequence SWDIO/TMS \@SWCLK/TCK 
+\brief Generate SWJ sequence SWDIO/TMS \@SWCLK/TCK
 \details
 
-The <b>DAP_SWJ_Sequence Command</b> can be used to generate required SWJ sequences for 
+The <b>DAP_SWJ_Sequence Command</b> can be used to generate required SWJ sequences for
 SWD/JTAG Reset, SWD<->JTAG switch and Dormant operation.
 
 <b>DAP_SWJ_Sequence Command</b>
@@ -619,12 +631,12 @@ SWD/JTAG Reset, SWD<->JTAG switch and Dormant operation.
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWD_Configure DAP_SWD_Configure
 \ingroup DAP_swd_gr
 \brief Configure SWD Protocol
 \details
-The <b>DAP_SWD_Configure Command</b> sets the SWD protocol configuration. For more information about 
+The <b>DAP_SWD_Configure Command</b> sets the SWD protocol configuration. For more information about
 the SWD protocol refer to the <b>Arm Debug Interface v5 - Interface Specification.</b>
 
 <b>DAP_SWD_Configure Command</b>:
@@ -651,7 +663,7 @@ the SWD protocol refer to the <b>Arm Debug Interface v5 - Interface Specificatio
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWD_Sequence DAP_SWD_Sequence
 \ingroup DAP_swd_gr
 \brief Generate SWD sequence and output on SWDIO or capture input from SWDIO data.
@@ -666,7 +678,7 @@ For example, for SWD multi-drop target selection (see picture) it is required to
 \image html "SWD_Sequence.png" "SWD sequence for multi-drop target selection"
 
  - For mode=0 (output: SWDIO is driven), the data for the SWDIO pin are part of the <b>DAP_SWD_Sequence Command</b>.
- - For mode=1 (input: SWDIO is not driven), the data from the SWDIO pin are captured and returned as part of the <b>DAP_SWD_Sequence Response</b>. 
+ - For mode=1 (input: SWDIO is not driven), the data from the SWDIO pin are captured and returned as part of the <b>DAP_SWD_Sequence Response</b>.
 
 <b>DAP_SWD_Sequence Command</b>:
 \code
@@ -699,7 +711,7 @@ For example, for SWD multi-drop target selection (see picture) it is required to
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWO_Transport DAP_SWO_Transport
 \ingroup DAP_swo_gr
 \brief Set SWO transport mode
@@ -715,11 +727,11 @@ Sets the SWO transport mode for reading trace data.
  | BYTE | BYTE      |
  > 0x17 | Transport |
  |******|***********|
-\endcode  
+\endcode
 
   - \b Transport:
     - 0 - None (default)
-    - 1 - Read trace data via DAP_SWO_Data command   
+    - 1 - Read trace data via DAP_SWO_Data command
     - 2 - Send trace data via separate \ref WinUSB "WinUSB" endpoint (requires CMSIS-DAP v2 configuration)
     - ... - reserved
 
@@ -737,7 +749,7 @@ Sets the SWO transport mode for reading trace data.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWO_Mode DAP_SWO_Mode
 \ingroup DAP_swo_gr
 \brief Set SWO capture mode
@@ -753,11 +765,11 @@ Sets the SWO trace capture mode.
  | BYTE | BYTE |
  > 0x18 | Mode |
  |******|******|
-\endcode  
+\endcode
 
 - \b Mode:
   - 0 - Off (default)
-  - 1 - UART    
+  - 1 - UART
   - 2 - Manchester
 
 <b>DAP_SWO_Mode Response:</b>
@@ -771,7 +783,7 @@ Sets the SWO trace capture mode.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWO_Baudrate DAP_SWO_Baudrate
 \ingroup DAP_swo_gr
 \brief Set SWO baudrate
@@ -787,7 +799,7 @@ Sets the baudrate for capturing SWO trace data. Can be called iteratively to det
  | BYTE | WORD     |
  > 0x19 | Baudrate |
  |******|**********|
-\endcode  
+\endcode
   - \b Baudrate: Requested baudrate
 
 <b>DAP_SWO_Baudrate Response:</b>
@@ -809,7 +821,7 @@ Sets the baudrate for capturing SWO trace data. Can be called iteratively to det
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWO_Control DAP_SWO_Control
 \ingroup DAP_swo_gr
 \brief Control SWO trace data capture
@@ -825,7 +837,7 @@ Controls the SWO trace data capture.
  | BYTE | BYTE    |
  > 0x1A | Control |
  |******|*********|
-\endcode  
+\endcode
   - \b Control:
     - 0 - Stop
     - 1 - Start
@@ -843,7 +855,7 @@ Controls the SWO trace data capture.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWO_Status DAP_SWO_Status
 \ingroup DAP_swo_gr
 \brief Read SWO trace status
@@ -859,7 +871,7 @@ Reads the SWO trace status.
  | BYTE |
  > 0x1B |
  |******|
-\endcode  
+\endcode
 
 <b>DAP_SWO_Status Response:</b>
 \code
@@ -876,7 +888,7 @@ Reads the SWO trace status.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWO_ExtendedStatus DAP_SWO_ExtendedStatus
 \ingroup DAP_swo_gr
 \brief Read SWO trace extended status
@@ -892,7 +904,7 @@ Reads extended information about the SWO trace status.
  | BYTE | BYTE    |
  > 0x1E | Control |
  |******|*********|
-\endcode  
+\endcode
 
   - <b>Control</b>:
     - Bit 0: Trace Status (1 - request, 0 - inactive)
@@ -918,12 +930,12 @@ Reads extended information about the SWO trace status.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_SWO_Data DAP_SWO_Data
 \ingroup DAP_swo_gr
 \brief Read SWO trace data
 \details
-  
+
 DAP_SWO_Data (0x1C):
 --------------------
 
@@ -934,7 +946,7 @@ Reads the captured SWO trace data from Trace Buffer.
  | BYTE | SHORT       |
  > 0x1C | Trace Count |
  |******|*************|
-\endcode  
+\endcode
   - <b>Trace Count</b>: Maxim number of Trace Data bytes to read
 
 <b>DAP_SWO_Data Response:</b>
@@ -953,13 +965,13 @@ Reads the captured SWO trace data from Trace Buffer.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_JTAG_Sequence DAP_JTAG_Sequence
 \ingroup DAP_jtag_gr
-\brief Generate JTAG sequence TMS, TDI and capture TDO 
+\brief Generate JTAG sequence TMS, TDI and capture TDO
 \details
 The <b>DAP_JTAG_Sequence Command</b> may be used to auto-detect devices on the JTAG chain.
-The result of this command can be used to calculate on the host computer the number of JTAG 
+The result of this command can be used to calculate on the host computer the number of JTAG
 devices and the JTAG IR register length. This information is the input for \ref DAP_JTAG_Configure.
 
 <b>DAP_JTAG_Sequence Command</b>:
@@ -993,7 +1005,7 @@ devices and the JTAG IR register length. This information is the input for \ref 
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_JTAG_Configure DAP_JTAG_Configure
 \ingroup DAP_jtag_gr
 \brief Configure JTAG Chain
@@ -1005,7 +1017,7 @@ configured by the debugger on the host computer.
 <b>DAP_JTAG_Configure Command</b>:
 \code
 | BYTE | BYTE *| BYTE *****|
-> 0x15 | Count | IR Length | 
+> 0x15 | Count | IR Length |
 |******|*******|+++++++++++|
 \endcode
 
@@ -1024,7 +1036,7 @@ configured by the debugger on the host computer.
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_jtag_idcode DAP_JTAG_IDCODE
 \ingroup DAP_jtag_gr
 \brief Read JTAG IDCODE
@@ -1053,7 +1065,7 @@ The <b>DAP_JTAG_IDCODE Command</b> request the JTAG IDCODE for the selected devi
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_TransferConfigure DAP_TransferConfigure
 \ingroup DAP_transfer_gr
 \brief Configure Transfers
@@ -1069,7 +1081,7 @@ The <b>DAP_TransferConfigure Command</b> sets parameters for \ref DAP_Transfer a
 
 - <b>Idle Cycles</b>: Number of extra idle cycles after each transfer.
 - <b>WAIT Retry</b>: Number of transfer retries after WAIT response.
-- <b>Match Retry</b>: Number of retries on reads with Value Match in \ref DAP_Transfer. On value mismatch the 
+- <b>Match Retry</b>: Number of retries on reads with Value Match in \ref DAP_Transfer. On value mismatch the
     Register is read again until its value matches or the <b>Match Retry</b> count exceeds.\n
 \code
   retry = Match_Retry;
@@ -1090,7 +1102,7 @@ The <b>DAP_TransferConfigure Command</b> sets parameters for \ref DAP_Transfer a
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_Transfer DAP_Transfer
 \ingroup DAP_transfer_gr
 \brief Read/write single and multiple registers.
@@ -1101,7 +1113,7 @@ Each CoreSight register is accessed with a single 32-bit read or write.
 The CoreSight registers are addressed with DPBANKSEL/APBANKSEL and address lines A2, A3 (A0 = 0 and A1 = 0).
 This command executes several read/write operations on the selected DP/AP registers.
 The Transfer Data in the Response are in the order of the Transfer Request in the Command but might be shorter in case of communication failures.
-The data transfer is aborted on a communication error: 
+The data transfer is aborted on a communication error:
   - Protocol Error
   - Target FAULT response
   - Target WAIT responses exceed configured value
@@ -1135,9 +1147,9 @@ The data transfer is aborted on a communication error:
 
 \note
 <b>Transfer Request</b> - Bit 7 (Time Stamp) cannot be combined with Bit 4 (Value Match) or Bit 5 (Match Mask).
-  
-  
-  
+
+
+
 <b>DAP_Transfer Response:</b>
 \code
 | BYTE | BYTE **********| BYTE *************| WORD ********| WORD *********|
@@ -1151,7 +1163,7 @@ The data transfer is aborted on a communication error:
   - Bit 2..0: ACK (Acknowledge) value:
       - 1 = OK (for SWD protocol), OK or FAULT (for JTAG protocol),
       - 2 = WAIT
-      - 4 = FAULT 
+      - 4 = FAULT
       - 7 = NO_ACK (no response from target)
   - Bit 3: 1 = Protocol Error (SWD)
   - Bit 4: 1 = Value Mismatch (Read Register with Value Match)
@@ -1165,7 +1177,7 @@ The data transfer is aborted on a communication error:
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_TransferBlock DAP_TransferBlock
 \ingroup DAP_transfer_gr
 \brief Read/Write a block of data from/to a single register.
@@ -1176,7 +1188,7 @@ A data block are multiple 32-bit values which are read or written from/to the sa
 The CoreSight register is addressed with DPBANKSEL/APBANKSEL and address lines A2, A3 (A0 = 0 and A1 = 0).
 The command can execute several read/write operations to a single DP/AP register.
 
-The data transfer is aborted on a communication error: 
+The data transfer is aborted on a communication error:
   - Protocol Error
   - Target FAULT response
   - Target WAIT responses exceed configured value
@@ -1198,7 +1210,7 @@ The data transfer is aborted on a communication error:
   - Bit 2: A2 := Register Address bit 2
   - Bit 3: A3 := Register Address bit 3
 
-- <b>Transfer Data</b>: register values  
+- <b>Transfer Data</b>: register values
   - for Write Register transfer request: the register values written to the CoreSight register.
   - no data is sent for Read Register operations.
 
@@ -1217,23 +1229,23 @@ The data transfer is aborted on a communication error:
   - Bit 2..0: ACK (Acknowledge) value:
       - 1 = OK (for SWD protocol), OK or FAULT (for JTAG protocol),
       - 2 = WAIT
-      - 4 = FAULT 
+      - 4 = FAULT
       - 7 = NO_ACK (no response from target)
   - Bit 3: Protocol Error (SWD)
 
-- <b>Transfer Data</b>: register values  
+- <b>Transfer Data</b>: register values
   - no data is receive for Write Register operations.
   - for Read Register transfer request: the register values read from CoreSight register.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_TransferAbort DAP_TransferAbort
 \ingroup DAP_transfer_gr
 \brief Abort current Transfer
 \details
 The <b>DAP_TransferAbort Command</b> aborts the current transfer. The command can be executed while \ref DAP_Transfer or \ref DAP_TransferBlock command
-is still in progress. The command is ignored if there is no transfer in progress. The command itself has no response, however the 
+is still in progress. The command is ignored if there is no transfer in progress. The command itself has no response, however the
 aborted \ref DAP_Transfer or \ref DAP_TransferBlock command will respond with information about the actually transferred data.
 
 <b>DAP_TransferAbort Command</b>:
@@ -1247,7 +1259,7 @@ aborted \ref DAP_Transfer or \ref DAP_TransferBlock command will respond with in
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_ExecuteCommands_gr DAP_ExecuteCommands
 \ingroup DAP_atomic_gr
 \brief Execute multiple DAP commands from a single packet.
@@ -1262,8 +1274,8 @@ Executes multiple DAP commands that are provided in a single packet. Packet size
 \endcode
 
   - \b NumCmd: Number of commands to execute
-  - <b>Commands Requests</b>: Concatenated command requests 
-  
+  - <b>Commands Requests</b>: Concatenated command requests
+
 <b>DAP_ExecuteCommands Response:</b>
 \code
  | BYTE | BYTE **|+++++++++++++++++++|
@@ -1273,7 +1285,7 @@ Executes multiple DAP commands that are provided in a single packet. Packet size
 
   - \b NumCmd: Number of commands executed
   - <b>Commands Responses</b>: Concatenated command responses
-  
+
 <b>Example</b>:
 
 Execute two \ref DAP_SWJ_Pins commands with \ref DAP_Delay in between.
@@ -1299,7 +1311,7 @@ Execute two \ref DAP_SWJ_Pins commands with \ref DAP_Delay in between.
 
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_QueueCommands_gr DAP_QueueCommands
 \ingroup DAP_atomic_gr
 \brief Queue multiple DAP commands provided in a multiple packets.
@@ -1328,8 +1340,8 @@ The command is similar to \ref DAP_ExecuteCommands_gr on a packet level but queu
         Queued commands are executed before this command
  - \b NumCmd: Number of commands to queue (single packet)
  - <b>Commands Requests</b>: Concatenated command requests (single packet)
- 
-<b>DAP_QueueCommands Response:</b> 
+
+<b>DAP_QueueCommands Response:</b>
 \code
  | BYTE | BYTE **|+++++++++++++++++++|
  < 0x7F | NumCmd | Command Responses |
@@ -1345,7 +1357,7 @@ The command is similar to \ref DAP_ExecuteCommands_gr on a packet level but queu
  - \b < Command Response (first non \b DAP_QueueCommands command)
  - \b NumCmd: Number of commands executed (single packet)
  - <b>Commands Responses</b>: Concatenated command responses (single packet)
- 
+
 \b Example:
 
 Queue \ref DAP_SWJ_Pins and \ref DAP_Delay in first packet. \n
@@ -1360,17 +1372,17 @@ Send \ref DAP_SWJ_Pins in fourth packet which executes queued commands and comma
  > 0x7E | 0x02 | 0x10 | Pin Output | Pin Select | Pin Wait | 0x09 | Delay |
  |******|******|******|************|************|**********|******|*******|
    Queue|NumCmd| DAP_SWJ_Pins                              | DAP_Delay    |
-    
+
  | BYTE | BYTE | BYTE | BYTE ******| BYTE ******| WORD ****|
  > 0x7E | 0x01 | 0x10 | Pin Output | Pin Select | Pin Wait |
  |******|******|******|************|************|**********|
    Queue|NumCmd| DAP_SWJ_Pins                              |
-    
+
  | BYTE | BYTE | BYTE | SHORT |
  > 0x7E | 0x01 | 0x09 | Delay |
  |******|******|******|*******|
    Queue|NumCmd| DAP_Delay    |
-    
+
  | BYTE | BYTE ******| BYTE ******| WORD ****|
  > 0x10 | Pin Output | Pin Select | Pin Wait |
  |******|************|************|**********|
@@ -1384,26 +1396,26 @@ Send \ref DAP_SWJ_Pins in fourth packet which executes queued commands and comma
  < 0x7F | 0x02 | 0x10 | Pin Input | 0x09 | Status |
  |******|******|******|***********|******|********|
         |NumCmd| DAP_SWJ_Pins     | DAP_Delay     |
-  
+
  | BYTE | BYTE | BYTE | BYTE *****|
  < 0x7F | 0x01 | 0x10 | Pin Input |
  |******|******|******|***********|
         |NumCmd| DAP_SWJ_Pins     |
-   
+
  | BYTE | BYTE | BYTE | BYTE **|
  < 0x7F | 0x01 | 0x09 | Status |
  |******|******|******|********|
         |NumCmd| DAP_Delay     |
-   
+
  | BYTE | BYTE *****|
  < 0x10 | Pin Input |
  |******|***********|
    DAP_SWJ_Pins     |
-\endcode   
+\endcode
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_UART_Transport DAP_UART_Transport
 \ingroup DAP_uart_gr
 \brief Set UART transport mode.
@@ -1425,11 +1437,11 @@ Sets the UART transport mode for receiving and transmitting data.
   - 1 - Transport data via USB COM Port (default, if implemented).
   - 2 - Transport data via DAP commands.
 
-\note By default, data is transported via the USB COM Port (if implemented). In this case, 
-      the UART is controlled via a terminal (for example Putty), which can configure the 
+\note By default, data is transported via the USB COM Port (if implemented). In this case,
+      the UART is controlled via a terminal (for example Putty), which can configure the
       UART (data bits, party, baudrate ...) and transfer the data.
 
-\note When transport data via DAP is enabled, CMSIS-DAP takes control over the UART with commands: 
+\note When transport data via DAP is enabled, CMSIS-DAP takes control over the UART with commands:
       \ref DAP_UART_Configure, \ref DAP_UART_Control, \ref DAP_UART_Status and \ref DAP_UART_Transfer.
 
 <b>DAP_UART_Transport Response:</b>
@@ -1443,7 +1455,7 @@ Sets the UART transport mode for receiving and transmitting data.
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_UART_Configure DAP_UART_Configure
 \ingroup DAP_uart_gr
 \brief Set UART configuration.
@@ -1480,7 +1492,7 @@ Sets the UART configuration (only for transport via DAP).
  |******|********|**********|
 \endcode
 
-- <b>Status</b>: 0x00 = OK else ERROR: 
+- <b>Status</b>: 0x00 = OK else ERROR:
   - Bit 0: 1 = Data bits configuration error.
   - Bit 1: 1 = Parity configuration error.
   - Bit 2: 1 = Stop bits configuration error.
@@ -1494,7 +1506,7 @@ Sets the UART configuration (only for transport via DAP).
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_UART_Control DAP_UART_Control
 \ingroup DAP_uart_gr
 \brief Control UART data receive and transmit.
@@ -1539,7 +1551,7 @@ Enables and disables UART receive and transmit (only for transport via DAP).
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_UART_Status DAP_UART_Status
 \ingroup DAP_uart_gr
 \brief Get UART status.
@@ -1582,7 +1594,7 @@ Reads UART status (only for transport via DAP).
 */
 
 /**************************************************************************************************/
-/** 
+/**
 \defgroup DAP_UART_Transfer DAP_UART_Transfer
 \ingroup DAP_uart_gr
 \brief Transfer data via UART.
@@ -1628,7 +1640,7 @@ Receive and Transmit data via target UART (only for transport via DAP).
 - <b>Tx Count</b>: Number of bytes accepted from <b>Transmit data</b> and queued to UART transmit buffer.
 
 - <b>Rx Count</b>: Number of bytes in <b>Receive data</b> read from UART receive buffer.
-  
+
 - <b>Receive data</b>: Bytes received from the target device via UART.
 
 */


### PR DESCRIPTION
These changes implement the proposal from #962, improving the version info reported by the DAP_Info command.

- Add ID 0x07, `DAP_ID_PRODUCT_VER`: **Product Firmware Version** (string), vendor-specified version format.
    - A stub for `DAP_ProductFirmwareVerString()` was added to `DAP_config.h`.
- Change ID 0x04 to be specified as: **CMSIS-DAP Protocol Version** (string). The value must be one of the versions from the \ref dap_revisionHistory "CMSIS-DAP revision history", such as "2.0.0"
    - Changed the constant in `DAP.h` to `DAP_ID_CMSIS_DAP_VER`.
    - Kept `DAP_ID_FW_VER` as an alias of `DAP_ID_CMSIS_DAP_VER`, with a comment saying it's deprecated.

Other included changes:
- Rebuilt the example projects to update the included .axf files.
- Added a `.gitignore` to ignore the generated `Objects` and `Listings` folders under the examples.
- Bumped CMSIS-DAP to version 2.1.0.

All changes have been tested in DAPLink and pyOCD.