### PR TITLE
Add stdint.h to arm_nn_types.h

### DIFF
--- a/CMSIS/NN/Include/arm_nn_types.h
+++ b/CMSIS/NN/Include/arm_nn_types.h
@@ -28,10 +28,10 @@
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
 
-#include <stdint.h>
-
 #ifndef _ARM_NN_TYPES_H
 #define _ARM_NN_TYPES_H
+
+#include <stdint.h>
 
 /** CMSIS-NN object to contain the width and height of a tile */
 typedef struct

--- a/CMSIS/NN/Include/arm_nn_types.h
+++ b/CMSIS/NN/Include/arm_nn_types.h
@@ -28,6 +28,7 @@
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
 
+#include <stdint.h>
 
 #ifndef _ARM_NN_TYPES_H
 #define _ARM_NN_TYPES_H

--- a/CMSIS/NN/Include/arm_nn_types.h
+++ b/CMSIS/NN/Include/arm_nn_types.h
@@ -28,6 +28,7 @@
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
 
+
 #ifndef _ARM_NN_TYPES_H
 #define _ARM_NN_TYPES_H
 


### PR DESCRIPTION
Ensure int32_t and other stdint types are recognized.

Fixes https://github.com/ARM-software/CMSIS_5/issues/1009