### PR TITLE
gen_pack: Add powershell version

### DIFF
--- a/CMSIS/DoxyGen/Pack/src/pack_utilities.txt
+++ b/CMSIS/DoxyGen/Pack/src/pack_utilities.txt
@@ -11,6 +11,7 @@ overview over programs that are either part of the CMSIS Pack or are available f
 	- Several \subpage cp_Editors can verify XML files using the XML schema files that are part of the CMSIS Pack.
 	- \subpage cp_ZIPTool create the actual ZIP archive of a Software Pack.
 	- \subpage bash_script that generates a CMSIS Software Pack on Linux or Windows operating systems.
+  - \subpage pwsh_script that generates a CMSIS Software Pack on Windows operating systems.
 
 */
 	
@@ -48,6 +49,8 @@ $ sudo apt-get install libxml2-utils
 \endcode
 
 <b>Installing on Windows</b>
+
+\note If you use \c gen_pack.ps1, you can skip this step.
 
 For Windows <a href="https://www.zlatkovic.com/pub/libxml/" target="_blank"><b>libxml</b></a> provides an XML processor
 that provides the functionality of <b>xmllint</b>.  
@@ -109,6 +112,8 @@ $ sudo apt-get install p7zip-full
 \endcode
 
 <b>Installing on Windows</b>
+
+\note If you use \c gen_pack.ps1, you can skip this step.
 
 In the download section of <a href="http://www.7-zip.org/" target="_blank">7-Zip</a>, download the appropriate installer
 for your Windows system. Use defaults for your installation.
@@ -186,5 +191,61 @@ The <b>gen_pack.sh</b> script template allows you to configure:
  
 
 \verbinclude gen_pack.sh
+
+*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\page pwsh_script Powershell Script gen_pack.ps1
+
+The following <a href="https://docs.microsoft.com/en-us/powershell/" target="_blank">Powershell</a> script template
+\ref gen_pack_ps1 "gen_pack.ps1" allows you to generate a pack file under Windows.
+
+For using \ref gen_pack_ps1 "gen_pack.ps1" 
+ - Adapt the file \ref gen_pack_ps1 "gen_pack.ps1" that is available in the directory <b>/CMSIS/Pack/Bash</b> to the
+   requirements of your software pack and .
+
+The script is generic enough to cope with a wide range of requirements. It uses the information from the
+\ref packFormat "*.PDSC file" to generate the output filename according the CMSIS-Pack conventions and validates the pack
+consistency with \ref packChk.
+
+Below is a sample output (reduced).
+\code
+> .\gen_pack.ps1
+ 
+Starting CMSIS-Pack Generation: 06/25/2021 10:28:48
+PackChk.exe 1.3.89 (Apr  1 2020 09:48:51)
+Copyright (C) 2012-2019 ARM Ltd and ARM Germany GmbH. All rights reserved.
+
+M362: Also suppressing Messages M502 and M504
+
+Phase1: Read PDSC files
+
+Phase2: Static Data & Dependencies check
+
+*** WARNING M304: C:\Users\Admin\AppData\Local\Arm\Packs\ARM\CMSIS\5.7.0\CMSIS\Pack\Bash\build\MyVendor.MyPack.pdsc
+  No package URL (<url>-tag and/or value) found in PDSC file!
+
+
+Phase3: RTE Model based Data & Dependencies check
+
+Found 0 Error(s) and 1 Warning(s).
+
+MyVendor.MyPack.1.0.0.pack
+build of pack succeeded
+cleaning up ...
+Completed CMSIS-Pack Generation: 06/25/2021 10:28:49
+\endcode
+
+\anchor gen_pack_ps1
+<b>gen_pack.ps1 Powershell script template file</b>
+
+The <b>gen_pack.ps1</b> script template allows you to configure:
+ - Path environment variables for related utilities (\c CMSIS_PACK_PATH, \c PATH_TO_ADD)
+ - Directory names for temporary build and output files (\c PACK_WAREHOUSE, \c PACK_BUILD)
+ - Directory names and files in the root directory that should be included in the pack (\c PACK_DIRS, \c PACK_BASE_FILES)
+ 
+
+\verbinclude gen_pack.ps1
 
 */

--- a/CMSIS/Pack/Bash/gen_pack.ps1
+++ b/CMSIS/Pack/Bash/gen_pack.ps1
@@ -1,0 +1,120 @@
+# Version: 1.0 
+# Date: 2021-06-23
+# Author: Junchang Liu (liujunchang97@outlook.com)
+# This powershell script generates a CMSIS Software Pack:
+#
+# Pre-requisites:
+# - PackChk in path with execute permission
+#   (see CMSIS-Pack: CMSIS/Utilities/<os>/PackChk)
+# - powershell 7.0.0 or higher
+#   https://github.com/PowerShell/PowerShell/releases
+
+############### EDIT BELOW ###############
+# Extend Path environment variable locally
+
+$CMSIS_VERSION = "5.7.0"
+$CMSIS_PACK_PATH = "$env:LOCALAPPDATA\Arm\Packs\ARM\CMSIS\$CMSIS_VERSION"
+$env:Path += ";$CMSIS_PACK_PATH\CMSIS\Utilities\Win32"
+
+# Specify file names to be added to pack base directory
+$PACK_BASE_FILES = "License.txt", "README.md"
+
+# Pack warehouse directory - destination 
+$PACK_WAREHOUSE = "output"
+
+# Temporary pack build directory
+$PACK_BUILD = "build"
+
+# Specify directories included in pack relative to base directory
+# All directories:
+$PACK_DIRS = Get-ChildItem -Directory -Exclude $PACK_WAREHOUSE, $PACK_BUILD
+
+############ DO NOT EDIT BELOW ###########
+$ErrorActionPreference = "Stop"
+
+Write-Output "Starting CMSIS-Pack Generation: $(Get-Date)"
+
+try {
+  Get-Command PackChk > $null
+}
+catch {
+  Write-Output @"
+Error: No PackChk Utility found
+Action: Add PackChk to your path
+<pack_root_dir>/ARM/CMSIS/<version>/CMSIS/Utilities/<os>/
+"@
+  exit -1
+}
+
+$PACK_DESCRIPTION_FILE = Get-ChildItem -Name -Filter *.pdsc
+$PDSC_NUM = (Get-ChildItem -Filter *.pdsc|Measure-Object).Count
+if ($PDSC_NUM -eq 0) {
+  Write-Output "Error: No *.pdsc file found in current directory"
+  exit -1
+} elseif ($PDSC_NUM -gt 1) {
+  Write-Output @"
+Error: Only one PDSC file allowed in directory structure:
+Found: $PACK_DESCRIPTION_FILE
+Action: Delete unused pdsc files
+"@
+  exit -1
+}
+
+$PACK_VENDOR, $PACK_NAME = $PACK_DESCRIPTION_FILE.ToString().Split(".")[0, 1]
+
+#if $PACK_BUILD directory does not exist, create it.
+New-Item -ItemType Directory -Force $PACK_BUILD > $null
+
+# Copy files into build base directory: $PACK_BUILD
+# pdsc file is mandatory in base directory:
+Copy-Item -Force "$PACK_VENDOR.$PACK_NAME.pdsc" -Destination $PACK_BUILD
+
+# directories
+Copy-Item -Force $PACK_DIRS -Destination $PACK_BUILD -Recurse
+
+# files for base directory
+Copy-Item -Force $PACK_BASE_FILES -Destination $PACK_BUILD -Recurse
+
+# Run Schema Check:
+try {
+  [xml]$PDSC_XML = Get-Content "$PACK_BUILD\$PACK_VENDOR.$PACK_NAME.pdsc"
+  $PDSC_XML.Schemas.Add("", "$CMSIS_PACK_PATH\CMSIS\Utilities\PACK.xsd") > $null
+  $PDSC_XML.Validate($null)
+}
+catch {
+  Write-Output "build aborted: Schema check of $PACK_VENDOR.$PACK_NAME.pdsc against PACK.xsd failed"
+  exit -1
+}
+
+
+# Run Pack Check and generate PackName file with version
+PackChk "$PACK_BUILD\$PACK_VENDOR.$PACK_NAME.pdsc" -n PackName.txt -x M362
+
+[string]$PACKNAME = Get-Content PackName.txt
+
+Write-Output $PACKNAME
+
+# Archiving
+New-Item -ItemType Directory -Force $PACK_WAREHOUSE > $null
+
+try {
+  $compress = @{
+    Path = Get-ChildItem -Path $PACK_BUILD
+    CompressionLevel = "Optimal"
+    DestinationPath = "$PACK_WAREHOUSE\$PACKNAME"
+  }
+  Compress-Archive -Force @compress
+}
+catch {
+  Write-Output "build aborted: archiving failed"
+  exit -1
+}
+
+Write-Output "build of pack succeeded"
+
+# Clean up
+Write-Output "cleaning up ..."
+
+Remove-Item -Recurse $PACK_BUILD
+
+Write-Output "Completed CMSIS-Pack Generation: $(Get-Date)"


### PR DESCRIPTION
Powershell exists in most modern Windows computers, so users do not need to install extra tools like bash version on Windows.

This file may not be appropriate to put in the `Bash` folder.