### PR TITLE
Fix: Issue of SCB_DisableDCache(),SCB_InvalidateDCache(),SCB_CleanDCache() functions when compiling with -O0

### DIFF
--- a/CMSIS/Core/Include/cachel1_armv7.h
+++ b/CMSIS/Core/Include/cachel1_armv7.h
@@ -1,8 +1,8 @@
 /******************************************************************************
  * @file     cachel1_armv7.h
  * @brief    CMSIS Level 1 Cache API for Armv7-M and later
- * @version  V1.0.1
- * @date     25. October 2021
+ * @version  V1.0.2
+ * @date     26. October 2021
  ******************************************************************************/
 /*
  * Copyright (c) 2020-2021 Arm Limited. All rights reserved.


### PR DESCRIPTION
The variables 'ccsidr', 'sets' and 'ways' needs to be defined as 'register uint32_t' to avoid issues when using the -O0 flag.

These variables are used in the 'do/while' which invalidates/cleans the cache, however, by using -O0 flag (On STM32H7),
the compiler does not exclude them from the cache, so the system invalidates/cleans also them and the result is to end-up in an infinite loop.