### PR TITLE
DoxyGen: remind users to enable trace before using PMU

### DIFF
--- a/CMSIS/DoxyGen/Core/src/Ref_PMU8.txt
+++ b/CMSIS/DoxyGen/Core/src/Ref_PMU8.txt
@@ -15,6 +15,9 @@ unsigned int l1_dcache_miss_count = 0;
 unsigned int instructions_retired_count = 0;
  
 // Enable the PMU
+// Note: Before using the PMU, software needs to ensure 
+// that trace is enabled via the Debug Exception Monitor Control Register, DEMCR:
+// CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
  
 ARM_PMU_Enable();
  


### PR DESCRIPTION
Add some notes to remind users to enable trace via:
	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
before using PMU.

This is originally mentioned in
	'Application Note
	Armv8.1-M Performance Monitoring User Guide'