### PR TITLE
CoreValidation: Fix Cortex-A builds.

### DIFF
--- a/CMSIS/CoreValidation/Tests/ac5.rtebuild
+++ b/CMSIS/CoreValidation/Tests/ac5.rtebuild
@@ -5,10 +5,10 @@ import:
 targets:
   arm:
     toolchain   : ARMCC5
+    info        : [ --info summarysizes, --map, --load_addr_map_info, --xref, --callgraph, --symbols, --info sizes, --info totals, --info unused, --info veneers, "--list ${builddir}/${targetName}.map" ]
   armcm:
     cflags      : [ --c99, -c, "--cpu ${cpu}", "--fpu=${fpu}", --li, -g, "-%{optimize}", --apcs=interwork, --split_sections, --asm, --interleave ]
     asmflags    : [ "--cpu ${cpu}", "--fpu=${fpu}", --li, -g, --apcs=interwork ]
-    info        : [ --info summarysizes, --map, --load_addr_map_info, --xref, --callgraph, --symbols, --info sizes, --info totals, --info unused, --info veneers, "--list ${builddir}/${targetName}.map" ]
     linkflags   : [ "--cpu ${cpu}", "--fpu=${fpu}", --strict, --no_remove, --entry Reset_Handler, --diag_suppress=L6314, --diag_suppress=L6092w, "${info}" ]
     linkscript  : "config/core_m/rtebuild_ac5.sct"
   armcm0:
@@ -39,7 +39,7 @@ targets:
     toolchain  : ARMCC5
     cflags      : [ "--cpu=${cpu}", "--apcs=/${float}", --li, --arm, --c99, "-%{optimize}", -g, -c ]
     asmflags    : [ "--cpu=${cpu}", "--apcs=/${float}", --li, --arm, -g ]
-    linkflags   : [ "--cpu=${cpu}", "--entry=Vectors" ]
+    linkflags   : [ "--cpu=${cpu}", "--entry=Vectors", "${info}" ]
     linkscript : "./config/core_a/rtebuild_ac5.sct"
     source:
       - ../../../Device/ARM/${device}/Source/AC5/startup_${device}.c

--- a/CMSIS/CoreValidation/Tests/build.py
+++ b/CMSIS/CoreValidation/Tests/build.py
@@ -177,13 +177,6 @@ def get_model_inst(model):
 
 
 @matrix_filter
-def filter_ac5_ac6ltm_cma(config):
-    return ((config.compiler == CompilerAxis.AC6LTM or
-             config.compiler == CompilerAxis.AC5      ) and 
-            config.device.match("CA*"))
-    
-
-@matrix_filter
 def filter_ac5_armv8m(config):
     return (config.compiler == CompilerAxis.AC5 and 
             config.device.match("CM[235][35]*"))

--- a/CMSIS/CoreValidation/Tests/config/core_a/rtebuild.sct
+++ b/CMSIS/CoreValidation/Tests/config/core_a/rtebuild.sct
@@ -1,0 +1,77 @@
+#! armclang -E --target=arm-arm-none-eabi -xc
+;**************************************************
+; Copyright (c) 2017 ARM Ltd.  All rights reserved.
+;**************************************************
+
+; Scatter-file for RTX Example on Versatile Express
+
+; This scatter-file places application code, data, stack and heap at suitable addresses in the memory map.
+
+; This platform has 2GB SDRAM starting at 0x80000000.
+
+#include "mem.h"
+
+SDRAM __ROM_BASE __ROM_SIZE       ; load region size_region
+{
+  VECTORS __ROM_BASE __ROM_SIZE ; load address = execution address
+  {
+      * (RESET, +FIRST)         ; Vector table and other startup code
+      * (InRoot$$Sections)      ; All (library) code that must be in a root region
+      * (+RO-CODE)              ; Application RO code (.text)
+      * (+RO-DATA)              ; Application RO data (.constdata)
+  }
+  
+  RW_DATA __RAM_BASE __RW_DATA_SIZE
+  { * (+RW) }                   ; Application RW data (.data)
+  
+  ZI_DATA (__RAM_BASE+
+           __RW_DATA_SIZE) __ZI_DATA_SIZE
+  { * (+ZI) }                   ; Application ZI data (.bss)
+  
+  ARM_LIB_HEAP  (__RAM_BASE
+                +__RW_DATA_SIZE
+                +__ZI_DATA_SIZE)    EMPTY __HEAP_SIZE        ; Heap region growing up
+  { }
+    
+  ARM_LIB_STACK (__RAM_BASE
+                +__RAM_SIZE       
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE
+                -__UND_STACK_SIZE) EMPTY -__STACK_SIZE      ; Stack region growing down
+  { }              
+                
+  UND_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE) EMPTY -__UND_STACK_SIZE  ; UND mode stack
+  { }
+  
+  ABT_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE) EMPTY -__ABT_STACK_SIZE  ; ABT mode stack
+  { }
+  
+  SVC_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE) EMPTY -__SVC_STACK_SIZE  ; SVC mode stack
+  { }  
+  
+  IRQ_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE) EMPTY -__IRQ_STACK_SIZE  ; IRQ mode stack
+  { }  
+  
+  FIQ_STACK     (__RAM_BASE
+                +__RAM_SIZE)       EMPTY -__FIQ_STACK_SIZE  ; FIQ mode stack
+  { }
+  
+  TTB            __TTB_BASE        EMPTY __TTB_SIZE         ; Level-1 Translation Table for MMU
+  { }                                        
+}

--- a/CMSIS/CoreValidation/Tests/main.c
+++ b/CMSIS/CoreValidation/Tests/main.c
@@ -55,6 +55,7 @@ int main (void)
 
 __IRQ
 void IRQ_Handler(void);
+__IRQ
 void IRQ_Handler(void) {
   const IRQn_ID_t irqn = IRQ_GetActiveIRQ();
   IRQHandler_t const handler = IRQ_GetHandler(irqn);
@@ -68,6 +69,7 @@ void IRQ_Handler(void) {
 
 __IRQ __NO_RETURN
 void Undef_Handler (void);
+__IRQ __NO_RETURN
 void Undef_Handler (void) {
   cmsis_cv_abort(__FILENAME__, __LINE__, "Undefined Instruction!");
   exit(0);
@@ -75,11 +77,13 @@ void Undef_Handler (void) {
 
 __IRQ
 void SVC_Handler   (void);
+__IRQ
 void SVC_Handler   (void) {
 }
 
 __IRQ __NO_RETURN
 void PAbt_Handler  (void);
+__IRQ __NO_RETURN
 void PAbt_Handler  (void) {
   cmsis_cv_abort(__FILENAME__, __LINE__, "Prefetch Abort!");
   exit(0);
@@ -87,6 +91,7 @@ void PAbt_Handler  (void) {
 
 __IRQ __NO_RETURN
 void DAbt_Handler  (void);
+__IRQ __NO_RETURN
 void DAbt_Handler  (void) {
   cmsis_cv_abort(__FILENAME__, __LINE__, "Data Abort!");
   exit(0);
@@ -94,6 +99,7 @@ void DAbt_Handler  (void) {
 
 __IRQ
 void FIQ_Handler   (void);
+__IRQ
 void FIQ_Handler   (void) {
 }
 #endif
@@ -101,6 +107,7 @@ void FIQ_Handler   (void) {
 #if defined(__CORTEX_M)
 __NO_RETURN
 void HardFault_Handler(void);
+__NO_RETURN
 void HardFault_Handler(void) {
   cmsis_cv_abort(__FILENAME__, __LINE__, "HardFault!");
   #ifdef __MICROLIB


### PR DESCRIPTION
- Add missing scatter file for Arm Compiler 6
- Add map file generation with Arm Compiler 5
- Remove filter from build.py
- Fix main.c handler function definitions