### PR TITLE
CMSIS-Core: Fix for correct use of asm keyword

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -1964,9 +1964,9 @@ __STATIC_FORCEINLINE uint32_t __SXTB16(uint32_t op1)
 
 __STATIC_FORCEINLINE uint32_t __SXTB16_RORn(uint32_t op1, uint32_t rotate)
 {
-  uint32_t result; 
+  uint32_t result;
   if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U))) {
-    asm volatile ("sxtb16 %0, %1, ROR %2" : "=r" (result) : "r" (op1), "i" (rotate) ); 
+    __ASM volatile ("sxtb16 %0, %1, ROR %2" : "=r" (result) : "r" (op1), "i" (rotate) );
   } else {
     result = __SXTB16(__ROR(op1, rotate)) ;
   }


### PR DESCRIPTION
asm keyword is replaced by compiler specific  __ASM define
for __SXTB16_RORn()