### PR TITLE
RTX5: Add os initialization for IAR

### DIFF
--- a/CMSIS/RTOS2/RTX/Source/rtx_lib.c
+++ b/CMSIS/RTOS2/RTX/Source/rtx_lib.c
@@ -642,6 +642,14 @@ __WEAK void software_init_hook (void) {
   (void)osKernelInitialize();
 }
 
+#elif defined(__ICCARM__)
+
+extern void $Super$$__iar_data_init3 (void);
+void $Sub$$__iar_data_init3 (void) {
+  $Super$$__iar_data_init3();
+  (void)osKernelInitialize();
+}
+
 #endif
 
 


### PR DESCRIPTION
Call osKernelInitialize() from IAR startup hook similar to
ARMCLANG and GNUARM.

Signed-off-by: TTornblom <thomas.tornblom@iar.com>