### PR TITLE
CMSIS-NN: Add -Ofast to unit tests and update README

### DIFF
--- a/CMSIS/NN/README.md
+++ b/CMSIS/NN/README.md
@@ -77,6 +77,8 @@ cmake .. -DCMAKE_TOOLCHAIN_FILE=~/ethos-u-core-platform/cmake/toolchain/armclang
 ### Compiler options
 Default optimization level is Ofast. Please change according to project needs. Just bear in mind it will impact performance.
 
+The compiler option '-fomit-frame-pointer' is enabled by default at -O and higher. With no optimization level you may need to specifiy '-fomit-frame-pointer' as a minimum.
+
 The compiler option '-fno-builtin' does not utilize optimized implementations of e.g. memcpy and memset, which are heavily used by CMSIS-NN. It can significantly downgrade performance. So this should be avoided.
 The compiler option '-ffreestanding' should also be avoided as it enables '-fno-builtin' implicitly.
 

--- a/CMSIS/NN/Tests/UnitTest/CMakeLists.txt
+++ b/CMSIS/NN/Tests/UnitTest/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -22,7 +22,9 @@ project(cmsis_nn_unit_tests VERSION 0.0.1)
 
 set(CMSIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
 
-add_compile_options(-Werror
+add_compile_options(-Ofast
+                    -fomit-frame-pointer
+                    -Werror
                     -Wimplicit-function-declaration
                     -Wunused-variable
                     -Wunused-function


### PR DESCRIPTION
Adding -Ofast (and -fomit-frame-pointer for clarity) to unit tests. 