### PR TITLE
RTX5: Remove unused member of osRtxThread_t

### DIFF
--- a/CMSIS/RTOS2/RTX/Include/rtx_os.h
+++ b/CMSIS/RTOS2/RTX/Include/rtx_os.h
@@ -123,9 +123,11 @@ typedef struct osRtxThread_s {
   uint32_t                 stack_size;  ///< Stack Size
   uint32_t                         sp;  ///< Current Stack Pointer
   uint32_t                thread_addr;  ///< Thread entry address
+#if (DOMAIN_NS == 1)
   uint32_t                  tz_memory;  ///< TrustZone Memory Identifier
 #ifdef RTX_TF_M_EXTENSION
   uint32_t                  tz_module;  ///< TrustZone Module Identifier
+#endif
 #endif
 } osRtxThread_t;
  


### PR DESCRIPTION
tz_memory has never been used when DOMAIN_NS is enabled.