### PR TITLE
DoxyGen: Fixed documentation of cache maintenance functions.

### DIFF
--- a/CMSIS/DoxyGen/Core/src/core_cm7.txt
+++ b/CMSIS/DoxyGen/Core/src/core_cm7.txt
@@ -71,7 +71,7 @@ __STATIC_FORCEINLINE void SCB_InvalidateICache (void);
   \param[in]   addr    address
   \param[in]   isize   size of memory block (in number of bytes)
 */
-__STATIC_FORCEINLINE void SCB_InvalidateICache_by_Addr (void *addr, int32_t isize);
+__STATIC_FORCEINLINE void SCB_InvalidateICache_by_Addr (volatile void *addr, int32_t isize);
 
 /**
   @}  // close ICache functions
@@ -146,7 +146,7 @@ __STATIC_FORCEINLINE void SCB_CleanInvalidateDCache (void);
   
   The function invalidates a memory block of size \em dsize [bytes] starting at address \em address. The address is aligned to 32-byte boundary.
 */
-__STATIC_FORCEINLINE void SCB_InvalidateDCache_by_Addr (uint32_t *addr, int32_t dsize);
+__STATIC_FORCEINLINE void SCB_InvalidateDCache_by_Addr (volatile void *addr, int32_t dsize);
 
 
 /**
@@ -158,7 +158,7 @@ __STATIC_FORCEINLINE void SCB_InvalidateDCache_by_Addr (uint32_t *addr, int32_t 
 
 
 */
-__STATIC_FORCEINLINE void SCB_CleanDCache_by_Addr (uint32_t *addr, int32_t dsize);
+__STATIC_FORCEINLINE void SCB_CleanDCache_by_Addr (volatile void *addr, int32_t dsize);
 
 
 /**
@@ -168,7 +168,7 @@ __STATIC_FORCEINLINE void SCB_CleanDCache_by_Addr (uint32_t *addr, int32_t dsize
   
   The function invalidates and cleans a memory block of size \em dsize [bytes] starting at address \em address. The address is aligned to 32-byte boundary.
 */
-__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache_by_Addr (uint32_t *addr, int32_t dsize);
+__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache_by_Addr (volatile void *addr, int32_t dsize);
 
 /**
 @}  // close D-Cache Functions


### PR DESCRIPTION
In c0e1824 the data type of the addr parameters were changed
to volatile void* but the documentation got missed.