### PR TITLE
fix bug in documentation

### DIFF
--- a/CMSIS/DoxyGen/Core/src/Ref_NVIC.txt
+++ b/CMSIS/DoxyGen/Core/src/Ref_NVIC.txt
@@ -482,7 +482,7 @@ void NVIC_EnableIRQ(IRQn_Type IRQn);
     
     \returns    
             - 0  Interrupt is not enabled
-            - 1  Interrupt is pending
+            - 1  Interrupt is enabled
 
     \remarks
         - IRQn must not be negative.


### PR DESCRIPTION
there was fault for `uint32_t NVIC_GetEnableIRQ(IRQn_Type IRQn)` function documentation that fixed.