### PR TITLE
CMSIS-NN: Add .clang-format file

### DIFF
--- a/CMSIS/NN/.clang-format
+++ b/CMSIS/NN/.clang-format
@@ -1,0 +1,47 @@
+
+# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeElse:      true
+  IndentBraces:    true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+ColumnLimit:     120
+DerivePointerAlignment: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+...
+


### PR DESCRIPTION
.clang-format file is added to NN directory to
specify modifications to the default style when
using clang-format

