### PR TITLE
DSP: Fix uninitialised variable references

### DIFF
--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_q31.c
@@ -296,7 +296,7 @@ void arm_biquad_cas_df1_32x64_q31(
     q31_t     b0, b1, b2, a1, a2;   /*  Filter coefficients           */
     int32_t   shift = (int32_t) S->postShift + 1;   /*  Shift to be applied to the output */
     uint32_t  sample, stage = S->numStages; /*  loop counters                     */
-    q31x4_t vecCoef, vecIn;
+    q31x4_t vecCoef = { 0 }, vecIn;
     q63_t     acc;
 
     if (blockSize <= 3)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f16.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f16.c
@@ -63,7 +63,7 @@ void arm_biquad_cascade_df1_f16(
     const float16_t *pCoeffs = S->pCoeffs;    /*  coefficient pointer       */
     float16_t Xn1, Xn2, Yn1, Yn2;   /*  Filter pState variables   */
     float16_t X0, X1, X2, X3;   /*  temporary input           */
-    float16_t X4, X5, X6, X7;   /*  temporary input           */
+    float16_t X4, X5, X6, X7 = 0;   /*  temporary input           */
     _Float16 lastX, lastY;             /*  X,Y history for tail handling */
     f16x8_t coeffs;
     f16x8_t accVec;           /* accumultor vector */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f32.c
@@ -176,7 +176,7 @@ void arm_biquad_cascade_df1_f32(
     const float32_t *pCoeffs = S->pCoeffs;    /*  coefficient pointer       */
     float32_t Xn1, Xn2, Yn1, Yn2;       /*  Filter pState variables   */
     float32_t lastX, lastY;             /*  X,Y history for tail handling */
-    float32_t X0, X1, X2, X3;           /*  temporary input           */
+    float32_t X0, X1, X2, X3 = 0;       /*  temporary input           */
     f32x4_t coeffs;
     f32x4_t accVec;                   /* accumultor vector */
     uint32_t  sample, stage = S->numStages; /*  loop counters             */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q31.c
@@ -69,7 +69,7 @@ void arm_biquad_cascade_df1_q31(
     uint32_t        stages = S->numStages;      /*  loop counters                 */
     int             postShift = S->postShift;
     q31x4_t         b0Coeffs, b1Coeffs, a0Coeffs, a1Coeffs;     /*  Coefficients vector           */
-    q31x4_t         stateVec;
+    q31x4_t         stateVec = { 0 };
     q31_t          *pState = S->pState; /*  pState pointer initialization */
     q31x4_t         inVec0;
     int64_t         acc;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_f32.c
@@ -142,7 +142,7 @@ void arm_fir_decimate_f32(
     uint32_t  i, tapCnt, blkCnt, outBlockSize = blockSize / S->M;   /* Loop counters */
     uint32_t  blkCntN4;
     const float32_t *px0, *px1, *px2, *px3;
-    f32x4_t accv, acc0v, acc1v, acc2v, acc3v;
+    f32x4_t accv = { 0 }, acc0v, acc1v, acc2v, acc3v;
     f32x4_t x0v, x1v, x2v, x3v;
     f32x4_t c0v;
 


### PR DESCRIPTION
This commit adds initialisation for the variables that can be used
potentially uninitialised so that GCC does not generate warnings while
building the MVE function implementations.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>