### PR TITLE
rtx-def: fix license - apache 2.0

### DIFF
--- a/CMSIS/RTOS2/RTX/Include/rtx_def.h
+++ b/CMSIS/RTOS2/RTX/Include/rtx_def.h
@@ -1,7 +1,19 @@
 /*
  * Copyright (c) 2021 Arm Limited. All rights reserved.
  *
- * This Software is licensed under an Arm proprietary license.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * -----------------------------------------------------------------------------
  *


### PR DESCRIPTION
Using the same license as any other file in RTX. 

I found this while working with 5.8.0 release (our license check in Mbed OS failed due to non permissive license found). It would be good to have license check introduced to gate PRs.