### PR TITLE
Do not build f16 code if datatype is disabled

### DIFF
--- a/CMSIS/DSP/Source/TransformFunctions/CMakeLists.txt
+++ b/CMSIS/DSP/Source/TransformFunctions/CMakeLists.txt
@@ -119,6 +119,7 @@ target_sources(CMSISDSPTransform PRIVATE arm_rfft_fast_f64.c)
 target_sources(CMSISDSPTransform PRIVATE arm_rfft_fast_init_f64.c)
 endif()
 
+if ((NOT DISABLEFLOAT16))
 if (NOT CONFIGTABLE OR ALLFFT OR RFFT_FAST_F16_32 OR RFFT_FAST_F16_64 OR RFFT_FAST_F16_128
    OR RFFT_FAST_F16_256 OR RFFT_FAST_F16_512 OR RFFT_FAST_F16_1024 OR RFFT_FAST_F16_2048
    OR RFFT_FAST_F16_4096 )
@@ -127,6 +128,7 @@ target_sources(CMSISDSPTransform PRIVATE arm_rfft_fast_init_f16.c)
 target_sources(CMSISDSPTransform PRIVATE arm_cfft_f16.c)
 target_sources(CMSISDSPTransform PRIVATE arm_cfft_init_f16.c)
 target_sources(CMSISDSPTransform PRIVATE arm_cfft_radix8_f16.c)
+endif()
 endif()
 
 if (NOT CONFIGTABLE OR ALLFFT OR RFFT_F32_128 OR RFFT_F32_512 OR RFFT_F32_2048 OR RFFT_F32_8192)


### PR DESCRIPTION
to not build float16 code if the datatype is disabled.

Not sure if the condition should be extended. Feel free to adapt