### PR TITLE
fix thread insertion in ready list when blocked by higher priority thread

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_thread.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_thread.c
@@ -400,7 +400,7 @@ static void osRtxThreadBlock (os_thread_t *thread) {
   prev = osRtxThreadObject(&osRtxInfo.thread.ready);
   next = prev->thread_next;
 
-  while ((next != NULL) && (next->priority > priority)) {
+  while ((next != NULL) && (next->priority >= priority)) {
     prev = next;
     next = next->thread_next;
   }


### PR DESCRIPTION
Hi,
I encountered the following issue using rtx.
There is a situation in which i ended up with one thread not sharing time with threads with same priority, in round-robin scheduling.
This happens when the thread in question is frequently interrupted by a higher priority thread.
In this interrupt the thread is blocked and reinserted in the ready list before other processes with same priority.
In the end, if a thread is always interrupted before it ends its timeslice, it never gives other threads with same priority the chance to run.
I think this can easily be fixed inserting the blocked thread in the ready list after al threads with same priority already in.