### PR TITLE
Correct DSP document: Correct the size of the referenced sine table.

### DIFF
--- a/CMSIS/DSP/Source/FastMathFunctions/arm_cos_f32.c
+++ b/CMSIS/DSP/Source/FastMathFunctions/arm_cos_f32.c
@@ -44,7 +44,7 @@
   [0 +0.9999] mapping to [0 2*pi).  The fixed-point range is chosen so that a
   value of 2*pi wraps around to 0.
 
-  The implementation is based on table lookup using 256 values together with linear interpolation.
+  The implementation is based on table lookup using 512 values together with linear interpolation.
   The steps used are:
    -# Calculation of the nearest integer table index
    -# Compute the fractional portion (fract) of the table index.

--- a/CMSIS/DSP/Source/FastMathFunctions/arm_sin_f32.c
+++ b/CMSIS/DSP/Source/FastMathFunctions/arm_sin_f32.c
@@ -44,7 +44,7 @@
   [0 +0.9999] mapping to [0 2*pi).  The fixed-point range is chosen so that a
   value of 2*pi wraps around to 0.
 
-  The implementation is based on table lookup using 256 values together with linear interpolation.
+  The implementation is based on table lookup using 512 values together with linear interpolation.
   The steps used are:
    -# Calculation of the nearest integer table index
    -# Compute the fractional portion (fract) of the table index.


### PR DESCRIPTION
The size of the sinTable is 512 + 1 according to FAST_MATH_TABLE_SIZE = 512. The documentation says that sin(cos) is derived by linear interpolation with a value of 256, so I've corrected this to 512.