### PR TITLE
CMSIS-NN: Refactor CMake

### DIFF
--- a/CMSIS/NN/CMakeLists.txt
+++ b/CMSIS/NN/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -16,8 +16,14 @@
 # limitations under the License.
 #
 
-add_cmsis_nn_unit_test_executable(test_arm_fully_connected_s8)
+cmake_minimum_required(VERSION 3.15.6)
 
-target_sources(test_arm_fully_connected_s8 PRIVATE
-    Unity/unity_test_arm_fully_connected_s8.c
-    Unity/TestRunner/unity_test_arm_fully_connected_s8_runner.c)
+project(CMSISNN)
+
+set(CMSIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+option(BUILD_CMSIS_NN_FUNCTIONS "Build CMSIS-NN Source." OFF)
+
+if(BUILD_CMSIS_NN_FUNCTIONS)
+    add_subdirectory(Source)
+endif()

--- a/CMSIS/NN/Source/ActivationFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ActivationFunctions/CMakeLists.txt
@@ -1,18 +1,29 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNActivation)
 
-include(configLib)
-
 file(GLOB SRC "./*_s8.c")
-
 add_library(CMSISNNActivation STATIC ${SRC})
-
-configLib(CMSISNNActivation ${ROOT})
-configDsp(CMSISNNActivation ${ROOT})
 
 ### Includes
 target_include_directories(CMSISNNActivation PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNActivation PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNActivation PUBLIC "${ROOT}/CMSIS/DSP/Include")
 
 

--- a/CMSIS/NN/Source/BasicMathFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/BasicMathFunctions/CMakeLists.txt
@@ -1,18 +1,30 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNBasicMaths)
-
-include(configLib)
 
 file(GLOB SRC "./*_*.c")
 
 add_library(CMSISNNBasicMaths STATIC ${SRC})
 
-configLib(CMSISNNBasicMaths ${ROOT})
-configDsp(CMSISNNBasicMaths ${ROOT})
-
 ### Includes
 target_include_directories(CMSISNNBasicMaths PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNBasicMaths PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNBasicMaths PUBLIC "${ROOT}/CMSIS/DSP/Include")
 
 

--- a/CMSIS/NN/Source/CMakeLists.txt
+++ b/CMSIS/NN/Source/CMakeLists.txt
@@ -1,23 +1,22 @@
-cmake_minimum_required (VERSION 3.6)
-cmake_policy(SET CMP0077 NEW)
-project(CMSISNN)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-set(EXTERNAL_TOOLCHAIN "YES" CACHE STRING "Use toolchain in ${ROOT}/CMSIS/DSP/Toolchain/ or not. (YES, NO)")
-
-if(EXTERNAL_TOOLCHAIN STREQUAL "YES")
-    function(compilerSpecificCompileOptions PROJECTNAME ROOT)
-        # Override compilerSpecificCompileOptions defined in ${ROOT}/CMSIS/DSP/Toolchain
-    endfunction()
-endif()
-
-# Needed to find the config modules
-list(APPEND CMAKE_MODULE_PATH ${ROOT}/CMSIS/DSP)
-# CMSIS-NN is dependent on features in the CMSIS-DSP
-# and must use similar logic for configuring the build
-list(APPEND CMAKE_MODULE_PATH ${ROOT}/CMSIS/DSP/Source)
-
-include(configLib)
-include(configDsp)
+SET(ROOT ${CMSIS_PATH})
 
 # Select which parts of the CMSIS-DSP must be compiled.
 # There are some dependencies between the parts but they are not tracked
@@ -31,6 +30,7 @@ option(POOLING              "Pooling"               ON)
 option(SOFTMAX              "Softmax"               ON)
 option(BASICMATHSNN         "Basic Maths for NN"    ON)
 option(RESHAPE              "Reshape"               ON)
+option(SVDF                 "SVDF"                  ON)
 
 # When OFF it is the default behavior : all tables are included.
 option(NNSUPPORT            "NN Support"            ON)
@@ -46,9 +46,6 @@ option(NNSUPPORT            "NN Support"            ON)
 SET(NN ${ROOT}/CMSIS/NN)
 
 list(APPEND CMAKE_MODULE_PATH ${NN}/Source)
-
-
-
 
 add_library(CMSISNN INTERFACE)
 
@@ -97,8 +94,10 @@ if (RESHAPE)
   target_link_libraries(CMSISNN INTERFACE CMSISNNReshape)
 endif()
 
+if (SVDF)
+  add_subdirectory(SVDFunctions)
+  target_link_libraries(CMSISNN INTERFACE CMSISNNSVDF)
+endif()
+
 ### Includes
 target_include_directories(CMSISNN INTERFACE "${NN}/Include")
-
-
-

--- a/CMSIS/NN/Source/ConcatenationFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ConcatenationFunctions/CMakeLists.txt
@@ -1,17 +1,28 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNConcatenation)
-
-include(configLib)
-include(configDsp)
 
 file(GLOB SRC "./*_*.c")
 
 add_library(CMSISNNConcatenation STATIC ${SRC})
 
-configLib(CMSISNNConcatenation ${ROOT})
-configDsp(CMSISNNConcatenation ${ROOT})
-
 ### Includes
 target_include_directories(CMSISNNConcatenation PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNConcatenation PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNConcatenation PUBLIC "${ROOT}/CMSIS/DSP/Include")

--- a/CMSIS/NN/Source/ConvolutionFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ConvolutionFunctions/CMakeLists.txt
@@ -1,17 +1,29 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNConvolutions)
-
-include(configLib)
 
 file(GLOB SRC "./*_s8*.c")
 add_library(CMSISNNConvolutions STATIC ${SRC})
 
-configLib(CMSISNNConvolutions ${ROOT})
-configDsp(CMSISNNConvolutions ${ROOT})
-
 ### Includes
 target_include_directories(CMSISNNConvolutions PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNConvolutions PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNConvolutions PUBLIC "${ROOT}/CMSIS/DSP/Include")
 
 

--- a/CMSIS/NN/Source/FullyConnectedFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/CMakeLists.txt
@@ -1,18 +1,29 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNFullyConnected)
 
-include(configLib)
-
 file(GLOB SRC "./*_s8.c")
-
 add_library(CMSISNNFullyConnected STATIC ${SRC})
-
-configLib(CMSISNNFullyConnected ${ROOT})
-configDsp(CMSISNNFullyConnected ${ROOT})
 
 ### Includes
 target_include_directories(CMSISNNFullyConnected PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNFullyConnected PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNFullyConnected PUBLIC "${ROOT}/CMSIS/DSP/Include")
 
 

--- a/CMSIS/NN/Source/NNSupportFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/NNSupportFunctions/CMakeLists.txt
@@ -1,19 +1,28 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNSupport)
-
-include(configLib)
 
 file(GLOB SRC "./*_s8.c")
 add_library(CMSISNNSupport STATIC ${SRC})
 target_sources(CMSISNNSupport PUBLIC arm_q7_to_q15_with_offset.c)
 
-configLib(CMSISNNSupport ${ROOT})
-configDsp(CMSISNNSupport ${ROOT})
-
 ### Includes
 target_include_directories(CMSISNNSupport PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNSupport PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNSupport PUBLIC "${ROOT}/CMSIS/DSP/Include")
-
-
-

--- a/CMSIS/NN/Source/PoolingFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/PoolingFunctions/CMakeLists.txt
@@ -1,18 +1,29 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNPooling)
 
-include(configLib)
-
 file(GLOB SRC "./*_s8.c")
-
 add_library(CMSISNNPooling STATIC ${SRC})
-
-configLib(CMSISNNPooling ${ROOT})
-configDsp(CMSISNNPooling ${ROOT})
 
 ### Includes
 target_include_directories(CMSISNNPooling PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNPooling PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNPooling PUBLIC "${ROOT}/CMSIS/DSP/Include")
 
 

--- a/CMSIS/NN/Source/ReshapeFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ReshapeFunctions/CMakeLists.txt
@@ -1,19 +1,29 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNReshape)
-
-include(configLib)
-include(configDsp)
-
 
 file(GLOB SRC "./*_*.c")
 
 add_library(CMSISNNReshape STATIC ${SRC})
 
-configLib(CMSISNNReshape ${ROOT})
-configDsp(CMSISNNReshape ${ROOT})
-
 ### Includes
 target_include_directories(CMSISNNReshape PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNReshape PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNReshape PUBLIC "${ROOT}/CMSIS/DSP/Include")
 

--- a/CMSIS/NN/Source/SVDFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/SVDFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -16,8 +16,16 @@
 # limitations under the License.
 #
 
-add_cmsis_nn_unit_test_executable(test_arm_fully_connected_s8)
+project(CMSISNNSVDF)
 
-target_sources(test_arm_fully_connected_s8 PRIVATE
-    Unity/unity_test_arm_fully_connected_s8.c
-    Unity/TestRunner/unity_test_arm_fully_connected_s8_runner.c)
+file(GLOB SRC "./*_s8.c")
+
+add_library(CMSISNNSVDF STATIC ${SRC})
+
+### Includes
+target_include_directories(CMSISNNSVDF PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNSVDF PUBLIC "${ROOT}/CMSIS/Core/Include")
+target_include_directories(CMSISNNSVDF PUBLIC "${ROOT}/CMSIS/DSP/Include")
+
+
+

--- a/CMSIS/NN/Source/SoftmaxFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/SoftmaxFunctions/CMakeLists.txt
@@ -1,18 +1,29 @@
-cmake_minimum_required (VERSION 3.6)
+#
+# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 project(CMSISNNSoftmax)
 
-include(configLib)
-
 file(GLOB SRC "./*_s8.c")
-
 add_library(CMSISNNSoftmax STATIC ${SRC})
-
-configLib(CMSISNNSoftmax ${ROOT})
-configDsp(CMSISNNSoftmax ${ROOT})
 
 ### Includes
 target_include_directories(CMSISNNSoftmax PUBLIC "${NN}/Include")
+target_include_directories(CMSISNNSoftmax PUBLIC "${ROOT}/CMSIS/Core/Include")
 target_include_directories(CMSISNNSoftmax PUBLIC "${ROOT}/CMSIS/DSP/Include")
 
 

--- a/CMSIS/NN/Tests/UnitTest/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/CMakeLists.txt
@@ -20,10 +20,10 @@ cmake_minimum_required(VERSION 3.15.6)
 
 project(cmsis_nn_unit_tests VERSION 0.0.1)
 
-set(CMSIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." CACHE PATH "Path to CMSIS.")
+set(CMSIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
 
-set(BUILD_CMSIS_NN_UNIT_DEFAULT OFF)
-option(BUILD_CMSIS_NN_UNIT "If building the unit tests from another project." ${BUILD_CMSIS_NN_UNIT_DEFAULT})
+option(BUILD_CMSIS_NN_UNIT "If building the unit tests from another project, i.e. \
+platform dependencies need to be provided externally." OFF)
 
 if(NOT BUILD_CMSIS_NN_UNIT)
     set(BUILD_CMSIS_NN_UNIT_TESTS_FOR_FVP_BASED_CORSTONE_300 ON)
@@ -37,12 +37,15 @@ if(BUILD_CMSIS_NN_UNIT_TESTS_FOR_FVP_BASED_CORSTONE_300)
     set(CMAKE_EXECUTABLE_SUFFIX ".elf")
 endif()
 
-set_property(GLOBAL PROPERTY cmsis_nn_unit_test_executables)
+# Build the functions to be tested.
+set(BUILD_CMSIS_NN_FUNCTIONS ON)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../.. cmsis-nn)
 
 # Target for all unit tests.
 add_custom_target(cmsis_nn_unit_tests)
 
 # This function should be used instead of add_executable.
+set_property(GLOBAL PROPERTY cmsis_nn_unit_test_executables)
 function(add_cmsis_nn_unit_test_executable)
     get_property(tmp GLOBAL PROPERTY cmsis_nn_unit_test_executables)
     foreach(target ${ARGV})
@@ -55,22 +58,6 @@ function(add_cmsis_nn_unit_test_executable)
     endforeach()
     set_property(GLOBAL PROPERTY cmsis_nn_unit_test_executables "${tmp}")
 endfunction(add_cmsis_nn_unit_test_executable)
-
-add_library(arm_nn_mat_mult_core)
-target_include_directories(arm_nn_mat_mult_core PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(arm_nn_mat_mult_core PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(arm_nn_mat_mult_core PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-target_sources(arm_nn_mat_mult_core PRIVATE
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_4x_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c)
-
-add_library(arm_nn_depthwise_conv_nt)
-target_include_directories(arm_nn_depthwise_conv_nt PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(arm_nn_depthwise_conv_nt PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(arm_nn_depthwise_conv_nt PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-target_sources(arm_nn_depthwise_conv_nt PRIVATE
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_depthwise_conv_nt_t_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_depthwise_conv_nt_t_padded_s8.c)
 
 add_subdirectory(TestCases/test_arm_avgpool_s8)
 add_subdirectory(TestCases/test_arm_convolve_1x1_s8_fast)
@@ -89,6 +76,14 @@ MESSAGE(STATUS "Downloading Unity and generating test runners for CMSIS-NN unit 
 execute_process(COMMAND ${MAKE_CMD} ${MAKE_CMD_SCRIPT} ${MAKE_CMD_SCRIPT_OPTION}
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(Unity)
+
+# Link common dependencies.
+get_property(executables GLOBAL PROPERTY cmsis_nn_unit_test_executables)
+string(REPLACE " " ";" cmsis_nn_unit_test_list_of_executables ${executables})
+foreach(target ${cmsis_nn_unit_test_list_of_executables})
+    target_link_libraries(${target} LINK_PUBLIC unity)
+    target_link_libraries(${target} LINK_PUBLIC CMSISNN)
+endforeach()
 
 if(BUILD_CMSIS_NN_UNIT_TESTS_FOR_FVP_BASED_CORSTONE_300)
     add_library(retarget STATIC

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_avgpool_s8/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_avgpool_s8/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,11 +20,4 @@ add_cmsis_nn_unit_test_executable(test_arm_avgpool_s8)
 
 target_sources(test_arm_avgpool_s8 PRIVATE
     Unity/unity_test_arm_avgpool_s8.c
-    Unity/TestRunner/unity_test_arm_avgpool_s8_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c)
-
-target_include_directories(test_arm_avgpool_s8 PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_avgpool_s8 PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_avgpool_s8 PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-
-target_link_libraries(test_arm_avgpool_s8 LINK_PUBLIC unity)
+    Unity/TestRunner/unity_test_arm_avgpool_s8_runner.c)

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,19 +20,8 @@ add_cmsis_nn_unit_test_executable(test_arm_convolve_1x1_s8_fast)
 
 target_sources(test_arm_convolve_1x1_s8_fast PRIVATE
     Unity/unity_test_arm_convolve_1x1_s8_fast
-    Unity/TestRunner/unity_test_arm_convolve_1x1_s8_fast_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c)
+    Unity/TestRunner/unity_test_arm_convolve_1x1_s8_fast_runner.c)
 
-target_include_directories(test_arm_convolve_1x1_s8_fast PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_convolve_1x1_s8_fast PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_convolve_1x1_s8_fast PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
 
-target_link_libraries(test_arm_convolve_1x1_s8_fast LINK_PUBLIC arm_nn_mat_mult_core)
-target_link_libraries(test_arm_convolve_1x1_s8_fast LINK_PUBLIC unity)
+
+

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s8/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s8/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,19 +20,4 @@ add_cmsis_nn_unit_test_executable(test_arm_convolve_s8)
 
 target_sources(test_arm_convolve_s8 PRIVATE
     Unity/unity_test_arm_convolve_s8.c
-    Unity/TestRunner/unity_test_arm_convolve_s8_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c)
-
-target_include_directories(test_arm_convolve_s8 PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_convolve_s8 PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_convolve_s8 PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-
-target_link_libraries(test_arm_convolve_s8 LINK_PUBLIC arm_nn_mat_mult_core)
-target_link_libraries(test_arm_convolve_s8 LINK_PUBLIC unity)
+    Unity/TestRunner/unity_test_arm_convolve_s8_runner.c)

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,11 +20,4 @@ add_cmsis_nn_unit_test_executable(test_arm_depthwise_conv_3x3_s8)
 
 target_sources(test_arm_depthwise_conv_3x3_s8 PRIVATE
     Unity/unity_test_arm_depthwise_conv_3x3_s8.c
-    Unity/TestRunner/unity_test_arm_depthwise_conv_3x3_s8_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c)
-
-target_include_directories(test_arm_depthwise_conv_3x3_s8 PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_depthwise_conv_3x3_s8 PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_depthwise_conv_3x3_s8 PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-
-target_link_libraries(test_arm_depthwise_conv_3x3_s8 LINK_PUBLIC unity)
+    Unity/TestRunner/unity_test_arm_depthwise_conv_3x3_s8_runner.c)

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,14 +20,4 @@ add_cmsis_nn_unit_test_executable(test_arm_depthwise_conv_s8)
 
 target_sources(test_arm_depthwise_conv_s8 PRIVATE
     Unity/unity_test_arm_depthwise_conv_s8.c
-    Unity/TestRunner/unity_test_arm_depthwise_conv_s8_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c)
-
-target_include_directories(test_arm_depthwise_conv_s8 PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_depthwise_conv_s8 PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_depthwise_conv_s8 PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-
-target_link_libraries(test_arm_depthwise_conv_s8 LINK_PUBLIC arm_nn_depthwise_conv_nt)
-target_link_libraries(test_arm_depthwise_conv_s8 LINK_PUBLIC arm_nn_mat_mult_core)
-target_link_libraries(test_arm_depthwise_conv_s8 LINK_PUBLIC unity)
+    Unity/TestRunner/unity_test_arm_depthwise_conv_s8_runner.c)

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,14 +20,4 @@ add_cmsis_nn_unit_test_executable(test_arm_depthwise_conv_s8_opt)
 
 target_sources(test_arm_depthwise_conv_s8_opt PRIVATE
     Unity/unity_test_arm_depthwise_conv_s8_opt.c
-    Unity/TestRunner/unity_test_arm_depthwise_conv_s8_opt_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c)
-
-target_include_directories(test_arm_depthwise_conv_s8_opt PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_depthwise_conv_s8_opt PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_depthwise_conv_s8_opt PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-
-target_link_libraries(test_arm_depthwise_conv_s8_opt LINK_PUBLIC arm_nn_depthwise_conv_nt)
-target_link_libraries(test_arm_depthwise_conv_s8_opt LINK_PUBLIC unity)
+    Unity/TestRunner/unity_test_arm_depthwise_conv_s8_opt_runner.c)

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_max_pool_s8/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_max_pool_s8/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,11 +20,6 @@ add_cmsis_nn_unit_test_executable(test_arm_max_pool_s8)
 
 target_sources(test_arm_max_pool_s8 PRIVATE
     Unity/unity_test_arm_max_pool_s8.c
-    Unity/TestRunner/unity_test_arm_max_pool_s8_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8.c)
+    Unity/TestRunner/unity_test_arm_max_pool_s8_runner.c)
 
-target_include_directories(test_arm_max_pool_s8 PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_max_pool_s8 PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_max_pool_s8 PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
 
-target_link_libraries(test_arm_max_pool_s8 LINK_PUBLIC unity)

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_softmax_s8/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_softmax_s8/CMakeLists.txt
@@ -20,11 +20,4 @@ add_cmsis_nn_unit_test_executable(test_arm_softmax_s8)
 
 target_sources(test_arm_softmax_s8 PRIVATE
     Unity/unity_test_arm_softmax_s8.c
-    Unity/TestRunner/unity_test_arm_softmax_s8_runner.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_s8.c)
-
-target_include_directories(test_arm_softmax_s8 PRIVATE ${CMSIS_PATH}/CMSIS/NN/Include)
-target_include_directories(test_arm_softmax_s8 PRIVATE ${CMSIS_PATH}/CMSIS/DSP/Include)
-target_include_directories(test_arm_softmax_s8 PRIVATE ${CMSIS_PATH}/CMSIS/Core/Include)
-
-target_link_libraries(test_arm_softmax_s8 LINK_PUBLIC unity)
+    Unity/TestRunner/unity_test_arm_softmax_s8_runner.c)


### PR DESCRIPTION
* Builds CMSIS-NN source the same way as when building unit tests and
  when building it standalone.
* Builds SVDF as well.