### PR TITLE
CMSIS-NN: Remove depdendency to CMSIS-DSP

### DIFF
--- a/CMSIS/NN/Include/arm_nn_math_types.h
+++ b/CMSIS/NN/Include/arm_nn_math_types.h
@@ -1,0 +1,167 @@
+/******************************************************************************
+ * @file     arm_nn_math_types.h
+ * @brief    Compiler include and basic types
+ * @version  V1.0.0
+ * @date     08 July 2021
+ * Target Processor: Cortex-M
+ ******************************************************************************/
+/*
+ * Copyright (c) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+   Copied from CMSIS/DSP/arm_math_types.h and modified
+*/
+
+#ifndef _ARM_NN_MATH_TYPES_H_
+
+#define _ARM_NN_MATH_TYPES_H_
+
+/* DSP inlcude for enum arm_status. */
+#include "arm_math_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Compiler specific diagnostic adjustment */
+#if defined(__CC_ARM)
+
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+
+#elif defined(__GNUC__)
+
+#elif defined(__ICCARM__)
+
+#elif defined(__TI_ARM__)
+
+#elif defined(__CSMC__)
+
+#elif defined(__TASKING__)
+
+#elif defined(_MSC_VER)
+
+#else
+#error Unknown compiler
+#endif
+
+/* Included for instrinsics definitions */
+#if defined(_MSC_VER)
+#include <stdint.h>
+#ifndef __STATIC_FORCEINLINE
+#define __STATIC_FORCEINLINE static __forceinline
+#endif
+#ifndef __STATIC_INLINE
+#define __STATIC_INLINE static __inline
+#endif
+#ifndef __ALIGNED
+#define __ALIGNED(x) __declspec(align(x))
+#endif
+
+#elif defined(__GNUC_PYTHON__)
+#include <stdint.h>
+#ifndef __ALIGNED
+#define __ALIGNED(x) __attribute__((aligned(x)))
+#endif
+#ifndef __STATIC_FORCEINLINE
+#define __STATIC_FORCEINLINE static inline __attribute__((always_inline))
+#endif
+#ifndef __STATIC_INLINE
+#define __STATIC_INLINE static inline
+#endif
+
+#else
+#include "cmsis_compiler.h"
+#endif
+
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <string.h>
+
+/* evaluate ARM DSP feature */
+#if (defined(__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
+#ifndef ARM_MATH_DSP
+#define ARM_MATH_DSP 1
+#endif
+#endif
+
+#if __ARM_FEATURE_MVE
+#ifndef ARM_MATH_MVEI
+#define ARM_MATH_MVEI
+#endif
+#endif
+
+/* Compiler specific diagnostic adjustment */
+#if defined(__CC_ARM)
+
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+
+#elif defined(__GNUC__)
+// #pragma GCC diagnostic pop
+
+#elif defined(__ICCARM__)
+
+#elif defined(__TI_ARM__)
+
+#elif defined(__CSMC__)
+
+#elif defined(__TASKING__)
+
+#elif defined(_MSC_VER)
+
+#else
+#error Unknown compiler
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#if __ARM_FEATURE_MVE
+#include <arm_mve.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Add necessary typedefs
+ */
+
+#define NN_Q31_MAX ((q31_t)(0x7FFFFFFFL))
+#define NN_Q7_MAX ((q7_t)(0x7F))
+#define NN_Q31_MIN ((q31_t)(0x80000000L))
+#define NN_Q7_MIN ((q7_t)(0x80))
+
+/**
+ * @brief Error status returned by some functions in the library.
+ */
+
+typedef enum
+{
+    ARM_CMSIS_NN_SUCCESS = 0,        /**< No error */
+    ARM_CMSIS_NN_ARG_ERROR = -1,     /**< One or more arguments are incorrect */
+    ARM_CMSIS_NN_NO_IMPL_ERROR = -2, /**<  No implementation available */
+} arm_cmsis_nn_status;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*ifndef _ARM_NN_MATH_TYPES_H_ */

--- a/CMSIS/NN/Include/arm_nn_tables.h
+++ b/CMSIS/NN/Include/arm_nn_tables.h
@@ -3,8 +3,8 @@
  * Title:        arm_nn_tables.h
  * Description:  Extern declaration for NN tables
  *
- * $Date:        09. October 2020
- * $Revision:    V.1.0.1
+ * $Date:        17. August 2021
+ * $Revision:    V.1.0.2
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -29,12 +29,12 @@
 #ifndef _ARM_NN_TABLES_H
 #define _ARM_NN_TABLES_H
 
-#include "arm_math_types.h"
+#include "arm_nn_math_types.h"
 
 /**
-* @brief tables for various activation functions
-*
-*/
+ * @brief tables for various activation functions
+ *
+ */
 
 extern const q15_t sigmoidTable_q15[256];
 extern const q7_t sigmoidTable_q7[256];

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnfunctions.h
  * Description:  Public header file for CMSIS NN Library
  *
- * $Date:        13 August 2021
- * $Revision:    V.7.3.0
+ * $Date:        17 August 2021
+ * $Revision:    V.7.3.1
  *
  * Target Processor:  Cortex-M CPUs
  * -------------------------------------------------------------------- */
@@ -124,7 +124,7 @@
 #ifndef _ARM_NNFUNCTIONS_H
 #define _ARM_NNFUNCTIONS_H
 
-#include "arm_math_types.h"
+#include "arm_nn_math_types.h"
 #include "arm_nn_types.h"
 
 #define USE_INTRINSIC

--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        13. Aug 2021
- * $Revision:    V.5.9.0
+ * $Date:        17. Aug 2021
+ * $Revision:    V.5.9.1
  *
  * Target Processor:  Cortex-M CPUs
  * -------------------------------------------------------------------- */
@@ -30,8 +30,7 @@
 #ifndef _ARM_NNSUPPORTFUNCTIONS_H_
 #define _ARM_NNSUPPORTFUNCTIONS_H_
 
-#include "arm_common_tables.h"
-#include "arm_math_types.h"
+#include "arm_nn_math_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -768,8 +767,8 @@ void arm_nn_mult_q7(q7_t *pSrcA, q7_t *pSrcB, q7_t *pDst, const uint16_t out_shi
 /**
  * @brief           Saturating doubling high multiply. Result matches
  *                  NEON instruction VQRDMULH.
- * @param[in]       m1        Multiplicand. Range: {Q31_MIN, Q31_MAX}
- * @param[in]       m2        Multiplier. Range: {Q31_MIN, Q31_MAX}
+ * @param[in]       m1        Multiplicand. Range: {NN_Q31_MIN, NN_Q31_MAX}
+ * @param[in]       m2        Multiplier. Range: {NN_Q31_MIN, NN_Q31_MAX}
  * @return          Result of multiplication.
  *
  */
@@ -790,9 +789,9 @@ __STATIC_FORCEINLINE q31_t arm_nn_doubling_high_mult(const q31_t m1, const q31_t
     // as well.
     result = (int32_t)(mult / (1ll << 31));
 
-    if ((m1 == m2) && (m1 == (int32_t)Q31_MIN))
+    if ((m1 == m2) && (m1 == (int32_t)NN_Q31_MIN))
     {
-        result = Q31_MAX;
+        result = NN_Q31_MAX;
     }
     return result;
 }
@@ -801,13 +800,13 @@ __STATIC_FORCEINLINE q31_t arm_nn_doubling_high_mult(const q31_t m1, const q31_t
  * @brief           Doubling high multiply without saturation. This is intended
  *                  for requantization where the scale is a positive integer
  *
- * @param[in]       m1        Multiplicand. Range: {Q31_MIN, Q31_MAX}
- * @param[in]       m2        Multiplier Range: {Q31_MIN, Q31_MAX}
+ * @param[in]       m1        Multiplicand. Range: {NN_Q31_MIN, NN_Q31_MAX}
+ * @param[in]       m2        Multiplier Range: {NN_Q31_MIN, NN_Q31_MAX}
  * @return          Result of multiplication.
  * @note            The result of this matches that of neon instruction
- *                  VQRDMULH for m1 in range {Q31_MIN, Q31_MAX} and m2 in
- *                  range {Q31_MIN + 1, Q31_MAX}. Saturation occurs when
- *                  m1 equals m2 equals Q31_MIN and that is not handled by
+ *                  VQRDMULH for m1 in range {NN_Q31_MIN, NN_Q31_MAX} and m2 in
+ *                  range {NN_Q31_MIN + 1, NN_Q31_MAX}. Saturation occurs when
+ *                  m1 equals m2 equals NN_Q31_MIN and that is not handled by
  *                  this function.
  *
  */
@@ -864,7 +863,7 @@ __STATIC_FORCEINLINE q31_t arm_nn_divide_by_power_of_two(const q31_t dividend, c
 /**
  * @brief           Requantize a given value.
  * @param[in]       val         Value to be requantized
- * @param[in]       multiplier  multiplier. Range {Q31_MIN + 1, Q32_MAX}
+ * @param[in]       multiplier  multiplier. Range {NN_Q31_MIN + 1, Q32_MAX}
  * @param[in]       shift       left or right shift for 'val * multiplier'
  *
  * @return          Returns (val * multiplier)/(2 ^ shift)
@@ -879,7 +878,8 @@ __STATIC_FORCEINLINE q31_t arm_nn_requantize(const q31_t val, const q31_t multip
 /**
  * @brief           Requantize a given 64 bit value.
  * @param[in]       val                 Value to be requantized
- * @param[in]       reduced_multiplier  Reduced multiplier from range {Q31_MIN + 1, Q32_MAX} to {Q16_MIN + 1, Q16_MAX}
+ * @param[in]       reduced_multiplier  Reduced multiplier from range {NN_Q31_MIN + 1, Q32_MAX} to {Q16_MIN + 1,
+ * Q16_MAX}
  * @param[in]       shift               left or right shift for 'val * multiplier'
  *
  * @return          Returns (val * multiplier)/(2 ^ shift)
@@ -1024,21 +1024,21 @@ __STATIC_FORCEINLINE int32_t arm_nn_exp_on_negative_values(int32_t val)
 #undef SELECT_IF_NON_ZERO
 
     mask = MASK_IF_ZERO(val);
-    return SELECT_USING_MASK(mask, Q31_MAX, result);
+    return SELECT_USING_MASK(mask, NN_Q31_MAX, result);
 }
 
 __STATIC_FORCEINLINE q31_t arm_nn_mult_by_power_of_two(const int32_t val, const int32_t exp)
 {
     const int32_t thresh = ((1 << (31 - exp)) - 1);
     int32_t result = val << exp;
-    result = SELECT_USING_MASK(MASK_IF_NON_ZERO(val > thresh), Q31_MAX, result);
-    result = SELECT_USING_MASK(MASK_IF_NON_ZERO(val < -thresh), Q31_MIN, result);
+    result = SELECT_USING_MASK(MASK_IF_NON_ZERO(val > thresh), NN_Q31_MAX, result);
+    result = SELECT_USING_MASK(MASK_IF_NON_ZERO(val < -thresh), NN_Q31_MIN, result);
     return result;
 }
 
 __STATIC_FORCEINLINE int32_t arm_nn_one_over_one_plus_x_for_x_in_0_1(int32_t val)
 {
-    const int64_t sum = (int64_t)val + (int64_t)Q31_MAX;
+    const int64_t sum = (int64_t)val + (int64_t)NN_Q31_MAX;
     const int32_t half_denominator = (int32_t)((sum + (sum >= 0 ? 1 : -1)) / 2L);
     int32_t x = 1515870810 + MUL_SAT(half_denominator, -1010580540);
 

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_svdf_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_svdf_s8.c
@@ -60,7 +60,7 @@ arm_status arm_nn_vec_mat_mult_t_svdf_s8(const q7_t *lhs,
                                          const int32_t activation_max)
 {
     (void)rhs_offset;
-    if (rhs_cols < 0 || (Q31_MAX - rhs_cols) < 16 || dst_offset < 0)
+    if (rhs_cols < 0 || (NN_Q31_MAX - rhs_cols) < 16 || dst_offset < 0)
     {
         return ARM_MATH_ARGUMENT_ERROR;
     }

--- a/CMSIS/NN/Source/SVDFunctions/arm_svdf_s8.c
+++ b/CMSIS/NN/Source/SVDFunctions/arm_svdf_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_svdf_s8.c
  * Description:  S8 basic SVDF layer function
  *
- * $Date:        15. April 2021
- * $Revision:    V.1.5.0
+ * $Date:        17. August 2021
+ * $Revision:    V.1.5.1
  *
  * Target Processor:  Cortex-M processors
  *

--- a/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_s8.c
+++ b/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_softmax_s8.c
  * Description:  S8 softmax function
  *
- * $Date:        01. March 2021
- * $Revision:    V.2.0.2
+ * $Date:        17. August 2021
+ * $Revision:    V.2.0.3
  *
  * Target Processor:  Cortex-M cores
  *
@@ -69,7 +69,7 @@ static int32x4_t arm_exp_on_negative_values_mve_32x4(int32x4_t val)
     mve_pred16_t p = vcmpeqq_n_s32(val, 0);
     mask = vmvnq_m_s32(vdupq_n_s32(0), vdupq_n_s32(0), p);
 
-    result = SELECT_USING_MASK(mask, vdupq_n_s32(Q31_MAX), result);
+    result = SELECT_USING_MASK(mask, vdupq_n_s32(NN_Q31_MAX), result);
     return result;
 }
 #endif
@@ -93,8 +93,8 @@ void arm_softmax_s8(const int8_t *input,
 {
 #ifdef ARM_MATH_MVEI
 
-#define ACT_MIN ((int8_t)Q7_MIN)
-#define ACT_MAX ((int8_t)Q7_MAX)
+#define ACT_MIN ((int8_t)NN_Q7_MIN)
+#define ACT_MAX ((int8_t)NN_Q7_MAX)
 
     const int32_t mask = (1 << shift);
 


### PR DESCRIPTION
All dependencies to CMSIS-DSP except for the return
type are removed.

