### PR TITLE
CMSIS-Core: Fix 64-bit compilation warnings

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -239,7 +239,7 @@ __STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  __ASM volatile ("MRS %w0, control" : "=r" (result) );
   return(result);
 }
 
@@ -267,7 +267,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_CONTROL_NS(void)
  */
 __STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
 {
-  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+  __ASM volatile ("MSR control, %w0" : : "r" (control) : "memory");
 }
 
 
@@ -293,7 +293,7 @@ __STATIC_FORCEINLINE uint32_t __get_IPSR(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  __ASM volatile ("MRS %w0, ipsr" : "=r" (result) );
   return(result);
 }
 
@@ -307,7 +307,7 @@ __STATIC_FORCEINLINE uint32_t __get_APSR(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  __ASM volatile ("MRS %w0, apsr" : "=r" (result) );
   return(result);
 }
 
@@ -321,7 +321,7 @@ __STATIC_FORCEINLINE uint32_t __get_xPSR(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  __ASM volatile ("MRS %w0, xpsr" : "=r" (result) );
   return(result);
 }
 
@@ -335,7 +335,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  __ASM volatile ("MRS %w0, psp"  : "=r" (result) );
   return(result);
 }
 
@@ -363,7 +363,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
  */
 __STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
 {
-  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+  __ASM volatile ("MSR psp, %w0" : : "r" (topOfProcStack) : );
 }
 
 
@@ -389,7 +389,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  __ASM volatile ("MRS %w0, msp" : "=r" (result) );
   return(result);
 }
 
@@ -417,7 +417,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
  */
 __STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
 {
-  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+  __ASM volatile ("MSR msp, %w0" : : "r" (topOfMainStack) : );
 }
 
 
@@ -470,7 +470,7 @@ __STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
 {
   uint32_t result;
 
-  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  __ASM volatile ("MRS %w0, primask" : "=r" (result) );
   return(result);
 }
 
@@ -498,7 +498,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PRIMASK_NS(void)
  */
 __STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
 {
-  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+  __ASM volatile ("MSR primask, %w0" : : "r" (priMask) : "memory");
 }
 
 
@@ -991,7 +991,7 @@ __STATIC_FORCEINLINE uint32_t __REV(uint32_t value)
 #else
   uint32_t result;
 
-  __ASM ("rev %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  __ASM ("rev %w0, %w1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
   return result;
 #endif
 }
@@ -1007,7 +1007,7 @@ __STATIC_FORCEINLINE uint32_t __REV16(uint32_t value)
 {
   uint32_t result;
 
-  __ASM ("rev16 %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  __ASM ("rev16 %w0, %w1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
   return result;
 }
 
@@ -1025,7 +1025,7 @@ __STATIC_FORCEINLINE int16_t __REVSH(int16_t value)
 #else
   int16_t result;
 
-  __ASM ("revsh %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  __ASM ("revsh %w0, %w1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
   return result;
 #endif
 }


### PR DESCRIPTION
Needed to add this to fix compilation on a 64-bit target with `-Werror`.