### PR TITLE
docs: fix simple typo, accumlate -> accumulate

### DIFF
--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_opt_q15.c
@@ -220,7 +220,7 @@ void arm_conv_fast_opt_q15(
       y1 = read_q15x2_ia ((q15_t **) &pIn2);
       y2 = read_q15x2_ia ((q15_t **) &pIn2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x1, y1, acc0);
       acc2 = __SMLAD(x2, y1, acc2);
 
@@ -231,13 +231,13 @@ void arm_conv_fast_opt_q15(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLADX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
       x1 = read_q15x2_ia (&pScr1);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x2, y2, acc0);
       acc2 = __SMLAD(x1, y2, acc2);
 
@@ -273,7 +273,7 @@ void arm_conv_fast_opt_q15(
 
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2);
       acc1 += (*pScr1++ * *pIn2);
       acc2 += (*pScr1++ * *pIn2);
@@ -340,7 +340,7 @@ void arm_conv_fast_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2++);
 
       /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q15.c
@@ -216,7 +216,7 @@ void arm_conv_opt_q15(
       y1 = read_q15x2_ia ((q15_t **) &pIn2);
       y2 = read_q15x2_ia ((q15_t **) &pIn2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLALD(x1, y1, acc0);
       acc2 = __SMLALD(x2, y1, acc2);
 
@@ -227,13 +227,13 @@ void arm_conv_opt_q15(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLALDX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
       x1 = read_q15x2_ia (&pScr1);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLALD(x2, y2, acc0);
       acc2 = __SMLALD(x1, y2, acc2);
 
@@ -269,7 +269,7 @@ void arm_conv_opt_q15(
 
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2);
       acc1 += (*pScr1++ * *pIn2);
       acc2 += (*pScr1++ * *pIn2);
@@ -336,7 +336,7 @@ void arm_conv_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2++);
 
       /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q7.c
@@ -223,7 +223,7 @@ void arm_conv_opt_q7(
       /* Read four samples from smaller buffer */
       y1 = read_q15x2_ia (&pScr2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x1, y1, acc0);
       acc2 = __SMLAD(x2, y1, acc2);
 
@@ -234,7 +234,7 @@ void arm_conv_opt_q7(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLADX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
@@ -280,7 +280,7 @@ void arm_conv_opt_q7(
 
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2);
       acc1 += (*pScr1++ * *pScr2);
       acc2 += (*pScr1++ * *pScr2);
@@ -335,7 +335,7 @@ void arm_conv_opt_q7(
     /* apply same above for remaining samples of smaller length sequence */
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2++);
 
       /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_opt_q15.c
@@ -230,7 +230,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         y1 = read_q15x2_ia ((q15_t **) &pIn2);
         y2 = read_q15x2_ia ((q15_t **) &pIn2);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLAD(x1, y1, acc0);
         acc2 = __SMLAD(x2, y1, acc2);
 
@@ -241,13 +241,13 @@ arm_status arm_conv_partial_fast_opt_q15(
         x3 = __PKHBT(x1, x2, 0);
 #endif
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 = __SMLADX(x3, y1, acc1);
 
         /* Read next two samples from scratch1 buffer */
         x1 = read_q15x2_ia (&pScr1);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLAD(x2, y2, acc0);
         acc2 = __SMLAD(x1, y2, acc2);
 
@@ -269,7 +269,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         x3 = __PKHBT(x1, x2, 0);
 #endif
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc3 = __SMLADX(x3, y2, acc3);
 
         /* Decrement loop counter */
@@ -284,7 +284,7 @@ arm_status arm_conv_partial_fast_opt_q15(
 
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2);
         acc1 += (*pScr1++ * *pIn2);
         acc2 += (*pScr1++ * *pIn2);
@@ -342,7 +342,7 @@ arm_status arm_conv_partial_fast_opt_q15(
         /* Read two samples from smaller buffer */
         y1 = read_q15x2_ia ((q15_t **) &pIn2);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLAD(x1, y1, acc0);
 
         /* Decrement loop counter */
@@ -354,7 +354,7 @@ arm_status arm_conv_partial_fast_opt_q15(
       /* apply same above for remaining samples of smaller length sequence */
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2++);
 
         /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q15.c
@@ -231,7 +231,7 @@ arm_status arm_conv_partial_opt_q15(
         y1 = read_q15x2_ia ((q15_t **) &pIn2);
         y2 = read_q15x2_ia ((q15_t **) &pIn2);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLALD(x1, y1, acc0);
         acc2 = __SMLALD(x2, y1, acc2);
 
@@ -242,13 +242,13 @@ arm_status arm_conv_partial_opt_q15(
         x3 = __PKHBT(x1, x2, 0);
 #endif
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 = __SMLALDX(x3, y1, acc1);
 
         /* Read next two samples from scratch1 buffer */
         x1 = read_q15x2_ia (&pScr1);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLALD(x2, y2, acc0);
         acc2 = __SMLALD(x1, y2, acc2);
 
@@ -284,7 +284,7 @@ arm_status arm_conv_partial_opt_q15(
 
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2);
         acc1 += (*pScr1++ * *pIn2);
         acc2 += (*pScr1++ * *pIn2);
@@ -353,7 +353,7 @@ arm_status arm_conv_partial_opt_q15(
       /* apply same above for remaining samples of smaller length sequence */
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pIn2++);
 
         /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q7.c
@@ -241,7 +241,7 @@ arm_status arm_conv_partial_opt_q7(
         /* Read four samples from smaller buffer */
         y1 = read_q15x2_ia (&pScr2);
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc0 = __SMLAD(x1, y1, acc0);
         acc2 = __SMLAD(x2, y1, acc2);
 
@@ -252,7 +252,7 @@ arm_status arm_conv_partial_opt_q7(
         x3 = __PKHBT(x1, x2, 0);
 #endif
 
-        /* multiply and accumlate */
+        /* multiply and accumulate */
         acc1 = __SMLADX(x3, y1, acc1);
 
         /* Read next two samples from scratch1 buffer */
@@ -298,7 +298,7 @@ arm_status arm_conv_partial_opt_q7(
 
       while (tapCnt > 0U)
       {
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pScr2);
         acc1 += (*pScr1++ * *pScr2);
         acc2 += (*pScr1++ * *pScr2);
@@ -360,7 +360,7 @@ arm_status arm_conv_partial_opt_q7(
       while (tapCnt > 0U)
       {
 
-        /* accumlate the results */
+        /* accumulate the results */
         acc0 += (*pScr1++ * *pScr2++);
 
         /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_opt_q15.c
@@ -197,7 +197,7 @@ void arm_correlate_fast_opt_q15(
       y1 = read_q15x2_ia ((q15_t **) &pIn2);
       y2 = read_q15x2_ia ((q15_t **) &pIn2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x1, y1, acc0);
       acc2 = __SMLAD(x2, y1, acc2);
 
@@ -208,13 +208,13 @@ void arm_correlate_fast_opt_q15(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLADX(x3, y1, acc1);
 
       /* Read next two samples from scratch buffer */
       x1 = read_q15x2_ia (&pScr1);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x2, y2, acc0);
       acc2 = __SMLAD(x1, y2, acc2);
 
@@ -250,7 +250,7 @@ void arm_correlate_fast_opt_q15(
 
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2);
       acc1 += (*pScr1++ * *pIn2);
       acc2 += (*pScr1++ * *pIn2);
@@ -318,7 +318,7 @@ void arm_correlate_fast_opt_q15(
     while (tapCnt > 0U)
     {
 
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2++);
 
       /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q15.c
@@ -192,7 +192,7 @@ void arm_correlate_opt_q15(
       y1 = read_q15x2_ia ((q15_t **) &pIn2);
       y2 = read_q15x2_ia ((q15_t **) &pIn2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLALD(x1, y1, acc0);
       acc2 = __SMLALD(x2, y1, acc2);
 
@@ -203,13 +203,13 @@ void arm_correlate_opt_q15(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLALDX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
       x1 = read_q15x2_ia (&pScr1);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLALD(x2, y2, acc0);
       acc2 = __SMLALD(x1, y2, acc2);
 
@@ -245,7 +245,7 @@ void arm_correlate_opt_q15(
 
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2);
       acc1 += (*pScr1++ * *pIn2);
       acc2 += (*pScr1++ * *pIn2);
@@ -314,7 +314,7 @@ void arm_correlate_opt_q15(
     /* apply same above for remaining samples of smaller length sequence */
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pIn2++);
 
       /* Decrement loop counter */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q7.c
@@ -248,7 +248,7 @@ void arm_correlate_opt_q7(
       /* Read four samples from smaller buffer */
       y1 = read_q15x2_ia (&pScr2);
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc0 = __SMLAD(x1, y1, acc0);
       acc2 = __SMLAD(x2, y1, acc2);
 
@@ -259,7 +259,7 @@ void arm_correlate_opt_q7(
       x3 = __PKHBT(x1, x2, 0);
 #endif
 
-      /* multiply and accumlate */
+      /* multiply and accumulate */
       acc1 = __SMLADX(x3, y1, acc1);
 
       /* Read next two samples from scratch1 buffer */
@@ -305,7 +305,7 @@ void arm_correlate_opt_q7(
 
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2);
       acc1 += (*pScr1++ * *pScr2);
       acc2 += (*pScr1++ * *pScr2);
@@ -362,7 +362,7 @@ void arm_correlate_opt_q7(
     /* apply same above for remaining samples of smaller length sequence */
     while (tapCnt > 0U)
     {
-      /* accumlate the results */
+      /* accumulate the results */
       acc0 += (*pScr1++ * *pScr2++);
 
       /* Decrement loop counter */


### PR DESCRIPTION
There is a small typo in CMSIS/DSP/Source/FilteringFunctions/arm_conv_fast_opt_q15.c, CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q15.c, CMSIS/DSP/Source/FilteringFunctions/arm_conv_opt_q7.c, CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_fast_opt_q15.c, CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q15.c, CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_opt_q7.c, CMSIS/DSP/Source/FilteringFunctions/arm_correlate_fast_opt_q15.c, CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q15.c, CMSIS/DSP/Source/FilteringFunctions/arm_correlate_opt_q7.c.

Should read `accumulate` rather than `accumlate`.

