### PR TITLE
This fixed some GCC warnings with -WConversion enabled:

### DIFF
--- a/CMSIS/DSP/Include/arm_math_memory.h
+++ b/CMSIS/DSP/Include/arm_math_memory.h
@@ -141,8 +141,8 @@ __STATIC_FORCEINLINE void write_q15x2_ia (
 #ifdef __ARM_FEATURE_UNALIGNED
   memcpy (*pQ15, &val, 4);
 #else
-  (*pQ15)[0] = (val & 0x0FFFF);
-  (*pQ15)[1] = (val >> 16) & 0x0FFFF;
+  (*pQ15)[0] = (q15_t)(val & 0x0FFFF);
+  (*pQ15)[1] = (q15_t)((val >> 16) & 0x0FFFF);
 #endif
 
  *pQ15 += 2;
@@ -163,8 +163,8 @@ __STATIC_FORCEINLINE void write_q15x2 (
 #ifdef __ARM_FEATURE_UNALIGNED
   memcpy (pQ15, &val, 4);
 #else
-  pQ15[0] = val & 0x0FFFF;
-  pQ15[1] = val >> 16;
+  pQ15[0] = (q15_t)(val & 0x0FFFF);
+  pQ15[1] = (q15_t)(val >> 16);
 #endif
 }
 
@@ -224,10 +224,10 @@ __STATIC_FORCEINLINE void write_q7x4_ia (
 #ifdef __ARM_FEATURE_UNALIGNED
   memcpy (*pQ7, &val, 4);
 #else
-  (*pQ7)[0] = val & 0x0FF;
-  (*pQ7)[1] = (val >> 8) & 0x0FF;
-  (*pQ7)[2] = (val >> 16) & 0x0FF;
-  (*pQ7)[3] = (val >> 24) & 0x0FF;
+  (*pQ7)[0] = (q7_t)(val & 0x0FF);
+  (*pQ7)[1] = (q7_t)((val >> 8) & 0x0FF);
+  (*pQ7)[2] = (q7_t)((val >> 16) & 0x0FF);
+  (*pQ7)[3] = (q7_t)((val >> 24) & 0x0FF);
 
 #endif
   *pQ7 += 4;


### PR DESCRIPTION
This warnings are soved:
CMSIS/DSP/Include/arm_math_memory.h:144:21: warning: conversion from 'q31_t' {aka 'int'} to 'q15_t' {aka 'short int'} may change value [-Wconversion]
CMSIS/DSP/Include/arm_math_memory.h:145:28: warning: conversion from 'q31_t' {aka 'int'} to 'q15_t' {aka 'short int'} may change value [-Wconversion]
CMSIS/DSP/Include/arm_math_memory.h:166:17: warning: conversion from 'q31_t' {aka 'int'} to 'q15_t' {aka 'short int'} may change value [-Wconversion]
CMSIS/DSP/Include/arm_math_memory.h:167:17: warning: conversion from 'q31_t' {aka 'int'} to 'q15_t' {aka 'short int'} may change value [-Wconversion]
CMSIS/DSP/Include/arm_math_memory.h:227:19: warning: conversion from 'q31_t' {aka 'int'} to 'q7_t' {aka 'signed char'} may change value [-Wconversion]
CMSIS/DSP/Include/arm_math_memory.h:228:26: warning: conversion from 'q31_t' {aka 'int'} to 'q7_t' {aka 'signed char'} may change value [-Wconversion]
CMSIS/DSP/Include/arm_math_memory.h:229:27: warning: conversion from 'q31_t' {aka 'int'} to 'q7_t' {aka 'signed char'} may change value [-Wconversion]
CMSIS/DSP/Include/arm_math_memory.h:230:27: warning: conversion from 'q31_t' {aka 'int'} to 'q7_t' {aka 'signed char'} may change value [-Wconversion]
