### PR TITLE
CMSIS-DSP: Fix signed/unsigned integer data type issue

### DIFF
--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u16.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u16.c
@@ -63,7 +63,7 @@ void arm_and_u16(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q15x8_t vecSrcA, vecSrcB;
+    uint16x8_t vecSrcA, vecSrcB;
 
     /* Compute 8 outputs at a time */
     blkCnt = blockSize >> 3;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u32.c
@@ -55,7 +55,7 @@ void arm_and_u32(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q31x4_t vecSrcA, vecSrcB;
+    uint32x4_t vecSrcA, vecSrcB;
 
     /* Compute 4 outputs at a time */
     blkCnt = blockSize >> 2;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u8.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u8.c
@@ -56,7 +56,7 @@ void arm_and_u8(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q7x16_t vecSrcA, vecSrcB;
+    uint8x16_t vecSrcA, vecSrcB;
 
     /* Compute 16 outputs at a time */
     blkCnt = blockSize >> 4;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_not_u16.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_not_u16.c
@@ -61,7 +61,7 @@ void arm_not_u16(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q15x8_t vecSrc;
+    uint16x8_t vecSrc;
 
     /* Compute 8 outputs at a time */
     blkCnt = blockSize >> 3;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_not_u32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_not_u32.c
@@ -53,7 +53,7 @@ void arm_not_u32(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q31x4_t vecSrc;
+    uint32x4_t vecSrc;
 
     /* Compute 8 outputs at a time */
     blkCnt = blockSize >> 2;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_not_u8.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_not_u8.c
@@ -53,7 +53,7 @@ void arm_not_u8(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q7x16_t vecSrc;
+    uint8x16_t vecSrc;
 
     /* Compute 16 outputs at a time */
     blkCnt = blockSize >> 4;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_or_u16.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_or_u16.c
@@ -63,7 +63,7 @@ void arm_or_u16(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q15x8_t vecSrcA, vecSrcB;
+    uint16x8_t vecSrcA, vecSrcB;
 
     /* Compute 8 outputs at a time */
     blkCnt = blockSize >> 3;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_or_u32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_or_u32.c
@@ -55,7 +55,7 @@ void arm_or_u32(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q31x4_t vecSrcA, vecSrcB;
+    uint32x4_t vecSrcA, vecSrcB;
 
     /* Compute 4 outputs at a time */
     blkCnt = blockSize >> 2;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_or_u8.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_or_u8.c
@@ -55,7 +55,7 @@ void arm_or_u8(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q7x16_t vecSrcA, vecSrcB;
+    uint8x16_t vecSrcA, vecSrcB;
 
     /* Compute 16 outputs at a time */
     blkCnt = blockSize >> 4;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_xor_u16.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_xor_u16.c
@@ -63,7 +63,7 @@ void arm_xor_u16(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q15x8_t vecSrcA, vecSrcB;
+    uint16x8_t vecSrcA, vecSrcB;
 
     /* Compute 8 outputs at a time */
     blkCnt = blockSize >> 3;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_xor_u32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_xor_u32.c
@@ -55,7 +55,7 @@ void arm_xor_u32(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q31x4_t vecSrcA, vecSrcB;
+    uint32x4_t vecSrcA, vecSrcB;
 
     /* Compute 4 outputs at a time */
     blkCnt = blockSize >> 2;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_xor_u8.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_xor_u8.c
@@ -55,7 +55,7 @@ void arm_xor_u8(
     uint32_t blkCnt;      /* Loop counter */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
-    q7x16_t vecSrcA, vecSrcB;
+    uint8x16_t vecSrcA, vecSrcB;
 
     /* Compute 16 outputs at a time */
     blkCnt = blockSize >> 4;


### PR DESCRIPTION
Compile error about the unsigned / signed integer :
CMSIS_5/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u8.c:66:19: error: incompatible types when assigning to type 'q7x16_t' {aka 'int8x16_t'} from type 'uint8x16_t'
66 | vecSrcA = vld1q(pSrcA);

CMSIS_5/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u8.c:67:19: error: incompatible types when assigning to type 'q7x16_t' {aka 'int8x16_t'} from type 'uint8x16_t'
67 | vecSrcB = vld1q(pSrcB);

CMSIS_5/CMSIS/DSP/Source/BasicMathFunctions/arm_and_u8.c:69:30: error: incompatible type for argument 1 of '__arm_vandq_u8'
69 | vst1q(pDst, vandq_u8(vecSrcA, vecSrcB) );