### PR TITLE
Update arm_offset_q31.c

### DIFF
--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q31.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_offset_q31.c
@@ -114,29 +114,13 @@ void arm_offset_q31(
     /* C = A + offset */
 
     /* Add offset and store result in destination buffer. */
-#if defined (ARM_MATH_DSP)
     *pDst++ = __QADD(*pSrc++, offset);
-#else
-    *pDst++ = (q31_t) clip_q63_to_q31((q63_t) * pSrc++ + offset);
-#endif
-
-#if defined (ARM_MATH_DSP)
+    
     *pDst++ = __QADD(*pSrc++, offset);
-#else
-    *pDst++ = (q31_t) clip_q63_to_q31((q63_t) * pSrc++ + offset);
-#endif
-
-#if defined (ARM_MATH_DSP)
+    
     *pDst++ = __QADD(*pSrc++, offset);
-#else
-    *pDst++ = (q31_t) clip_q63_to_q31((q63_t) * pSrc++ + offset);
-#endif
-
-#if defined (ARM_MATH_DSP)
+    
     *pDst++ = __QADD(*pSrc++, offset);
-#else
-    *pDst++ = (q31_t) clip_q63_to_q31((q63_t) * pSrc++ + offset);
-#endif
 
     /* Decrement loop counter */
     blkCnt--;


### PR DESCRIPTION
It seems that there is __QADD instruction in all cases. Can we just use __QADD here, like you did in arm_add_q31.c .

![image](https://user-images.githubusercontent.com/29007810/103473765-3c4e3d80-4dd7-11eb-8d4d-8ade82599f1d.png)
