### PR TITLE
Ignore old c cast style not supported by apple cc

### DIFF
--- a/CMSIS/DSP/Include/arm_math_types.h
+++ b/CMSIS/DSP/Include/arm_math_types.h
@@ -38,6 +38,7 @@ extern "C"
 #elif defined ( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
 
 #elif defined ( __APPLE_CC__ )
+  #pragma GCC diagnostic ignored "-Wold-style-cast"
 
 #elif defined ( __GNUC__ )
   #pragma GCC diagnostic push


### PR DESCRIPTION
Hello,

One more step to support Apple C Compiler: we need to add a specific ignore warning related to old c cast style.

Thanks again!