### PR TITLE
CMSIS-DSP: Fix lack of defined check on ARM_MATH_DSP #1248

### DIFF
--- a/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q7.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_conv_partial_q7.c
@@ -64,7 +64,7 @@ arm_status arm_conv_partial_q7(
         uint32_t numPoints)
 {
 
-#if ARM_MATH_DSP
+#if defined(ARM_MATH_DSP)
 
   const q7_t *pIn1;                                    /* InputA pointer */
   const q7_t *pIn2;                                    /* InputB pointer */


### PR DESCRIPTION
The rest of the DSP codebase checks ARM_MATH_DSP with `#if defined`;
however, arm_conv_partial_q7.c does not. This fixes this issue.