### PR TITLE
Doxygen: Fixed XML schema documentation (issue #1044)

### DIFF
--- a/CMSIS/DoxyGen/Pack/src/pdsc_format.txt
+++ b/CMSIS/DoxyGen/Pack/src/pdsc_format.txt
@@ -156,7 +156,7 @@ assists searching for packages.
   <tr>
     <td>xmlns:xs</td>
     <td>Is set to: \token{"http://www.w3.org/2001/XMLSchema-instance"} to indicate compliance to the XML format.</td>
-    <td>xs:decimal</td>
+    <td>xs:string</td>
     <td>required</td>
   </tr>
   <tr>

--- a/CMSIS/DoxyGen/SVD/src/svd_schema.txt
+++ b/CMSIS/DoxyGen/SVD/src/svd_schema.txt
@@ -110,11 +110,11 @@ is set for all registers unless redefined at a lower level.
     <td>xmlns:xs</td>
     <td>Specify the underlying XML schema to which the CMSIS-SVD schema is compliant. 
     Has to be set to: \token{"http://www.w3.org/2001/XMLSchema-instance"}.</td>
-    <td>xs:decimal</td>
+    <td>xs:string</td>
     <td>required</td>
   </tr>
   <tr>
-    <td>xmlns:xs</td>
+    <td>xs:noNamespaceSchemaLocation</td>
     <td>Specify the file path and file name of the CMSIS-SVD Schema. For example, \token{CMSIS-SVD.xsd}.</td>
     <td>xs:string</td>
     <td>required</td>

--- a/CMSIS/DoxyGen/Zone/src/XML_Format.txt
+++ b/CMSIS/DoxyGen/Zone/src/XML_Format.txt
@@ -175,7 +175,7 @@ The \ref xml_rzone_pg element is the root element of the .rzone file which descr
   <tr>
     <td>xmlns:xs</td>
     <td>Is set to: \token{"http://www.w3.org/2001/XMLSchema-instance"} to indicate compliance to the XML format.</td>
-    <td>xs:decimal</td>
+    <td>xs:string</td>
     <td>required</td>
   </tr>
   <tr>
@@ -1367,7 +1367,7 @@ The \ref xml_azone_pg element is the root element of the .azone file which store
   <tr>
     <td>xmlns:xs</td>
     <td>Is set to: \token{"http://www.w3.org/2001/XMLSchema-instance"} to indicate compliance to the XML format.</td>
-    <td>xs:decimal</td>
+    <td>xs:string</td>
     <td>required</td>
   </tr>
   <tr>


### PR DESCRIPTION
SVD:
 - xmlns:xs has type xs:string, not xs:decimal
 - xs:noNamespaceSchemaLocation was missing in favor
    of repeated xmlns:ns attribute.

PDSC:
 - xmlns:xs has type xs:string, not xs:decimal

Zone:
 - xmlns:xs has type xs:string, not xs:decimal