### PR TITLE
CMSIS-Core: aligned __disable_irq, __disable_fault_irq between suppor…

### DIFF
--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
  * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
- * @version  V5.4.1
- * @date     19. March 2021
+ * @version  V5.4.2
+ * @date     05. May 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
@@ -28,10 +28,6 @@
 #define __CMSIS_ARMCLANG_H
 
 #pragma clang system_header   /* treat file as system include file */
-
-#ifndef __ARM_COMPAT_H
-#include <arm_compat.h>    /* Compatibility header for Arm Compiler 5 intrinsics */
-#endif
 
 /* CMSIS compiler specific defines */
 #ifndef   __ASM
@@ -167,7 +163,10 @@ __STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
   \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
            Can only be executed in Privileged modes.
  */
-/* intrinsic void __enable_irq();  see arm_compat.h */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
 
 
 /**
@@ -175,7 +174,10 @@ __STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
   \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
            Can only be executed in Privileged modes.
  */
-/* intrinsic void __disable_irq();  see arm_compat.h */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
 
 
 /**
@@ -472,7 +474,10 @@ __STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
   \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
-#define __enable_fault_irq                __enable_fiq   /* see arm_compat.h */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
 
 
 /**
@@ -480,7 +485,10 @@ __STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
   \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
-#define __disable_fault_irq               __disable_fiq   /* see arm_compat.h */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
 
 
 /**

--- a/CMSIS/Core/Include/cmsis_armclang_ltm.h
+++ b/CMSIS/Core/Include/cmsis_armclang_ltm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang_ltm.h
  * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
- * @version  V1.5.1
- * @date     19. March 2021
+ * @version  V1.5.2
+ * @date     05. May 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2018-2021 Arm Limited. All rights reserved.
@@ -28,10 +28,6 @@
 #define __CMSIS_ARMCLANG_H
 
 #pragma clang system_header   /* treat file as system include file */
-
-#ifndef __ARM_COMPAT_H
-#include <arm_compat.h>    /* Compatibility header for Arm Compiler 5 intrinsics */
-#endif
 
 /* CMSIS compiler specific defines */
 #ifndef   __ASM
@@ -167,7 +163,10 @@ __STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
   \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
            Can only be executed in Privileged modes.
  */
-/* intrinsic void __enable_irq();  see arm_compat.h */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
 
 
 /**
@@ -175,7 +174,10 @@ __STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
   \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
            Can only be executed in Privileged modes.
  */
-/* intrinsic void __disable_irq();  see arm_compat.h */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
 
 
 /**
@@ -471,7 +473,10 @@ __STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
   \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
-#define __enable_fault_irq                __enable_fiq   /* see arm_compat.h */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
 
 
 /**
@@ -479,7 +484,10 @@ __STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
   \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
-#define __disable_fault_irq               __disable_fiq   /* see arm_compat.h */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
 
 
 /**

--- a/CMSIS/CoreValidation/Include/cmsis_cv.h
+++ b/CMSIS/CoreValidation/Include/cmsis_cv.h
@@ -2,7 +2,7 @@
  *      Name:         cmsis_cv.h
  *      Purpose:      cmsis_cv header
  *----------------------------------------------------------------------------
- *      Copyright (c) 2017 - 2018 Arm Limited. All rights reserved.
+ *      Copyright (c) 2017 - 2021 Arm Limited. All rights reserved.
  *----------------------------------------------------------------------------*/
 #ifndef __CMSIS_CV_H
 #define __CMSIS_CV_H
@@ -83,6 +83,7 @@ extern void TC_CoreSimd_MulAcc32 (void);
   extern void TC_CoreFunc_FPSCR (void);
 #elif defined(__CORTEX_A)
   extern void TC_CoreAFunc_IRQ (void);
+  extern void TC_CoreAFunc_FaultIRQ (void);
   extern void TC_CoreAFunc_FPSCR (void);
   extern void TC_CoreAFunc_CPSR (void);
   extern void TC_CoreAFunc_Mode (void);

--- a/CMSIS/CoreValidation/Source/CV_CoreAFunc.c
+++ b/CMSIS/CoreValidation/Source/CV_CoreAFunc.c
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
- *      Name:         CV_CoreFunc.c 
+ *      Name:         CV_CoreFunc.c
  *      Purpose:      CMSIS CORE validation tests implementation
  *-----------------------------------------------------------------------------
  *      Copyright (c) 2017 ARM Limited. All rights reserved.
@@ -19,15 +19,30 @@
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 void TC_CoreAFunc_IRQ(void) {
   uint32_t orig = __get_CPSR();
-  
+
   __enable_irq();
   uint32_t cpsr = __get_CPSR();
   ASSERT_TRUE((cpsr & CPSR_I_Msk) == 0U);
-  
+
   __disable_irq();
   cpsr = __get_CPSR();
   ASSERT_TRUE((cpsr & CPSR_I_Msk) == CPSR_I_Msk);
-  
+
+  __set_CPSR(orig);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_FaultIRQ(void) {
+  uint32_t orig = __get_CPSR();
+
+  __enable_fault_irq();
+  uint32_t cpsr = __get_CPSR();
+  ASSERT_TRUE((cpsr & CPSR_F_Msk) == 0U);
+
+  __disable_fault_irq();
+  cpsr = __get_CPSR();
+  ASSERT_TRUE((cpsr & CPSR_F_Msk) == CPSR_F_Msk);
+
   __set_CPSR(orig);
 }
 
@@ -225,24 +240,24 @@ static uint8_t vectorRAM[32U] __attribute__((aligned(32U)));
 
 void TC_CoreAFunc_VBAR(void) {
   uint32_t vbar = __get_VBAR();
-  
+
   memcpy(vectorRAM, (void*)vbar, sizeof(vectorRAM));
-  
+
   __set_VBAR((uint32_t)vectorRAM);
   ASSERT_TRUE(((uint32_t)vectorRAM) == __get_VBAR());
-  
+
   __set_VBAR(vbar);
 }
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 void TC_CoreAFunc_MVBAR(void) {
   uint32_t mvbar = __get_MVBAR();
-  
+
   memcpy(vectorRAM, (void*)mvbar, sizeof(vectorRAM));
-  
+
   __set_MVBAR((uint32_t)vectorRAM);
   ASSERT_TRUE(((uint32_t)vectorRAM) == __get_MVBAR());
-  
+
   __set_MVBAR(mvbar);
 }
 
@@ -251,19 +266,19 @@ void TC_CoreAFunc_MVBAR(void) {
 void TC_CoreAFunc_FPU_Enable(void) {
   uint32_t fpexc = __get_FPEXC();
   __set_FPEXC(fpexc & ~0x40000000u); // disable FPU
-  
+
   uint32_t cp15;
   __get_CP(15, 0, cp15, 1, 0, 2);
-  
+
   cp15 &= ~0x00F00000u;
   __set_CP(15, 0, cp15, 1, 0, 2); // disable FPU access
-  
+
   __FPU_Enable();
-    
+
   __get_CP(15, 0, cp15, 1, 0, 2);
   ASSERT_TRUE((cp15 & 0x00F00000u) == 0x00F00000u);
 
-  fpexc = __get_FPEXC();  
+  fpexc = __get_FPEXC();
   ASSERT_TRUE((fpexc & 0x40000000u) == 0x40000000u);
 }
 

--- a/CMSIS/CoreValidation/Source/CV_CoreFunc.c
+++ b/CMSIS/CoreValidation/Source/CV_CoreFunc.c
@@ -198,7 +198,7 @@ void TC_CoreFunc_IRQVect(void) {
   static VECTOR_TABLE_Type vectors[sizeof(__VECTOR_TABLE)/sizeof(__VECTOR_TABLE[0])] __ALIGNED(512);
 
   memcpy(vectors, __VECTOR_TABLE, sizeof(__VECTOR_TABLE));
-  
+
   const uint32_t orig_vtor = SCB->VTOR;
   const uint32_t vtor = ((uint32_t)vectors) & SCB_VTOR_TBLOFF_Msk;
   SCB->VTOR = vtor;
@@ -595,7 +595,6 @@ void TC_CoreFunc_PRIMASK (void) {
 
   __set_PRIMASK(primask);
   uint32_t result = __get_PRIMASK();
-
   ASSERT_TRUE(result == primask);
 
   __disable_irq();
@@ -633,7 +632,6 @@ void TC_CoreFunc_FAULTMASK (void) {
 
   __set_FAULTMASK(faultmask);
   uint32_t result = __get_FAULTMASK();
-
   ASSERT_TRUE(result == faultmask);
 
   __disable_fault_irq();

--- a/CMSIS/CoreValidation/Source/ConfigA/CV_Config.h
+++ b/CMSIS/CoreValidation/Source/ConfigA/CV_Config.h
@@ -2,7 +2,7 @@
  *      Name:         CV_Config.h
  *      Purpose:      CV Config header
  *----------------------------------------------------------------------------
- *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *      Copyright (c) 2017 - 2021 ARM Limited. All rights reserved.
  *----------------------------------------------------------------------------*/
 #ifndef __CV_CONFIG_H
 #define __CV_CONFIG_H
@@ -25,93 +25,94 @@
 
 // <h> Disable Test Cases
 // <i> Uncheck to disable an individual test case
-// <q00> TC_CoreInstr_NOP
-// <q01> TC_CoreInstr_REV
-// <q02> TC_CoreInstr_REV16
-// <q03> TC_CoreInstr_REVSH
-// <q04> TC_CoreInstr_ROR
-// <q05> TC_CoreInstr_RBIT
-// <q06> TC_CoreInstr_CLZ
-// <q07> TC_CoreInstr_SSAT
-// <q08> TC_CoreInstr_USAT
+// <q0> TC_CoreInstr_NOP
+#define TC_COREINSTR_NOP_EN                   1
+// <q0> TC_CoreInstr_REV
+#define TC_COREINSTR_REV_EN                   1
+// <q0> TC_CoreInstr_REV16
+#define TC_COREINSTR_REV16_EN                 1
+// <q0> TC_CoreInstr_REVSH
+#define TC_COREINSTR_REVSH_EN                 1
+// <q0> TC_CoreInstr_ROR
+#define TC_COREINSTR_ROR_EN                   1
+// <q0> TC_CoreInstr_RBIT
+#define TC_COREINSTR_RBIT_EN                  1
+// <q0> TC_CoreInstr_CLZ
+#define TC_COREINSTR_CLZ_EN                   1
+// <q0> TC_CoreInstr_Exclusives
+#define TC_COREINSTR_EXCLUSIVES_EN            1
+// <q0> TC_CoreInstr_SSAT
+#define TC_COREINSTR_SSAT_EN                  1
+// <q0> TC_CoreInstr_USAT
+#define TC_COREINSTR_USAT_EN                  1
 
-#define TC_COREINSTR_NOP_EN                 1
-#define TC_COREINSTR_REV_EN                 1
-#define TC_COREINSTR_REV16_EN               1
-#define TC_COREINSTR_REVSH_EN               1
-#define TC_COREINSTR_ROR_EN                 1
-#define TC_COREINSTR_RBIT_EN                1
-#define TC_COREINSTR_CLZ_EN                 1
-#define TC_COREINSTR_SSAT_EN                1
-#define TC_COREINSTR_USAT_EN                1
+// <q0> TC_CoreAFunc_IRQ
+#define TC_COREAFUNC_IRQ                      1
+// <q0> TC_CoreAFunc_FaultIRQ
+#define TC_COREAFUNC_FAULTIRQ                 1
+// <q0> TC_CoreAFunc_FPSCR
+#define TC_COREAFUNC_FPSCR                    1
+// <q0> TC_CoreAFunc_CPSR
+#define TC_COREAFUNC_CPSR                     1
+// <q0> TC_CoreAFunc_Mode
+#define TC_COREAFUNC_MODE                     1
+// <q0> TC_CoreAFunc_SP
+#define TC_COREAFUNC_SP                       1
+// <q0> TC_CoreAFunc_SP_usr
+#define TC_COREAFUNC_SP_USR                   1
+// <q0> TC_CoreAFunc_FPEXC
+#define TC_COREAFUNC_FPEXC                    1
+// <q0> TC_CoreAFunc_ACTLR
+#define TC_COREAFUNC_ACTLR                    1
+// <q0> TC_CoreAFunc_CPACR
+#define TC_COREAFUNC_CPACR                    1
+// <q0> TC_CoreAFunc_DFSR
+#define TC_COREAFUNC_DFSR                     1
+// <q0> TC_CoreAFunc_IFSR
+#define TC_COREAFUNC_IFSR                     1
+// <q0> TC_CoreAFunc_ISR
+#define TC_COREAFUNC_ISR                      1
+// <q0> TC_CoreAFunc_CBAR
+#define TC_COREAFUNC_CBAR                     1
+// <q0> TC_CoreAFunc_TTBR0
+#define TC_COREAFUNC_TTBR0                    1
+// <q0> TC_CoreAFunc_DACR
+#define TC_COREAFUNC_DACR                     1
+// <q0> TC_CoreAFunc_SCTLR
+#define TC_COREAFUNC_SCTLR                    1
+// <q0> TC_CoreAFunc_ACTRL
+#define TC_COREAFUNC_ACTRL                    1
+// <q0> TC_CoreAFunc_MPIDR
+#define TC_COREAFUNC_MPIDR                    1
+// <q0> TC_CoreAFunc_VBAR
+#define TC_COREAFUNC_VBAR                     1
+// <q0> TC_CoreAFunc_MVBAR
+#define TC_COREAFUNC_MVBAR                    1
+// <q0> TC_CoreAFunc_FPU_Enable
+#define TC_COREAFUNC_FPU_ENABLE               1
 
-// <q09> TC_CoreAFunc_FPSCR
-// <q10> TC_CoreAFunc_CPSR
-// <q11> TC_CoreAFunc_Mode
-// <q12> TC_CoreAFunc_SP
-// <q13> TC_CoreAFunc_SP_usr
-// <q14> TC_CoreAFunc_FPEXC
-// <q15> TC_CoreAFunc_ACTLR
-// <q16> TC_CoreAFunc_CPACR
-// <q17> TC_CoreAFunc_DFSR
-// <q18> TC_CoreAFunc_IFSR
-// <q19> TC_CoreAFunc_ISR
-// <q20> TC_CoreAFunc_CBAR
-// <q21> TC_CoreAFunc_TTBR0
-// <q22> TC_CoreAFunc_DACR
-// <q23> TC_CoreAFunc_SCTLR
-// <q24> TC_CoreAFunc_ACTRL
-// <q25> TC_CoreAFunc_MPIDR
-// <q26> TC_CoreAFunc_VBAR
-// <q27> TC_CoreAFunc_MVBAR
-// <q28> TC_CoreAFunc_FPU_Enable
+// <q0> TC_GenTimer_CNTFRQ
+#define TC_GENTIMER_CNTFRQ                    1
+// <q0> TC_GenTimer_CNTP_TVAL
+#define TC_GENTIMER_CNTP_TVAL                 1
+// <q0> TC_GenTimer_CNTP_CTL
+#define TC_GENTIMER_CNTP_CTL                  1
+// <q0> TC_GenTimer_CNTPCT
+#define TC_GENTIMER_CNTPCT                    1
+// <q0> TC_GenTimer_CNTP_CVAL
+#define TC_GENTIMER_CNTP_CVAL                 1
 
-#define TC_COREAFUNC_IRQ                    1
-#define TC_COREAFUNC_FPSCR                  1
-#define TC_COREAFUNC_CPSR                   1
-#define TC_COREAFUNC_MODE                   1
-#define TC_COREAFUNC_SP                     1
-#define TC_COREAFUNC_SP_USR                 1
-#define TC_COREAFUNC_FPEXC                  1
-#define TC_COREAFUNC_ACTLR                  1
-#define TC_COREAFUNC_CPACR                  1
-#define TC_COREAFUNC_DFSR                   1
-#define TC_COREAFUNC_IFSR                   1
-#define TC_COREAFUNC_ISR                    1
-#define TC_COREAFUNC_CBAR                   1
-#define TC_COREAFUNC_TTBR0                  1
-#define TC_COREAFUNC_DACR                   1
-#define TC_COREAFUNC_SCTLR                  1
-#define TC_COREAFUNC_ACTRL                  1
-#define TC_COREAFUNC_MPIDR                  1
-#define TC_COREAFUNC_VBAR                   1
-#define TC_COREAFUNC_MVBAR                  1
-#define TC_COREAFUNC_FPU_ENABLE             1
-
-// <q29> TC_GenTimer_CNTFRQ
-// <q30> TC_GenTimer_CNTP_TVAL
-// <q31> TC_GenTimer_CNTP_CTL
-// <q32> TC_GenTimer_CNTPCT
-// <q33> TC_GenTimer_CNTP_CVAL
-
-#define TC_GENTIMER_CNTFRQ                  1
-#define TC_GENTIMER_CNTP_TVAL               1
-#define TC_GENTIMER_CNTP_CTL                1
-#define TC_GENTIMER_CNTPCT                  1
-#define TC_GENTIMER_CNTP_CVAL               1
-
-// <q34> TC_CAL1Cache_EnDisable
-// <q35> TC_CAL1Cache_EnDisableBTAC
-// <q36> TC_CAL1Cache_log2_up
-// <q37> TC_CAL1Cache_InvalidateDCacheAll
-// <q38> TC_CAL1Cache_CleanDCacheAll
-// <q39> TC_CAL1Cache_CleanInvalidateDCacheAll
-
+// <q0> TC_CAL1Cache_EnDisable
 #define TC_CAL1CACHE_ENDISABLE                1
+// <q0> TC_CAL1Cache_EnDisableBTAC
 #define TC_CAL1CACHE_ENDISABLEBTAC            1
+// <q0> TC_CAL1Cache_log2_up
 #define TC_CAL1CACHE_LOG2_UP                  1
+// <q0> TC_CAL1Cache_InvalidateDCacheAll
 #define TC_CAL1CACHE_INVALIDATEDCACHEALL      1
+// <q0> TC_CAL1Cache_CleanDCacheAll
 #define TC_CAL1CACHE_CLEANDCACHEALL           1
+// <q0> TC_CAL1Cache_CleanInvalidateDCacheAll
 #define TC_CAL1CACHE_CLEANINVALIDATEDCACHEALL 1
 // </h>
 

--- a/CMSIS/CoreValidation/Source/cmsis_cv.c
+++ b/CMSIS/CoreValidation/Source/cmsis_cv.c
@@ -2,7 +2,7 @@
  *      Name:         cmsis_cv.c
  *      Purpose:      Driver validation test cases entry point
  *----------------------------------------------------------------------------
- *      Copyright (c) 2017 - 2018 Arm Limited. All rights reserved.
+ *      Copyright (c) 2017 - 2021 Arm Limited. All rights reserved.
  *----------------------------------------------------------------------------*/
 #include "cmsis_cv.h"
 #include "RTE_Components.h"
@@ -116,6 +116,7 @@ static TEST_CASE TC_LIST[] = {
 
   #elif defined(__CORTEX_A)
     TCD ( TC_CoreAFunc_IRQ,                        TC_COREAFUNC_IRQ                          ),
+    TCD ( TC_CoreAFunc_FaultIRQ,                   TC_COREAFUNC_FAULTIRQ                     ),
     TCD ( TC_CoreAFunc_FPSCR,                      TC_COREAFUNC_FPSCR                        ),
     TCD ( TC_CoreAFunc_CPSR,                       TC_COREAFUNC_CPSR                         ),
     TCD ( TC_CoreAFunc_Mode,                       TC_COREAFUNC_MODE                         ),

--- a/CMSIS/CoreValidation/Tests/config/core_a/CV_Config.h
+++ b/CMSIS/CoreValidation/Tests/config/core_a/CV_Config.h
@@ -2,7 +2,7 @@
  *      Name:         CV_Config.h
  *      Purpose:      CV Config header
  *----------------------------------------------------------------------------
- *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *      Copyright (c) 2017 - 2021 ARM Limited. All rights reserved.
  *----------------------------------------------------------------------------*/
 #ifndef __CV_CONFIG_H
 #define __CV_CONFIG_H
@@ -29,95 +29,94 @@
 
 // <h> Disable Test Cases
 // <i> Uncheck to disable an individual test case
-// <q00> TC_CoreInstr_NOP
-// <q01> TC_CoreInstr_REV
-// <q02> TC_CoreInstr_REV16
-// <q03> TC_CoreInstr_REVSH
-// <q04> TC_CoreInstr_ROR
-// <q05> TC_CoreInstr_RBIT
-// <q06> TC_CoreInstr_CLZ
-// <q07> TC_CoreInstr_Exclusives
-// <q08> TC_CoreInstr_SSAT
-// <q09> TC_CoreInstr_USAT
+// <q0> TC_CoreInstr_NOP
+#define TC_COREINSTR_NOP_EN                   1
+// <q0> TC_CoreInstr_REV
+#define TC_COREINSTR_REV_EN                   1
+// <q0> TC_CoreInstr_REV16
+#define TC_COREINSTR_REV16_EN                 1
+// <q0> TC_CoreInstr_REVSH
+#define TC_COREINSTR_REVSH_EN                 1
+// <q0> TC_CoreInstr_ROR
+#define TC_COREINSTR_ROR_EN                   1
+// <q0> TC_CoreInstr_RBIT
+#define TC_COREINSTR_RBIT_EN                  1
+// <q0> TC_CoreInstr_CLZ
+#define TC_COREINSTR_CLZ_EN                   1
+// <q0> TC_CoreInstr_Exclusives
+#define TC_COREINSTR_EXCLUSIVES_EN            1
+// <q0> TC_CoreInstr_SSAT
+#define TC_COREINSTR_SSAT_EN                  1
+// <q0> TC_CoreInstr_USAT
+#define TC_COREINSTR_USAT_EN                  1
 
-#define TC_COREINSTR_NOP_EN                 1
-#define TC_COREINSTR_REV_EN                 1
-#define TC_COREINSTR_REV16_EN               1
-#define TC_COREINSTR_REVSH_EN               1
-#define TC_COREINSTR_ROR_EN                 1
-#define TC_COREINSTR_RBIT_EN                1
-#define TC_COREINSTR_CLZ_EN                 1
-#define TC_COREINSTR_EXCLUSIVES_EN          1
-#define TC_COREINSTR_SSAT_EN                1
-#define TC_COREINSTR_USAT_EN                1
+// <q0> TC_CoreAFunc_IRQ
+#define TC_COREAFUNC_IRQ                      1
+// <q0> TC_CoreAFunc_FaultIRQ
+#define TC_COREAFUNC_FAULTIRQ                 1
+// <q0> TC_CoreAFunc_FPSCR
+#define TC_COREAFUNC_FPSCR                    1
+// <q0> TC_CoreAFunc_CPSR
+#define TC_COREAFUNC_CPSR                     1
+// <q0> TC_CoreAFunc_Mode
+#define TC_COREAFUNC_MODE                     1
+// <q0> TC_CoreAFunc_SP
+#define TC_COREAFUNC_SP                       1
+// <q0> TC_CoreAFunc_SP_usr
+#define TC_COREAFUNC_SP_USR                   1
+// <q0> TC_CoreAFunc_FPEXC
+#define TC_COREAFUNC_FPEXC                    1
+// <q0> TC_CoreAFunc_ACTLR
+#define TC_COREAFUNC_ACTLR                    1
+// <q0> TC_CoreAFunc_CPACR
+#define TC_COREAFUNC_CPACR                    1
+// <q0> TC_CoreAFunc_DFSR
+#define TC_COREAFUNC_DFSR                     1
+// <q0> TC_CoreAFunc_IFSR
+#define TC_COREAFUNC_IFSR                     1
+// <q0> TC_CoreAFunc_ISR
+#define TC_COREAFUNC_ISR                      1
+// <q0> TC_CoreAFunc_CBAR
+#define TC_COREAFUNC_CBAR                     1
+// <q0> TC_CoreAFunc_TTBR0
+#define TC_COREAFUNC_TTBR0                    1
+// <q0> TC_CoreAFunc_DACR
+#define TC_COREAFUNC_DACR                     1
+// <q0> TC_CoreAFunc_SCTLR
+#define TC_COREAFUNC_SCTLR                    1
+// <q0> TC_CoreAFunc_ACTRL
+#define TC_COREAFUNC_ACTRL                    1
+// <q0> TC_CoreAFunc_MPIDR
+#define TC_COREAFUNC_MPIDR                    1
+// <q0> TC_CoreAFunc_VBAR
+#define TC_COREAFUNC_VBAR                     1
+// <q0> TC_CoreAFunc_MVBAR
+#define TC_COREAFUNC_MVBAR                    1
+// <q0> TC_CoreAFunc_FPU_Enable
+#define TC_COREAFUNC_FPU_ENABLE               1
 
-// <q09> TC_CoreAFunc_FPSCR
-// <q10> TC_CoreAFunc_CPSR
-// <q11> TC_CoreAFunc_Mode
-// <q12> TC_CoreAFunc_SP
-// <q13> TC_CoreAFunc_SP_usr
-// <q14> TC_CoreAFunc_FPEXC
-// <q15> TC_CoreAFunc_ACTLR
-// <q16> TC_CoreAFunc_CPACR
-// <q17> TC_CoreAFunc_DFSR
-// <q18> TC_CoreAFunc_IFSR
-// <q19> TC_CoreAFunc_ISR
-// <q20> TC_CoreAFunc_CBAR
-// <q21> TC_CoreAFunc_TTBR0
-// <q22> TC_CoreAFunc_DACR
-// <q23> TC_CoreAFunc_SCTLR
-// <q24> TC_CoreAFunc_ACTRL
-// <q25> TC_CoreAFunc_MPIDR
-// <q26> TC_CoreAFunc_VBAR
-// <q27> TC_CoreAFunc_MVBAR
-// <q28> TC_CoreAFunc_FPU_Enable
+// <q0> TC_GenTimer_CNTFRQ
+#define TC_GENTIMER_CNTFRQ                    1
+// <q0> TC_GenTimer_CNTP_TVAL
+#define TC_GENTIMER_CNTP_TVAL                 1
+// <q0> TC_GenTimer_CNTP_CTL
+#define TC_GENTIMER_CNTP_CTL                  1
+// <q0> TC_GenTimer_CNTPCT
+#define TC_GENTIMER_CNTPCT                    1
+// <q0> TC_GenTimer_CNTP_CVAL
+#define TC_GENTIMER_CNTP_CVAL                 1
 
-#define TC_COREAFUNC_IRQ                    1
-#define TC_COREAFUNC_FPSCR                  1
-#define TC_COREAFUNC_CPSR                   1
-#define TC_COREAFUNC_MODE                   1
-#define TC_COREAFUNC_SP                     1
-#define TC_COREAFUNC_SP_USR                 1
-#define TC_COREAFUNC_FPEXC                  1
-#define TC_COREAFUNC_ACTLR                  1
-#define TC_COREAFUNC_CPACR                  1
-#define TC_COREAFUNC_DFSR                   1
-#define TC_COREAFUNC_IFSR                   1
-#define TC_COREAFUNC_ISR                    1
-#define TC_COREAFUNC_CBAR                   1
-#define TC_COREAFUNC_TTBR0                  1
-#define TC_COREAFUNC_DACR                   1
-#define TC_COREAFUNC_SCTLR                  1
-#define TC_COREAFUNC_ACTRL                  1
-#define TC_COREAFUNC_MPIDR                  1
-#define TC_COREAFUNC_VBAR                   1
-#define TC_COREAFUNC_MVBAR                  1
-#define TC_COREAFUNC_FPU_ENABLE             1
-
-// <q29> TC_GenTimer_CNTFRQ
-// <q30> TC_GenTimer_CNTP_TVAL
-// <q31> TC_GenTimer_CNTP_CTL
-// <q32> TC_GenTimer_CNTPCT
-// <q33> TC_GenTimer_CNTP_CVAL
-
-#define TC_GENTIMER_CNTFRQ                  1
-#define TC_GENTIMER_CNTP_TVAL               1
-#define TC_GENTIMER_CNTP_CTL                1
-#define TC_GENTIMER_CNTPCT                  1
-#define TC_GENTIMER_CNTP_CVAL               1
-
-// <q34> TC_CAL1Cache_EnDisable
-// <q35> TC_CAL1Cache_EnDisableBTAC
-// <q36> TC_CAL1Cache_log2_up
-// <q37> TC_CAL1Cache_InvalidateDCacheAll
-// <q38> TC_CAL1Cache_CleanDCacheAll
-// <q39> TC_CAL1Cache_CleanInvalidateDCacheAll
-
+// <q0> TC_CAL1Cache_EnDisable
 #define TC_CAL1CACHE_ENDISABLE                1
+// <q0> TC_CAL1Cache_EnDisableBTAC
 #define TC_CAL1CACHE_ENDISABLEBTAC            1
+// <q0> TC_CAL1Cache_log2_up
 #define TC_CAL1CACHE_LOG2_UP                  1
+// <q0> TC_CAL1Cache_InvalidateDCacheAll
 #define TC_CAL1CACHE_INVALIDATEDCACHEALL      1
+// <q0> TC_CAL1Cache_CleanDCacheAll
 #define TC_CAL1CACHE_CLEANDCACHEALL           1
+// <q0> TC_CAL1Cache_CleanInvalidateDCacheAll
 #define TC_CAL1CACHE_CLEANINVALIDATEDCACHEALL 1
 // </h>
 

--- a/CMSIS/Core_A/Include/cmsis_armcc.h
+++ b/CMSIS/Core_A/Include/cmsis_armcc.h
@@ -1,11 +1,11 @@
 /**************************************************************************//**
  * @file     cmsis_armcc.h
  * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.0.4
- * @date     30. July 2019
+ * @version  V1.0.5
+ * @date     05. May 2021
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -295,6 +295,34 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
 #define __USAT                            __usat
 
 /* ###########################  Core Function Access  ########################### */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+/* intrinsic void __enable_irq(); */
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+  Can only be executed in Privileged modes.
+ */
+/* intrinsic void __disable_irq(void); */
+
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+#define __enable_fault_irq                __enable_fiq
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+#define __disable_fault_irq               __disable_fiq
 
 /**
   \brief   Get FPSCR (Floating Point Status/Control)

--- a/CMSIS/Core_A/Include/cmsis_armclang.h
+++ b/CMSIS/Core_A/Include/cmsis_armclang.h
@@ -1,11 +1,11 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
  * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.2.0
- * @date     05. August 2019
+ * @version  V1.2.1
+ * @date     05. May 2021
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,10 +26,6 @@
 #define __CMSIS_ARMCLANG_H
 
 #pragma clang system_header   /* treat file as system include file */
-
-#ifndef __ARM_COMPAT_H
-#include <arm_compat.h>    /* Compatibility header for Arm Compiler 5 intrinsics */
-#endif
 
 /* CMSIS compiler specific defines */
 #ifndef   __ASM
@@ -373,6 +369,46 @@ __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
 /* ###########################  Core Function Access  ########################### */
 
 /**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+  Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+/**
   \brief   Get FPSCR
   \details Returns the current value of the Floating Point Status/Control register.
   \return               Floating Point Status/Control register value
@@ -401,7 +437,7 @@ __STATIC_FORCEINLINE uint32_t __get_CPSR(void)
  */
 __STATIC_FORCEINLINE void __set_CPSR(uint32_t cpsr)
 {
-__ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
+  __ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
 }
 
 /** \brief  Get Mode
@@ -409,7 +445,7 @@ __ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
  */
 __STATIC_FORCEINLINE uint32_t __get_mode(void)
 {
-	return (__get_CPSR() & 0x1FU);
+  return (__get_CPSR() & 0x1FU);
 }
 
 /** \brief  Set Mode
@@ -423,7 +459,7 @@ __STATIC_FORCEINLINE void __set_mode(uint32_t mode)
 /** \brief  Get Stack Pointer
     \return Stack Pointer value
  */
-__STATIC_FORCEINLINE uint32_t __get_SP()
+__STATIC_FORCEINLINE uint32_t __get_SP(void)
 {
   uint32_t result;
   __ASM volatile("MOV  %0, sp" : "=r" (result) : : "memory");
@@ -441,7 +477,7 @@ __STATIC_FORCEINLINE void __set_SP(uint32_t stack)
 /** \brief  Get USR/SYS Stack Pointer
     \return USR/SYS Stack Pointer value
  */
-__STATIC_FORCEINLINE uint32_t __get_SP_usr()
+__STATIC_FORCEINLINE uint32_t __get_SP_usr(void)
 {
   uint32_t cpsr;
   uint32_t result;
@@ -546,7 +582,7 @@ __STATIC_INLINE void __FPU_Enable(void)
     "        VMOV    D14,R2,R2         \n"
     "        VMOV    D15,R2,R2         \n"
 
-#if __ARM_NEON == 1
+#if (defined(__ARM_NEON) && (__ARM_NEON == 1))
     //Initialise D32 registers to 0
     "        VMOV    D16,R2,R2         \n"
     "        VMOV    D17,R2,R2         \n"

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -1,11 +1,11 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
  * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.3.0
- * @date     17. December 2019
+ * @version  V1.3.1
+ * @date     05. May 2021
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -37,7 +37,6 @@
 #endif
 
 /* CMSIS compiler specific defines */
-
 #ifndef   __ASM
   #define __ASM                                  __asm
 #endif
@@ -57,7 +56,7 @@
   #define __NO_RETURN                            __attribute__((__noreturn__))
 #endif
 #ifndef   CMSIS_DEPRECATED
- #define  CMSIS_DEPRECATED                       __attribute__((deprecated))
+  #define CMSIS_DEPRECATED                       __attribute__((deprecated))
 #endif
 #ifndef   __USED
   #define __USED                                 __attribute__((used))
@@ -433,10 +432,11 @@ __STATIC_FORCEINLINE  int16_t __REVSH(int16_t value)
   \param [in]    op2  Number of Bits to rotate
   \return               Rotated value
  */
-__STATIC_FORCEINLINE  uint32_t __ROR(uint32_t op1, uint32_t op2)
+__STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
 {
   op2 %= 32U;
-  if (op2 == 0U) {
+  if (op2 == 0U)
+  {
     return op1;
   }
   return (op1 >> op2) | (op1 << (32U - op2));
@@ -448,7 +448,7 @@ __STATIC_FORCEINLINE  uint32_t __ROR(uint32_t op1, uint32_t op2)
   \param [in]    value  is ignored by the processor.
                  If required, a debugger can use it to store additional information about the breakpoint.
  */
-#define __BKPT(value)                       __ASM volatile ("bkpt "#value)
+#define __BKPT(value)   __ASM volatile ("bkpt "#value)
 
 /**
   \brief   Reverse bit order of value
@@ -669,16 +669,36 @@ __STATIC_FORCEINLINE void __enable_irq(void)
   \details Disables IRQ interrupts by setting the I-bit in the CPSR.
   Can only be executed in Privileged modes.
  */
-__STATIC_FORCEINLINE  void __disable_irq(void)
+__STATIC_FORCEINLINE void __disable_irq(void)
 {
   __ASM volatile ("cpsid i" : : : "memory");
 }
 
 /**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+/**
   \brief   Get FPSCR
   \details Returns the current value of the Floating Point Status/Control register.
-  \return Floating Point Status/Control register value
-*/
+  \return               Floating Point Status/Control register value
+ */
 __STATIC_FORCEINLINE  uint32_t __get_FPSCR(void)
 {
   #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
@@ -702,8 +722,8 @@ __STATIC_FORCEINLINE  uint32_t __get_FPSCR(void)
 /**
   \brief   Set FPSCR
   \details Assigns the given value to the Floating Point Status/Control register.
-  \param [in] fpscr  Floating Point Status/Control value to set
-*/
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
 __STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
 {
   #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
@@ -736,7 +756,7 @@ __STATIC_FORCEINLINE uint32_t __get_CPSR(void)
  */
 __STATIC_FORCEINLINE void __set_CPSR(uint32_t cpsr)
 {
-__ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
+  __ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
 }
 
 /** \brief  Get Mode
@@ -744,7 +764,7 @@ __ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
  */
 __STATIC_FORCEINLINE uint32_t __get_mode(void)
 {
-    return (__get_CPSR() & 0x1FU);
+  return (__get_CPSR() & 0x1FU);
 }
 
 /** \brief  Set Mode
@@ -810,7 +830,7 @@ __STATIC_FORCEINLINE uint32_t __get_FPEXC(void)
 {
 #if (__FPU_PRESENT == 1)
   uint32_t result;
-  __ASM volatile("VMRS %0, fpexc" : "=r" (result) );
+  __ASM volatile("VMRS %0, fpexc" : "=r" (result) : : "memory");
   return(result);
 #else
   return(0);
@@ -833,8 +853,8 @@ __STATIC_FORCEINLINE void __set_FPEXC(uint32_t fpexc)
 
 #define __get_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MRC p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : "=r" (Rt) : : "memory" )
 #define __set_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MCR p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : : "r" (Rt) : "memory" )
-#define __get_CP64(cp, op1, Rt, CRm) __ASM volatile("MRRC p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : "=r" (Rt) : : "memory" )
-#define __set_CP64(cp, op1, Rt, CRm) __ASM volatile("MCRR p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : : "r" (Rt) : "memory" )
+#define __get_CP64(cp, op1, Rt, CRm)         __ASM volatile("MRRC p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : "=r" (Rt) : : "memory" )
+#define __set_CP64(cp, op1, Rt, CRm)         __ASM volatile("MCRR p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : : "r" (Rt) : "memory" )
 
 #include "cmsis_cp15.h"
 


### PR DESCRIPTION
…ted compilers (#1187)

 - reworked compiler header files
 - corrected CoreValidation tests