### PR TITLE
CMSIS-Core(M): Fix link error for Cortex-m23

### DIFF
--- a/Device/ARM/ARMCM23/Source/ARM/startup_ARMCM23.S
+++ b/Device/ARM/ARMCM23/Source/ARM/startup_ARMCM23.S
@@ -30,7 +30,7 @@
                 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
                 #define __STACK_SEAL     Image$$STACKSEAL$$ZI$$Base
                 #endif
-
+                .eabi_attribute Tag_ABI_align_preserved, 1
                 .section RESET
                 .align   2
                 .globl   __Vectors


### PR DESCRIPTION
Fix the issue #1469 where the linker complains about
the alignment.

Signed-off-by: Adrien Grassein <agrassein@nanoxplore.com>