### PR TITLE
CMSIS-NN: CMake updates

### DIFF
--- a/CMSIS/NN/CMakeLists.txt
+++ b/CMSIS/NN/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,8 +23,6 @@ project(CMSISNN)
 set(CMSIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 
 option(BUILD_CMSIS_NN_FUNCTIONS "Build CMSIS-NN Source." ON)
-
-add_compile_options(-Ofast)
 
 if(BUILD_CMSIS_NN_FUNCTIONS)
     add_subdirectory(Source)

--- a/CMSIS/NN/Source/ActivationFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ActivationFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,4 @@
 #
 
 file(GLOB SRC "./*_s8.c")
-target_sources(cmsis-nn PUBLIC ${SRC})
+target_sources(cmsis-nn PRIVATE ${SRC})

--- a/CMSIS/NN/Source/BasicMathFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/BasicMathFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,4 @@
 #
 
 file(GLOB SRC "./*_*.c")
-target_sources(cmsis-nn PUBLIC ${SRC})
+target_sources(cmsis-nn PRIVATE ${SRC})

--- a/CMSIS/NN/Source/CMakeLists.txt
+++ b/CMSIS/NN/Source/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -48,6 +48,8 @@ SET(NN ${ROOT}/CMSIS/NN)
 list(APPEND CMAKE_MODULE_PATH ${NN}/Source)
 
 add_library(cmsis-nn STATIC)
+
+target_compile_options(cmsis-nn PRIVATE -Ofast)
 
 ### Includes
 target_include_directories(cmsis-nn PUBLIC "${NN}/Include")

--- a/CMSIS/NN/Source/ConcatenationFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ConcatenationFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,4 @@
 #
 
 file(GLOB SRC "./*_*.c")
-target_sources(cmsis-nn PUBLIC ${SRC})
+target_sources(cmsis-nn PRIVATE ${SRC})

--- a/CMSIS/NN/Source/ConvolutionFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ConvolutionFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,7 +17,7 @@
 #
 
 file(GLOB SRC "./*_s8*.c")
-target_sources(cmsis-nn PUBLIC arm_convolve_s16.c arm_convolve_wrapper_s16.c arm_convolve_fast_s16.c ${SRC})
+target_sources(cmsis-nn PRIVATE arm_convolve_s16.c arm_convolve_wrapper_s16.c arm_convolve_fast_s16.c ${SRC})
 
 
 

--- a/CMSIS/NN/Source/FullyConnectedFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,5 +17,5 @@
 #
 
 file(GLOB SRC "./*_s8.c")
-target_sources(cmsis-nn PUBLIC ${SRC} arm_fully_connected_s16.c)
+target_sources(cmsis-nn PRIVATE ${SRC} arm_fully_connected_s16.c)
 

--- a/CMSIS/NN/Source/NNSupportFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/NNSupportFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,7 +17,7 @@
 #
 
 file(GLOB SRC "./*_s8.c")
-target_sources(cmsis-nn PUBLIC ${SRC} arm_q7_to_q15_with_offset.c
+target_sources(cmsis-nn PRIVATE ${SRC} arm_q7_to_q15_with_offset.c
                                       arm_nn_mat_mul_kernel_s16.c
                                       arm_q7_to_q15_with_offset.c
                                       arm_nn_mat_mul_kernel_s16.c

--- a/CMSIS/NN/Source/PoolingFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/PoolingFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,6 +17,6 @@
 #
 
 file(GLOB SRC "./*_s8.c")
-target_sources(cmsis-nn PUBLIC ${SRC})
+target_sources(cmsis-nn PRIVATE ${SRC})
 
 

--- a/CMSIS/NN/Source/ReshapeFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/ReshapeFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,4 @@
 #
 
 file(GLOB SRC "./*_*.c")
-target_sources(cmsis-nn PUBLIC ${SRC})
+target_sources(cmsis-nn PRIVATE ${SRC})

--- a/CMSIS/NN/Source/SVDFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/SVDFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,4 @@
 #
 
 file(GLOB SRC "./*_s8.c")
-target_sources(cmsis-nn PUBLIC ${SRC})
+target_sources(cmsis-nn PRIVATE ${SRC})

--- a/CMSIS/NN/Source/SoftmaxFunctions/CMakeLists.txt
+++ b/CMSIS/NN/Source/SoftmaxFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+# Copyright (c) 2019-2021 Arm Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,4 @@
 #
 
 file(GLOB SRC "./*_s8.c")
-target_sources(cmsis-nn PUBLIC ${SRC})
+target_sources(cmsis-nn PRIVATE ${SRC})


### PR DESCRIPTION
Sources added to the cmsis-nn static library should with added with
scope PRIVATE. Else they will be exported and built by the other
target linking the library.

Compile options should be set per target.

Change-Id: Ib5c5ce1db8f7baa28bba411be7eea955f5a3af29