### PR TITLE
Replace keyword __asm with __ASM

### DIFF
--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
@@ -56,7 +56,7 @@ arm_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
 
-        __asm volatile (
+        __ASM volatile (
            "   vldrb.8         q0, [%[col]], 16     \n"
            "   wlstp.8         lr, %[cnt], 1f       \n"
            "2:                                      \n"

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_4x_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_4x_s8.c
@@ -63,7 +63,7 @@ arm_status arm_nn_mat_mul_core_4x_s8(const int32_t row_elements,
     int32_t sum_tmp = 0;
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    __asm volatile(
+    __ASM volatile(
         "   vldrb.8         q0, [%[col]], 16     \n"
         "   wlstp.8         lr, %[cnt], 1f       \n"
         "2:                                      \n"


### PR DESCRIPTION
Replaced __asm keyword with __ASM for a couple of functions
arm_nn_mat_mul_core_1x_s8.c & arm_nn_mat_mul_core_4x_s8.c