### PR TITLE
Fixing compilation issue with Visual Studio 2022 in Arm64EC

### DIFF
--- a/CMSIS/DSP/Include/arm_math_types.h
+++ b/CMSIS/DSP/Include/arm_math_types.h
@@ -95,12 +95,16 @@ extern "C"
 #endif
 
 #if defined(ARM_MATH_NEON)
-#include <arm_neon.h>
-#if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) && __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-  #if !defined(ARM_MATH_NEON_FLOAT16)
-  #define ARM_MATH_NEON_FLOAT16
+  #if defined(_MSC_VER) && defined(_M_ARM64EC)
+    #include <arm64_neon.h>
+  #else
+    #include <arm_neon.h>
   #endif
-#endif
+  #if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) && __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
+    #if !defined(ARM_MATH_NEON_FLOAT16)
+      #define ARM_MATH_NEON_FLOAT16
+    #endif
+  #endif
 #endif
 
 #if !defined(ARM_MATH_AUTOVECTORIZE)


### PR DESCRIPTION
Dear @christophe0606, 

The goal of this pull request is to fix a compilation issue encountered with Visual Studio 2022 if the Arm64EC mode is used.
For some reasons, including the <arm_neon.h> directly in Arm/Arm64 works, but not in Arm64EC. As a workaround it is possible to use <arm64_neon.h> instead in Arm64EC.

I don't know if there is a particular reason for Microsoft to do that (I have asked here: https://docs.microsoft.com/en-us/answers/questions/791892/why-is-it-not-working-to-include-arm-neonh-in-a-ar.html). This might also just be a bug on Microsoft side?

Meanwhile for CMSIS to support Visual Studio 2022 with Arm64EC, the following change is required.

Thanks in advance!

Best Regards,
JbR