### PR TITLE
Update system_ARMCM55.c

### DIFF
--- a/Device/ARM/ARMCM55/Source/system_ARMCM55.c
+++ b/Device/ARM/ARMCM55/Source/system_ARMCM55.c
@@ -96,7 +96,8 @@ void SystemInit (void)
 
   /* Enable Loop and branch info cache */
   SCB->CCR |= SCB_CCR_LOB_Msk;
-__ISB();
+  __DSB();
+  __ISB();
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   TZ_SAU_Setup();


### PR DESCRIPTION
Adding DSB before ISB to align with the recommended code in Cortex-M55 Technical Reference Manual (https://developer.arm.com/documentation/101051/0100/Initialization/Enabling-the-branch-cache).