### PR TITLE
CMSIS-NN: Add custom target for unit tests

### DIFF
--- a/CMSIS/NN/Tests/UnitTest/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/CMakeLists.txt
@@ -35,6 +35,9 @@ endif()
 
 set_property(GLOBAL PROPERTY cmsis_nn_unit_test_executables)
 
+# Target for all unit tests.
+add_custom_target(cmsis_nn_unit_tests)
+
 # This function should be used instead of add_executable.
 function(add_cmsis_nn_unit_test_executable)
     get_property(tmp GLOBAL PROPERTY cmsis_nn_unit_test_executables)
@@ -44,6 +47,7 @@ function(add_cmsis_nn_unit_test_executable)
         if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             target_link_options(${target} PRIVATE "--specs=nosys.specs")
         endif()
+        add_dependencies(cmsis_nn_unit_tests ${target})
     endforeach()
     set_property(GLOBAL PROPERTY cmsis_nn_unit_test_executables "${tmp}")
 endfunction(add_cmsis_nn_unit_test_executable)

--- a/CMSIS/NN/Tests/UnitTest/README.md
+++ b/CMSIS/NN/Tests/UnitTest/README.md
@@ -55,6 +55,13 @@ First clone the Arm Ethos-U Core Software and Arm Ethos-U Core Platform projects
     ```cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/Ethos-u-core-platform>/cmake/toolchain/arm-none-eabi-gcc.cmake -DETHOSU_CORE_PLATFORM_PATH=</path/to/Ethos-u-core-platform> -DUSE_ETHOSU_CORE_PLATFORM=ON -DTARGET_CPU=cortex-m55 -DETHOS_U_CORE_SOFTWARE_PATH=</path/to/Ethos-u-core-software> -DCORE_SOFTWARE_ACCELERATOR=CMSIS-NN -DCORE_SOFTWARE_RTOS=None```
     ```make cmsis_nn_unit_tests```
 ```
+
+This will build all unit tests. You can also just build a specific unit test only, for example:
+
+```
+    ```make test_arm_depthwise_conv_s8_opt```
+```
+
 Some more examples, assuming Ethos-u-core-platform and Ethos-u-core_software are cloned into your home directory:
 
 ```

--- a/CMSIS/NN/Tests/UnitTest/README.md
+++ b/CMSIS/NN/Tests/UnitTest/README.md
@@ -53,9 +53,9 @@ First clone the Arm Ethos-U Core Software and Arm Ethos-U Core Platform projects
     ```mkdir build```
     ```cd build```
     ```cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/Ethos-u-core-platform>/cmake/toolchain/arm-none-eabi-gcc.cmake -DETHOSU_CORE_PLATFORM_PATH=</path/to/Ethos-u-core-platform> -DUSE_ETHOSU_CORE_PLATFORM=ON -DTARGET_CPU=cortex-m55 -DETHOS_U_CORE_SOFTWARE_PATH=</path/to/Ethos-u-core-software> -DCORE_SOFTWARE_ACCELERATOR=CMSIS-NN -DCORE_SOFTWARE_RTOS=None```
-    ```make test_arm_depthwise_conv_s8_opt```
+    ```make cmsis_nn_unit_tests```
 ```
-Note that here you may want to specifiy the unit test targets to build otherwise it will build external targets as well. Some more examples, assuming Ethos-u-core-platform and Ethos-u-core_software are cloned into your home directory:
+Some more examples, assuming Ethos-u-core-platform and Ethos-u-core_software are cloned into your home directory:
 
 ```
     ```cmake .. -DCMAKE_TOOLCHAIN_FILE=~/ethos-u-core-platform/cmake/toolchain/arm-none-eabi-gcc.cmake -DETHOSU_CORE_PLATFORM_PATH=~/ethos-u-core-platform -DUSE_ETHOSU_CORE_PLATFORM=ON -DTARGET_CPU=cortex-m55 -DETHOS_U_CORE_SOFTWARE_PATH=~/ethos-u-core-software -DCORE_SOFTWARE_ACCELERATOR=CMSIS-NN -DCORE_SOFTWARE_RTOS=None```


### PR DESCRIPTION
Make it possible to build all unit tests with one target.