### PR TITLE
Fix warning unused tmp variable

### DIFF
--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
@@ -132,7 +132,9 @@ void arm_dot_prod_f32(
     f32x4_t vec1;
     f32x4_t vec2;
     f32x4_t accum = vdupq_n_f32(0);   
-    f32x2_t tmp = vdup_n_f32(0);    
+#if !defined(__aarch64__)
+    f32x2_t tmp = vdup_n_f32(0); 
+#endif   
 
     /* Compute 4 outputs at a time */
     blkCnt = blockSize >> 2U;

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
@@ -3,8 +3,8 @@
  * Title:        arm_dot_prod_f32.c
  * Description:  Floating-point dot product
  *
- * $Date:        23 April 2021
- * $Revision:    V1.9.0
+ * $Date:        05 October 2021
+ * $Revision:    V1.9.1
  *
  * Target Processor: Cortex-M and Cortex-A cores
  * -------------------------------------------------------------------- */

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cholesky_f32.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cholesky_f32.c
@@ -221,7 +221,9 @@ arm_status arm_mat_cholesky_f32(
     f32x4_t acc, acc0, acc1, acc2, acc3;
     f32x4_t vecGi;
     f32x4_t vecGj,vecGj0,vecGj1,vecGj2,vecGj3;
-    f32x2_t tmp = vdup_n_f32(0);    
+#if !defined(__aarch64__)
+    f32x2_t tmp = vdup_n_f32(0);   
+#endif    
     float32_t sum=0.0f;
     float32_t sum0=0.0f,sum1=0.0f,sum2=0.0f,sum3=0.0f;
 

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cholesky_f32.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cholesky_f32.c
@@ -3,8 +3,8 @@
  * Title:        arm_mat_cholesky_f32.c
  * Description:  Floating-point Cholesky decomposition
  *
- * $Date:        23 April 2021
- * $Revision:    V1.9.0
+ * $Date:        05 October 2021
+ * $Revision:    V1.9.1
  *
  * Target Processor: Cortex-M and Cortex-A cores
  * -------------------------------------------------------------------- */


### PR DESCRIPTION
Hello all,

Please find here a fix for a warning happening in arm64 where a tmp variable is defined but not used.

Thanks again!