### PR TITLE
Core: add missing Secure Fault syndrome registers and fix register name typo.

### DIFF
--- a/CMSIS/Core/Include/core_armv81mml.h
+++ b/CMSIS/Core/Include/core_armv81mml.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     core_armv81mml.h
  * @brief    CMSIS Armv8.1-M Mainline Core Peripheral Access Layer Header File
- * @version  V1.4.1
- * @date     04. June 2021
+ * @version  V1.4.2
+ * @date     13. October 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2018-2021 Arm Limited. All rights reserved.

--- a/CMSIS/Core/Include/core_armv8mml.h
+++ b/CMSIS/Core/Include/core_armv8mml.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     core_armv8mml.h
  * @brief    CMSIS Armv8-M Mainline Core Peripheral Access Layer Header File
- * @version  V5.2.2
- * @date     04. June 2021
+ * @version  V5.2.3
+ * @date     13. October 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.

--- a/CMSIS/Core/Include/core_cm33.h
+++ b/CMSIS/Core/Include/core_cm33.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     core_cm33.h
  * @brief    CMSIS Cortex-M33 Core Peripheral Access Layer Header File
- * @version  V5.2.2
- * @date     04. June 2021
+ * @version  V5.2.3
+ * @date     13. October 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.

--- a/CMSIS/Core/Include/core_cm35p.h
+++ b/CMSIS/Core/Include/core_cm35p.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     core_cm35p.h
  * @brief    CMSIS Cortex-M35P Core Peripheral Access Layer Header File
- * @version  V1.1.2
- * @date     04. June 2021
+ * @version  V1.1.3
+ * @date     13. October 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2018-2021 Arm Limited. All rights reserved.

--- a/CMSIS/Core/Include/core_cm55.h
+++ b/CMSIS/Core/Include/core_cm55.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     core_cm55.h
  * @brief    CMSIS Cortex-M55 Core Peripheral Access Layer Header File
- * @version  V1.2.1
- * @date     04. June 2021
+ * @version  V1.2.2
+ * @date     13. October 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2018-2021 Arm Limited. All rights reserved.


### PR DESCRIPTION
This PR includes @AlbertHuang-CPU's fixes for `core_cm33.h` to add `SFAR` and `SFSR`, and to fix `ID_ADR`, and extends it to all v8-M and v8.1-M core and architecture headers.

The `SCB_Type::ID_ADR` register was renamed to `ID_AFR`. For backwards compatibility, a preprocessor macro was added to map `ID_ADR` to `ID_AFR`.

(I looked into anonymous unions but it's difficult to tell whether certain compilers, particularly Tasking and Cosmic, support the feature. Any compiler supporting C11 should support it, but I believe CMSIS only requires C99. There are pragmas to enable the feature for some compilers, but an alias macro seemed much simpler and less prone to issues.)