### PR TITLE
people forgot to update the sub version...

### DIFF
--- a/CMSIS/Core/Include/cmsis_version.h
+++ b/CMSIS/Core/Include/cmsis_version.h
@@ -33,7 +33,7 @@
 
 /*  CMSIS Version definitions */
 #define __CM_CMSIS_VERSION_MAIN  ( 5U)                                      /*!< [31:16] CMSIS Core(M) main version */
-#define __CM_CMSIS_VERSION_SUB   ( 4U)                                      /*!< [15:0]  CMSIS Core(M) sub version */
+#define __CM_CMSIS_VERSION_SUB   ( 5U)                                      /*!< [15:0]  CMSIS Core(M) sub version */
 #define __CM_CMSIS_VERSION       ((__CM_CMSIS_VERSION_MAIN << 16U) | \
                                    __CM_CMSIS_VERSION_SUB           )       /*!< CMSIS Core(M) version number */
 #endif


### PR DESCRIPTION
The CMSIS core version should be 5.5.0, and people forgot to update the cmsis_version.h
We should avoid this issue in the future. 