### PR TITLE
CoreValidation: Fix Arm Compiler 6 linker warnings.

### DIFF
--- a/CMSIS/CoreValidation/Tests/config/core_a/rtebuild.sct
+++ b/CMSIS/CoreValidation/Tests/config/core_a/rtebuild.sct
@@ -1,4 +1,4 @@
-#! armclang -E --target=arm-arm-none-eabi -xc
+#! armclang -E --target=arm-arm-none-eabi -march=armv7-a -xc
 ;**************************************************
 ; Copyright (c) 2017 ARM Ltd.  All rights reserved.
 ;**************************************************


### PR DESCRIPTION
The compiler issues warning about unsupported (deprecated)
target architectures when called with specific -march.