### PR TITLE
CMSIS-DSP: Ensure correlation array index is signed.

### DIFF
--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f16.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f16.c
@@ -1136,7 +1136,7 @@ void arm_correlate_f16(
       if ((((i - j) < srcBLen) && (j < srcALen)))
       {
         /* z[i] += x[i-j] * y[j] */
-        sum += pIn1[j] * pIn2[-((int32_t) i - j)];
+        sum += pIn1[j] * pIn2[-((int32_t) i - (int32_t) j)];
       }
     }
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_f32.c
@@ -1074,7 +1074,7 @@ void arm_correlate_f32(
       if ((((i - j) < srcBLen) && (j < srcALen)))
       {
         /* z[i] += x[i-j] * y[j] */
-        sum += pIn1[j] * pIn2[-((int32_t) i - j)];
+        sum += pIn1[j] * pIn2[-((int32_t) i - (int32_t) j)];
       }
     }
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q15.c
@@ -882,7 +882,7 @@ void arm_correlate_q15(
       if (((i - j) < srcBLen) && (j < srcALen))
       {
         /* z[i] += x[i-j] * y[j] */
-        sum += ((q31_t) pIn1[j] * pIn2[-((int32_t) i - j)]);
+        sum += ((q31_t) pIn1[j] * pIn2[-((int32_t) i - (int32_t) j)]);
       }
     }
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q31.c
@@ -858,7 +858,7 @@ void arm_correlate_q31(
       if (((i - j) < srcBLen) && (j < srcALen))
       {
         /* z[i] += x[i-j] * y[j] */
-        sum += ((q63_t) pIn1[j] * pIn2[-((int32_t) i - j)]);
+        sum += ((q63_t) pIn1[j] * pIn2[-((int32_t) i - (int32_t) j)]);
       }
     }
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_correlate_q7.c
@@ -981,7 +981,7 @@ void arm_correlate_q7(
       if (((i - j) < srcBLen) && (j < srcALen))
       {
         /* z[i] += x[i-j] * y[j] */
-        sum += ((q15_t) pIn1[j] * pIn2[-((int32_t) i - j)]);
+        sum += ((q15_t) pIn1[j] * pIn2[-((int32_t) i - (int32_t) j)]);
       }
     }
 


### PR DESCRIPTION
This attempts to ensures that even on a 64bit system, the array access
will be treated as a negative number, not a large unsigned offset ending
up reading from the middle of nowhere.