### PR TITLE
DSP: Cleanup warnings about sign change

### DIFF
--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_f16.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_f16.c
@@ -98,10 +98,10 @@ static void _arm_radix4_butterfly_f16_mve(const arm_cfft_instance_f16 * S,float1
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] =
-       {(0 - 16) * sizeof(float16_t *)
-       , (4 - 16) * sizeof(float16_t *)
-       , (8 - 16) * sizeof(float16_t *)
-       , (12 - 16) * sizeof(float16_t *)};
+        {(0 - 16) * (int32_t)sizeof(float16_t *),
+         (4 - 16) * (int32_t)sizeof(float16_t *),
+         (8 - 16) * (int32_t)sizeof(float16_t *),
+         (12 - 16) * (int32_t)sizeof(float16_t *)};
 
     n2 = fftLen;
     n1 = n2;
@@ -306,10 +306,10 @@ static void _arm_radix4_butterfly_inverse_f16_mve(const arm_cfft_instance_f16 * 
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] = {
-        (0 - 16) * sizeof(q31_t *),
-        (4 - 16) * sizeof(q31_t *),
-        (8 - 16) * sizeof(q31_t *),
-        (12 - 16) * sizeof(q31_t *)
+        (0 - 16) * (int32_t)sizeof(q31_t *),
+        (4 - 16) * (int32_t)sizeof(q31_t *),
+        (8 - 16) * (int32_t)sizeof(q31_t *),
+        (12 - 16) * (int32_t)sizeof(q31_t *)
     };
 
     n2 = fftLen;

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_f32.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_f32.c
@@ -99,10 +99,10 @@ static void _arm_radix4_butterfly_f32_mve(const arm_cfft_instance_f32 * S,float3
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] = {
-        (0 - 16) * sizeof(q31_t *),
-        (1 - 16) * sizeof(q31_t *),
-        (8 - 16) * sizeof(q31_t *),
-        (9 - 16) * sizeof(q31_t *)
+        (0 - 16) * (int32_t)sizeof(q31_t *),
+        (1 - 16) * (int32_t)sizeof(q31_t *),
+        (8 - 16) * (int32_t)sizeof(q31_t *),
+        (9 - 16) * (int32_t)sizeof(q31_t *)
     };
 
     n2 = fftLen;
@@ -308,10 +308,10 @@ static void _arm_radix4_butterfly_inverse_f32_mve(const arm_cfft_instance_f32 * 
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] = {
-        (0 - 16) * sizeof(q31_t *),
-        (1 - 16) * sizeof(q31_t *),
-        (8 - 16) * sizeof(q31_t *),
-        (9 - 16) * sizeof(q31_t *)
+        (0 - 16) * (int32_t)sizeof(q31_t *),
+        (1 - 16) * (int32_t)sizeof(q31_t *),
+        (8 - 16) * (int32_t)sizeof(q31_t *),
+        (9 - 16) * (int32_t)sizeof(q31_t *)
     };
 
     n2 = fftLen;

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
@@ -47,8 +47,10 @@ static void _arm_radix4_butterfly_q15_mve(
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] = {
-        (0 - 16) * sizeof(q15_t *), (4 - 16) * sizeof(q15_t *),
-        (8 - 16) * sizeof(q15_t *), (12 - 16) * sizeof(q15_t *)
+        (0 - 16) * (int32_t)sizeof(q15_t *),
+        (4 - 16) * (int32_t)sizeof(q15_t *),
+        (8 - 16) * (int32_t)sizeof(q15_t *),
+        (12 - 16) * (int32_t)sizeof(q15_t *)
     };
 
     /*
@@ -282,8 +284,10 @@ static void _arm_radix4_butterfly_inverse_q15_mve(const arm_cfft_instance_q15 *S
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] = {
-        (0 - 16) * sizeof(q15_t *), (4 - 16) * sizeof(q15_t *),
-        (8 - 16) * sizeof(q15_t *), (12 - 16) * sizeof(q15_t *)
+        (0 - 16) * (int32_t)sizeof(q15_t *),
+        (4 - 16) * (int32_t)sizeof(q15_t *),
+        (8 - 16) * (int32_t)sizeof(q15_t *),
+        (12 - 16) * (int32_t)sizeof(q15_t *)
     };
 
 

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q31.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q31.c
@@ -49,8 +49,10 @@ static void _arm_radix4_butterfly_q31_mve(
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] = {
-        (0 - 16) * sizeof(q31_t *), (1 - 16) * sizeof(q31_t *),
-        (8 - 16) * sizeof(q31_t *), (9 - 16) * sizeof(q31_t *)
+        (0 - 16) * (int32_t)sizeof(q31_t *),
+        (1 - 16) * (int32_t)sizeof(q31_t *),
+        (8 - 16) * (int32_t)sizeof(q31_t *),
+        (9 - 16) * (int32_t)sizeof(q31_t *)
     };
 
 
@@ -299,8 +301,10 @@ static void _arm_radix4_butterfly_inverse_q31_mve(
     uint32_t  stage = 0;
     int32_t  iter = 1;
     static const int32_t strides[4] = {
-        (0 - 16) * sizeof(q31_t *), (1 - 16) * sizeof(q31_t *),
-        (8 - 16) * sizeof(q31_t *), (9 - 16) * sizeof(q31_t *)
+        (0 - 16) * (int32_t)sizeof(q31_t *),
+        (1 - 16) * (int32_t)sizeof(q31_t *),
+        (8 - 16) * (int32_t)sizeof(q31_t *),
+        (9 - 16) * (int32_t)sizeof(q31_t *)
     };
 
     /*


### PR DESCRIPTION
The IAR compiler warns about changing sign when multiplying
the result from a sizeof() with a negative number. This patch
cleans this up.

This fixes the last warnings for #1328

Signed-off-by: TTornblom <thomas.tornblom@iar.com>