### PR TITLE
CMSIS-NN: Replace arm_status with arm_cmsis_nn_status struct

### DIFF
--- a/ARM.CMSIS.pdsc
+++ b/ARM.CMSIS.pdsc
@@ -10,6 +10,8 @@
   <releases>
     <release version="5.9.1">
       Active development ...
+      CMSIS-NN: 4.0.0 (see revision history for details)
+       - Changed return types of all API's
     </release>
     <release version="5.9.0" date="2022-05-02">
       CMSIS-Core(M): 5.6.0

--- a/CMSIS/DoxyGen/NN/nn.dxy
+++ b/CMSIS/DoxyGen/NN/nn.dxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "CMSIS-NN"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Version 3.1.0"
+PROJECT_NUMBER         = "Version 4.0.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/CMSIS/DoxyGen/NN/src/history.txt
+++ b/CMSIS/DoxyGen/NN/src/history.txt
@@ -7,6 +7,14 @@
     <th>Description</th>
   </tr>
   <tr>
+    <td>V4.0.0</td>
+    <td>
+    <ul>
+      <li> Replaced arm_status with arm_cmsis_nn_status struct </li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
     <td>V3.1.0</td>
     <td>
     <ul>

--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -22,7 +22,7 @@
  * Description:  Public header file for CMSIS NN Library
  *
  * $Date:        19 April 2022
- * $Revision:    V.9.0.0
+ * $Revision:    V.10.0.0
  *
  * Target Processor:  Cortex-M CPUs
  * -------------------------------------------------------------------- */
@@ -196,21 +196,21 @@ typedef enum
  * @param[out]     output_data    Output data pointer. Data type: int8
  *
  * @return     The function returns either
- *                  <code>ARM_MATH_SIZE_MISMATCH</code> if argument constraints fail. or,
- *                  <code>ARM_MATH_SUCCESS</code> on successful completion.
+ *                  <code>ARM_CMSIS_NN_ARG_ERROR</code> if argument constraints fail. or,
+ *                  <code>ARM_CMSIS_NN_SUCCESS</code> on successful completion.
  *
  */
-arm_status arm_convolve_wrapper_s8(const cmsis_nn_context *ctx,
-                                   const cmsis_nn_conv_params *conv_params,
-                                   const cmsis_nn_per_channel_quant_params *quant_params,
-                                   const cmsis_nn_dims *input_dims,
-                                   const q7_t *input_data,
-                                   const cmsis_nn_dims *filter_dims,
-                                   const q7_t *filter_data,
-                                   const cmsis_nn_dims *bias_dims,
-                                   const int32_t *bias_data,
-                                   const cmsis_nn_dims *output_dims,
-                                   q7_t *output_data);
+arm_cmsis_nn_status arm_convolve_wrapper_s8(const cmsis_nn_context *ctx,
+                                            const cmsis_nn_conv_params *conv_params,
+                                            const cmsis_nn_per_channel_quant_params *quant_params,
+                                            const cmsis_nn_dims *input_dims,
+                                            const q7_t *input_data,
+                                            const cmsis_nn_dims *filter_dims,
+                                            const q7_t *filter_data,
+                                            const cmsis_nn_dims *bias_dims,
+                                            const int32_t *bias_data,
+                                            const cmsis_nn_dims *output_dims,
+                                            q7_t *output_data);
 
 /**
  * @brief Get the required buffer size for arm_convolve_wrapper_s8
@@ -254,21 +254,21 @@ int32_t arm_convolve_wrapper_s8_get_buffer_size(const cmsis_nn_conv_params *conv
  * @param[out]     output_data    Output data pointer. Data type: int16
  *
  * @return     The function returns either
- *                  <code>ARM_MATH_SIZE_MISMATCH</code> if argument constraints fail. or,
- *                  <code>ARM_MATH_SUCCESS</code> on successful completion.
+ *                  <code>ARM_CMSIS_NN_ARG_ERROR</code> if argument constraints fail. or,
+ *                  <code>ARM_CMSIS_NN_SUCCESS</code> on successful completion.
  *
  */
-arm_status arm_convolve_wrapper_s16(const cmsis_nn_context *ctx,
-                                    const cmsis_nn_conv_params *conv_params,
-                                    const cmsis_nn_per_channel_quant_params *quant_params,
-                                    const cmsis_nn_dims *input_dims,
-                                    const q15_t *input_data,
-                                    const cmsis_nn_dims *filter_dims,
-                                    const q7_t *filter_data,
-                                    const cmsis_nn_dims *bias_dims,
-                                    const int64_t *bias_data,
-                                    const cmsis_nn_dims *output_dims,
-                                    q15_t *output_data);
+arm_cmsis_nn_status arm_convolve_wrapper_s16(const cmsis_nn_context *ctx,
+                                             const cmsis_nn_conv_params *conv_params,
+                                             const cmsis_nn_per_channel_quant_params *quant_params,
+                                             const cmsis_nn_dims *input_dims,
+                                             const q15_t *input_data,
+                                             const cmsis_nn_dims *filter_dims,
+                                             const q7_t *filter_data,
+                                             const cmsis_nn_dims *bias_dims,
+                                             const int64_t *bias_data,
+                                             const cmsis_nn_dims *output_dims,
+                                             q15_t *output_data);
 
 /**
  * @brief Get the required buffer size for arm_convolve_wrapper_s16
@@ -308,7 +308,7 @@ int32_t arm_convolve_wrapper_s16_get_buffer_size(const cmsis_nn_conv_params *con
  * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
  * @param[out]     output_data    Output data pointer. Data type: int8
 
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    1. Supported framework: TensorFlow Lite micro
@@ -316,17 +316,17 @@ int32_t arm_convolve_wrapper_s16_get_buffer_size(const cmsis_nn_conv_params *con
  *    3. Additional memory is required for optimization. Refer to argument 'ctx' for details.
  *
  */
-arm_status arm_convolve_s8(const cmsis_nn_context *ctx,
-                           const cmsis_nn_conv_params *conv_params,
-                           const cmsis_nn_per_channel_quant_params *quant_params,
-                           const cmsis_nn_dims *input_dims,
-                           const q7_t *input_data,
-                           const cmsis_nn_dims *filter_dims,
-                           const q7_t *filter_data,
-                           const cmsis_nn_dims *bias_dims,
-                           const int32_t *bias_data,
-                           const cmsis_nn_dims *output_dims,
-                           q7_t *output_data);
+arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
+                                    const cmsis_nn_conv_params *conv_params,
+                                    const cmsis_nn_per_channel_quant_params *quant_params,
+                                    const cmsis_nn_dims *input_dims,
+                                    const q7_t *input_data,
+                                    const cmsis_nn_dims *filter_dims,
+                                    const q7_t *filter_data,
+                                    const cmsis_nn_dims *bias_dims,
+                                    const int32_t *bias_data,
+                                    const cmsis_nn_dims *output_dims,
+                                    q7_t *output_data);
 
 /**
  * @brief Get the required buffer size for s8 convolution function
@@ -358,7 +358,7 @@ int32_t arm_convolve_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const c
  * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
  * @param[out]     output_data    Output data pointer. Data type: int16
 
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    1. Supported framework: TensorFlow Lite micro
@@ -366,17 +366,17 @@ int32_t arm_convolve_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const c
  *    3. Additional memory is required for optimization. Refer to argument 'ctx' for details.
  *
  */
-arm_status arm_convolve_s16(const cmsis_nn_context *ctx,
-                            const cmsis_nn_conv_params *conv_params,
-                            const cmsis_nn_per_channel_quant_params *quant_params,
-                            const cmsis_nn_dims *input_dims,
-                            const q15_t *input_data,
-                            const cmsis_nn_dims *filter_dims,
-                            const q7_t *filter_data,
-                            const cmsis_nn_dims *bias_dims,
-                            const int64_t *bias_data,
-                            const cmsis_nn_dims *output_dims,
-                            q15_t *output_data);
+arm_cmsis_nn_status arm_convolve_s16(const cmsis_nn_context *ctx,
+                                     const cmsis_nn_conv_params *conv_params,
+                                     const cmsis_nn_per_channel_quant_params *quant_params,
+                                     const cmsis_nn_dims *input_dims,
+                                     const q15_t *input_data,
+                                     const cmsis_nn_dims *filter_dims,
+                                     const q7_t *filter_data,
+                                     const cmsis_nn_dims *bias_dims,
+                                     const int64_t *bias_data,
+                                     const cmsis_nn_dims *output_dims,
+                                     q15_t *output_data);
 /**
  * @brief Optimized s16 convolution function
  * @param[in, out] ctx            Function context that contains the additional buffer if required by the function.
@@ -397,7 +397,7 @@ arm_status arm_convolve_s16(const cmsis_nn_context *ctx,
  * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
  * @param[out]     output_data    Output data pointer. Data type: int16
 
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    1. Supported framework: TensorFlow Lite micro
@@ -407,17 +407,17 @@ arm_status arm_convolve_s16(const cmsis_nn_context *ctx,
  *
  */
 
-arm_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
-                                 const cmsis_nn_conv_params *conv_params,
-                                 const cmsis_nn_per_channel_quant_params *quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q15_t *input_data,
-                                 const cmsis_nn_dims *filter_dims,
-                                 const q7_t *filter_data,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const int64_t *bias_data,
-                                 const cmsis_nn_dims *output_dims,
-                                 q15_t *output_data);
+arm_cmsis_nn_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
+                                          const cmsis_nn_conv_params *conv_params,
+                                          const cmsis_nn_per_channel_quant_params *quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q15_t *input_data,
+                                          const cmsis_nn_dims *filter_dims,
+                                          const q7_t *filter_data,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const int64_t *bias_data,
+                                          const cmsis_nn_dims *output_dims,
+                                          q15_t *output_data);
 
 /**
  * @brief Get the required buffer size for s16 convolution function
@@ -458,24 +458,24 @@ int32_t arm_convolve_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, c
  * @param[in]       dim_im_out  output tensor dimension
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
-arm_status arm_convolve_HWC_q7_basic(const q7_t *Im_in,
-                                     const uint16_t dim_im_in,
-                                     const uint16_t ch_im_in,
-                                     const q7_t *wt,
-                                     const uint16_t ch_im_out,
-                                     const uint16_t dim_kernel,
-                                     const uint16_t padding,
-                                     const uint16_t stride,
-                                     const q7_t *bias,
-                                     const uint16_t bias_shift,
-                                     const uint16_t out_shift,
-                                     q7_t *Im_out,
-                                     const uint16_t dim_im_out,
-                                     q15_t *bufferA,
-                                     q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q7_basic(const q7_t *Im_in,
+                                              const uint16_t dim_im_in,
+                                              const uint16_t ch_im_in,
+                                              const q7_t *wt,
+                                              const uint16_t ch_im_out,
+                                              const uint16_t dim_kernel,
+                                              const uint16_t padding,
+                                              const uint16_t stride,
+                                              const q7_t *bias,
+                                              const uint16_t bias_shift,
+                                              const uint16_t out_shift,
+                                              q7_t *Im_out,
+                                              const uint16_t dim_im_out,
+                                              q15_t *bufferA,
+                                              q7_t *bufferB);
 
 /**
  * @brief Basic Q7 convolution function (non-square shape)
@@ -499,28 +499,28 @@ arm_status arm_convolve_HWC_q7_basic(const q7_t *Im_in,
  * @param[in]       dim_im_out_y output tensor dimension y
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  */
-arm_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t *Im_in,
-                                               const uint16_t dim_im_in_x,
-                                               const uint16_t dim_im_in_y,
-                                               const uint16_t ch_im_in,
-                                               const q7_t *wt,
-                                               const uint16_t ch_im_out,
-                                               const uint16_t dim_kernel_x,
-                                               const uint16_t dim_kernel_y,
-                                               const uint16_t padding_x,
-                                               const uint16_t padding_y,
-                                               const uint16_t stride_x,
-                                               const uint16_t stride_y,
-                                               const q7_t *bias,
-                                               const uint16_t bias_shift,
-                                               const uint16_t out_shift,
-                                               q7_t *Im_out,
-                                               const uint16_t dim_im_out_x,
-                                               const uint16_t dim_im_out_y,
-                                               q15_t *bufferA,
-                                               q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t *Im_in,
+                                                        const uint16_t dim_im_in_x,
+                                                        const uint16_t dim_im_in_y,
+                                                        const uint16_t ch_im_in,
+                                                        const q7_t *wt,
+                                                        const uint16_t ch_im_out,
+                                                        const uint16_t dim_kernel_x,
+                                                        const uint16_t dim_kernel_y,
+                                                        const uint16_t padding_x,
+                                                        const uint16_t padding_y,
+                                                        const uint16_t stride_x,
+                                                        const uint16_t stride_y,
+                                                        const q7_t *bias,
+                                                        const uint16_t bias_shift,
+                                                        const uint16_t out_shift,
+                                                        q7_t *Im_out,
+                                                        const uint16_t dim_im_out_x,
+                                                        const uint16_t dim_im_out_y,
+                                                        q15_t *bufferA,
+                                                        q7_t *bufferB);
 
 /**
  * @brief Basic Q15 convolution function
@@ -539,24 +539,24 @@ arm_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t *Im_in,
  * @param[in]       dim_im_out  output tensor dimension
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
-arm_status arm_convolve_HWC_q15_basic(const q15_t *Im_in,
-                                      const uint16_t dim_im_in,
-                                      const uint16_t ch_im_in,
-                                      const q15_t *wt,
-                                      const uint16_t ch_im_out,
-                                      const uint16_t dim_kernel,
-                                      const uint16_t padding,
-                                      const uint16_t stride,
-                                      const q15_t *bias,
-                                      const uint16_t bias_shift,
-                                      const uint16_t out_shift,
-                                      q15_t *Im_out,
-                                      const uint16_t dim_im_out,
-                                      q15_t *bufferA,
-                                      q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q15_basic(const q15_t *Im_in,
+                                               const uint16_t dim_im_in,
+                                               const uint16_t ch_im_in,
+                                               const q15_t *wt,
+                                               const uint16_t ch_im_out,
+                                               const uint16_t dim_kernel,
+                                               const uint16_t padding,
+                                               const uint16_t stride,
+                                               const q15_t *bias,
+                                               const uint16_t bias_shift,
+                                               const uint16_t out_shift,
+                                               q15_t *Im_out,
+                                               const uint16_t dim_im_out,
+                                               q15_t *bufferA,
+                                               q7_t *bufferB);
 
 /**
  * @brief Fast Q7 convolution function
@@ -576,28 +576,29 @@ arm_status arm_convolve_HWC_q15_basic(const q15_t *Im_in,
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is the version with full list of optimization tricks, but with
  * some contraints:
  *   ch_im_in is multiple of 4
  *   ch_im_out is multiple of 2
  */
-arm_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
-                                    const uint16_t dim_im_in,
-                                    const uint16_t ch_im_in,
-                                    const q7_t *wt,
-                                    const uint16_t ch_im_out,
-                                    const uint16_t dim_kernel,
-                                    const uint16_t padding,
-                                    const uint16_t stride,
-                                    const q7_t *bias,
-                                    const uint16_t bias_shift,
-                                    const uint16_t out_shift,
-                                    q7_t *Im_out,
-                                    const uint16_t dim_im_out,
-                                    q15_t *bufferA,
-                                    q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
+                                             const uint16_t dim_im_in,
+                                             const uint16_t ch_im_in,
+                                             const q7_t *wt,
+                                             const uint16_t ch_im_out,
+                                             const uint16_t dim_kernel,
+                                             const uint16_t padding,
+                                             const uint16_t stride,
+                                             const q7_t *bias,
+                                             const uint16_t bias_shift,
+                                             const uint16_t out_shift,
+                                             q7_t *Im_out,
+                                             const uint16_t dim_im_out,
+                                             q15_t *bufferA,
+                                             q7_t *bufferB);
 
 /**
  * @brief Fast Q7 convolution function (non-sqaure shape)
@@ -622,7 +623,8 @@ arm_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is the version with full list of optimization tricks, but with
  * some contraints:
@@ -630,26 +632,26 @@ arm_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
  *   ch_im_out is multiple of 2
  */
 
-arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
-                                              const uint16_t dim_im_in_x,
-                                              const uint16_t dim_im_in_y,
-                                              const uint16_t ch_im_in,
-                                              const q7_t *wt,
-                                              const uint16_t ch_im_out,
-                                              const uint16_t dim_kernel_x,
-                                              const uint16_t dim_kernel_y,
-                                              const uint16_t padding_x,
-                                              const uint16_t padding_y,
-                                              const uint16_t stride_x,
-                                              const uint16_t stride_y,
-                                              const q7_t *bias,
-                                              const uint16_t bias_shift,
-                                              const uint16_t out_shift,
-                                              q7_t *Im_out,
-                                              const uint16_t dim_im_out_x,
-                                              const uint16_t dim_im_out_y,
-                                              q15_t *bufferA,
-                                              q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
+                                                       const uint16_t dim_im_in_x,
+                                                       const uint16_t dim_im_in_y,
+                                                       const uint16_t ch_im_in,
+                                                       const q7_t *wt,
+                                                       const uint16_t ch_im_out,
+                                                       const uint16_t dim_kernel_x,
+                                                       const uint16_t dim_kernel_y,
+                                                       const uint16_t padding_x,
+                                                       const uint16_t padding_y,
+                                                       const uint16_t stride_x,
+                                                       const uint16_t stride_y,
+                                                       const q7_t *bias,
+                                                       const uint16_t bias_shift,
+                                                       const uint16_t out_shift,
+                                                       q7_t *Im_out,
+                                                       const uint16_t dim_im_out_x,
+                                                       const uint16_t dim_im_out_y,
+                                                       q15_t *bufferA,
+                                                       q7_t *bufferB);
 
 /**
  * @brief Fast Q7 version of 1x1 convolution (non-sqaure shape)
@@ -674,8 +676,8 @@ arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
- *                          <code>ARM_MATH_SIZE_MISMATCH</code> if argument constraints fail. or,
- *                          <code>ARM_MATH_SUCCESS</code> on successful completion.
+ *                          <code>ARM_CMSIS_NN_ARG_ERROR</code> if argument constraints fail. or,
+ *                          <code>ARM_CMSIS_NN_SUCCESS</code> on successful completion.
  *
  * This function implement convolution with 1x1 kernel size (i.e., dim_kernel_x=1
  * and dim_kernel_y=1). It can be used for
@@ -686,26 +688,26 @@ arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
  *   ch_im_in is multiple of 4
  *   ch_im_out is multiple of 2
  */
-arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
-                                                  const uint16_t dim_im_in_x,
-                                                  const uint16_t dim_im_in_y,
-                                                  const uint16_t ch_im_in,
-                                                  const q7_t *wt,
-                                                  const uint16_t ch_im_out,
-                                                  const uint16_t dim_kernel_x,
-                                                  const uint16_t dim_kernel_y,
-                                                  const uint16_t padding_x,
-                                                  const uint16_t padding_y,
-                                                  const uint16_t stride_x,
-                                                  const uint16_t stride_y,
-                                                  const q7_t *bias,
-                                                  const uint16_t bias_shift,
-                                                  const uint16_t out_shift,
-                                                  q7_t *Im_out,
-                                                  const uint16_t dim_im_out_x,
-                                                  const uint16_t dim_im_out_y,
-                                                  q15_t *bufferA,
-                                                  q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
+                                                           const uint16_t dim_im_in_x,
+                                                           const uint16_t dim_im_in_y,
+                                                           const uint16_t ch_im_in,
+                                                           const q7_t *wt,
+                                                           const uint16_t ch_im_out,
+                                                           const uint16_t dim_kernel_x,
+                                                           const uint16_t dim_kernel_y,
+                                                           const uint16_t padding_x,
+                                                           const uint16_t padding_y,
+                                                           const uint16_t stride_x,
+                                                           const uint16_t stride_y,
+                                                           const q7_t *bias,
+                                                           const uint16_t bias_shift,
+                                                           const uint16_t out_shift,
+                                                           q7_t *Im_out,
+                                                           const uint16_t dim_im_out_x,
+                                                           const uint16_t dim_im_out_y,
+                                                           q15_t *bufferA,
+                                                           q7_t *bufferB);
 
 /**
  * @brief Fast s8 version for 1x1 convolution (non-square shape)
@@ -727,8 +729,8 @@ arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
  * @param[out]     output_data    Output data pointer. Data type: int8
  *
  * @return     The function returns either
- *                  <code>ARM_MATH_SIZE_MISMATCH</code> if argument constraints fail. or,
- *                  <code>ARM_MATH_SUCCESS</code> on successful completion.
+ *                  <code>ARM_CMSIS_NN_ARG_ERROR</code> if argument constraints fail. or,
+ *                  <code>ARM_CMSIS_NN_SUCCESS</code> on successful completion.
  *
  * @details
  *   - Supported framework : TensorFlow Lite Micro
@@ -738,17 +740,17 @@ arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
  *      -# conv_params->stride.w = conv_params->stride.h = 1
  *
  */
-arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
-                                    const cmsis_nn_conv_params *conv_params,
-                                    const cmsis_nn_per_channel_quant_params *quant_params,
-                                    const cmsis_nn_dims *input_dims,
-                                    const q7_t *input_data,
-                                    const cmsis_nn_dims *filter_dims,
-                                    const q7_t *filter_data,
-                                    const cmsis_nn_dims *bias_dims,
-                                    const int32_t *bias_data,
-                                    const cmsis_nn_dims *output_dims,
-                                    q7_t *output_data);
+arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
+                                             const cmsis_nn_conv_params *conv_params,
+                                             const cmsis_nn_per_channel_quant_params *quant_params,
+                                             const cmsis_nn_dims *input_dims,
+                                             const q7_t *input_data,
+                                             const cmsis_nn_dims *filter_dims,
+                                             const q7_t *filter_data,
+                                             const cmsis_nn_dims *bias_dims,
+                                             const int32_t *bias_data,
+                                             const cmsis_nn_dims *output_dims,
+                                             q7_t *output_data);
 
 /**
  * @brief Get the required buffer size for arm_convolve_1x1_s8_fast
@@ -780,8 +782,8 @@ int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims *input_dims
  * @param[out]     output_data    Output data pointer. Data type: int8
  *
  * @return     The function returns either
- *                  <code>ARM_MATH_SIZE_MISMATCH</code> if argument constraints fail. or,
- *                  <code>ARM_MATH_SUCCESS</code> on successful completion.
+ *                  <code>ARM_CMSIS_NN_ARG_ERROR</code> if argument constraints fail. or,
+ *                  <code>ARM_CMSIS_NN_SUCCESS</code> on successful completion.
  *
  * @details
  *   - Supported framework : TensorFlow Lite Micro
@@ -795,17 +797,17 @@ int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims *input_dims
  *@todo  Remove constraint on output_dims->w to make the function generic.
  *
  */
-arm_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
-                                 const cmsis_nn_conv_params *conv_params,
-                                 const cmsis_nn_per_channel_quant_params *quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q7_t *input_data,
-                                 const cmsis_nn_dims *filter_dims,
-                                 const q7_t *filter_data,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const int32_t *bias_data,
-                                 const cmsis_nn_dims *output_dims,
-                                 q7_t *output_data);
+arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
+                                          const cmsis_nn_conv_params *conv_params,
+                                          const cmsis_nn_per_channel_quant_params *quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q7_t *input_data,
+                                          const cmsis_nn_dims *filter_dims,
+                                          const q7_t *filter_data,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const int32_t *bias_data,
+                                          const cmsis_nn_dims *output_dims,
+                                          q7_t *output_data);
 
 /**
  * @brief Get the required additional buffer size for 1xn convolution
@@ -836,28 +838,29 @@ int32_t arm_convolve_1_x_n_s8_get_buffer_size(const cmsis_nn_dims *input_dims, c
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This kernel is written exclusively for convolution with ch_im_in
  * equals 3. This applies on the first layer of CNNs which has input
  * image with RGB format.
  */
 
-arm_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
-                                   const uint16_t dim_im_in,
-                                   const uint16_t ch_im_in,
-                                   const q7_t *wt,
-                                   const uint16_t ch_im_out,
-                                   const uint16_t dim_kernel,
-                                   const uint16_t padding,
-                                   const uint16_t stride,
-                                   const q7_t *bias,
-                                   const uint16_t bias_shift,
-                                   const uint16_t out_shift,
-                                   q7_t *Im_out,
-                                   const uint16_t dim_im_out,
-                                   q15_t *bufferA,
-                                   q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
+                                            const uint16_t dim_im_in,
+                                            const uint16_t ch_im_in,
+                                            const q7_t *wt,
+                                            const uint16_t ch_im_out,
+                                            const uint16_t dim_kernel,
+                                            const uint16_t padding,
+                                            const uint16_t stride,
+                                            const q7_t *bias,
+                                            const uint16_t bias_shift,
+                                            const uint16_t out_shift,
+                                            q7_t *Im_out,
+                                            const uint16_t dim_im_out,
+                                            q15_t *bufferA,
+                                            q7_t *bufferB);
 
 /**
  * @brief Fast Q15 convolution function
@@ -877,7 +880,8 @@ arm_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is the version with full list of optimization tricks, but with
  * some contraints:
@@ -886,21 +890,21 @@ arm_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
  *   dim_im_out is a multiple of 2
  */
 
-arm_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
-                                     const uint16_t dim_im_in,
-                                     const uint16_t ch_im_in,
-                                     const q15_t *wt,
-                                     const uint16_t ch_im_out,
-                                     const uint16_t dim_kernel,
-                                     const uint16_t padding,
-                                     const uint16_t stride,
-                                     const q15_t *bias,
-                                     const uint16_t bias_shift,
-                                     const uint16_t out_shift,
-                                     q15_t *Im_out,
-                                     const uint16_t dim_im_out,
-                                     q15_t *bufferA,
-                                     q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
+                                              const uint16_t dim_im_in,
+                                              const uint16_t ch_im_in,
+                                              const q15_t *wt,
+                                              const uint16_t ch_im_out,
+                                              const uint16_t dim_kernel,
+                                              const uint16_t padding,
+                                              const uint16_t stride,
+                                              const q15_t *bias,
+                                              const uint16_t bias_shift,
+                                              const uint16_t out_shift,
+                                              q15_t *Im_out,
+                                              const uint16_t dim_im_out,
+                                              q15_t *bufferA,
+                                              q7_t *bufferB);
 
 /**
  * @brief Fast Q15 convolution function (non-sqaure shape)
@@ -925,7 +929,8 @@ arm_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * @details
  *
@@ -943,26 +948,26 @@ arm_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
  *
  */
 
-arm_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
-                                               const uint16_t dim_im_in_x,
-                                               const uint16_t dim_im_in_y,
-                                               const uint16_t ch_im_in,
-                                               const q15_t *wt,
-                                               const uint16_t ch_im_out,
-                                               const uint16_t dim_kernel_x,
-                                               const uint16_t dim_kernel_y,
-                                               const uint16_t padding_x,
-                                               const uint16_t padding_y,
-                                               const uint16_t stride_x,
-                                               const uint16_t stride_y,
-                                               const q15_t *bias,
-                                               const uint16_t bias_shift,
-                                               const uint16_t out_shift,
-                                               q15_t *Im_out,
-                                               const uint16_t dim_im_out_x,
-                                               const uint16_t dim_im_out_y,
-                                               q15_t *bufferA,
-                                               q7_t *bufferB);
+arm_cmsis_nn_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
+                                                        const uint16_t dim_im_in_x,
+                                                        const uint16_t dim_im_in_y,
+                                                        const uint16_t ch_im_in,
+                                                        const q15_t *wt,
+                                                        const uint16_t ch_im_out,
+                                                        const uint16_t dim_kernel_x,
+                                                        const uint16_t dim_kernel_y,
+                                                        const uint16_t padding_x,
+                                                        const uint16_t padding_y,
+                                                        const uint16_t stride_x,
+                                                        const uint16_t stride_y,
+                                                        const q15_t *bias,
+                                                        const uint16_t bias_shift,
+                                                        const uint16_t out_shift,
+                                                        q15_t *Im_out,
+                                                        const uint16_t dim_im_out_x,
+                                                        const uint16_t dim_im_out_y,
+                                                        q15_t *bufferA,
+                                                        q7_t *bufferB);
 
 /**
  * @brief Q7 depthwise separable convolution function
@@ -982,7 +987,8 @@ arm_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is the version with full list of optimization tricks, but with
  * some contraints:
@@ -990,21 +996,21 @@ arm_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
  *   ch_im_out is multiple of 2
  */
 
-arm_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
-                                               const uint16_t dim_im_in,
-                                               const uint16_t ch_im_in,
-                                               const q7_t *wt,
-                                               const uint16_t ch_im_out,
-                                               const uint16_t dim_kernel,
-                                               const uint16_t padding,
-                                               const uint16_t stride,
-                                               const q7_t *bias,
-                                               const uint16_t bias_shift,
-                                               const uint16_t out_shift,
-                                               q7_t *Im_out,
-                                               const uint16_t dim_im_out,
-                                               q15_t *bufferA,
-                                               q7_t *bufferB);
+arm_cmsis_nn_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
+                                                        const uint16_t dim_im_in,
+                                                        const uint16_t ch_im_in,
+                                                        const q7_t *wt,
+                                                        const uint16_t ch_im_out,
+                                                        const uint16_t dim_kernel,
+                                                        const uint16_t padding,
+                                                        const uint16_t stride,
+                                                        const q7_t *bias,
+                                                        const uint16_t bias_shift,
+                                                        const uint16_t out_shift,
+                                                        q7_t *Im_out,
+                                                        const uint16_t dim_im_out,
+                                                        q15_t *bufferA,
+                                                        q7_t *bufferB);
 
 /**
  * @brief Q7 depthwise separable convolution function (non-square shape)
@@ -1029,33 +1035,34 @@ arm_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
  * @param[in,out]   bufferA       pointer to buffer space for input
  * @param[in,out]   bufferB       pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is the version with full list of optimization tricks, but with
  * some contraints:
  *   ch_im_in is multiple of 2
  *   ch_im_out is multiple of 2
  */
-arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
-                                                         const uint16_t dim_im_in_x,
-                                                         const uint16_t dim_im_in_y,
-                                                         const uint16_t ch_im_in,
-                                                         const q7_t *wt,
-                                                         const uint16_t ch_im_out,
-                                                         const uint16_t dim_kernel_x,
-                                                         const uint16_t dim_kernel_y,
-                                                         const uint16_t padding_x,
-                                                         const uint16_t padding_y,
-                                                         const uint16_t stride_x,
-                                                         const uint16_t stride_y,
-                                                         const q7_t *bias,
-                                                         const uint16_t bias_shift,
-                                                         const uint16_t out_shift,
-                                                         q7_t *Im_out,
-                                                         const uint16_t dim_im_out_x,
-                                                         const uint16_t dim_im_out_y,
-                                                         q15_t *bufferA,
-                                                         q7_t *bufferB);
+arm_cmsis_nn_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
+                                                                  const uint16_t dim_im_in_x,
+                                                                  const uint16_t dim_im_in_y,
+                                                                  const uint16_t ch_im_in,
+                                                                  const q7_t *wt,
+                                                                  const uint16_t ch_im_out,
+                                                                  const uint16_t dim_kernel_x,
+                                                                  const uint16_t dim_kernel_y,
+                                                                  const uint16_t padding_x,
+                                                                  const uint16_t padding_y,
+                                                                  const uint16_t stride_x,
+                                                                  const uint16_t stride_y,
+                                                                  const q7_t *bias,
+                                                                  const uint16_t bias_shift,
+                                                                  const uint16_t out_shift,
+                                                                  q7_t *Im_out,
+                                                                  const uint16_t dim_im_out_x,
+                                                                  const uint16_t dim_im_out_y,
+                                                                  q15_t *bufferA,
+                                                                  q7_t *bufferB);
 
 /**
  * @brief Wrapper function to pick the right optimized s8 depthwise convolution function
@@ -1081,7 +1088,7 @@ arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
  * @param[in]      output_dims    Output tensor dimensions. Format: [1, H, W, C_OUT]
  * @param[in, out] output_data    Output data pointer. Data type: int8
  * @return     The function returns
- *                <code>ARM_MATH_SUCCESS</code>   -  Successful completion.
+ *                <code>ARM_CMSIS_NN_SUCCESS</code>   -  Successful completion.
  *
  * @details
  *    - Supported framework: TensorFlow Lite
@@ -1093,17 +1100,17 @@ arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
  *    - Check details of arm_depthwise_conv_s8_opt() for potential data that can be accessed outside of the
  * boundary.
  */
-arm_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
-                                         const cmsis_nn_dw_conv_params *dw_conv_params,
-                                         const cmsis_nn_per_channel_quant_params *quant_params,
-                                         const cmsis_nn_dims *input_dims,
-                                         const q7_t *input_data,
-                                         const cmsis_nn_dims *filter_dims,
-                                         const q7_t *filter_data,
-                                         const cmsis_nn_dims *bias_dims,
-                                         const int32_t *bias_data,
-                                         const cmsis_nn_dims *output_dims,
-                                         q7_t *output_data);
+arm_cmsis_nn_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
+                                                  const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                  const cmsis_nn_per_channel_quant_params *quant_params,
+                                                  const cmsis_nn_dims *input_dims,
+                                                  const q7_t *input_data,
+                                                  const cmsis_nn_dims *filter_dims,
+                                                  const q7_t *filter_data,
+                                                  const cmsis_nn_dims *bias_dims,
+                                                  const int32_t *bias_data,
+                                                  const cmsis_nn_dims *output_dims,
+                                                  q7_t *output_data);
 
 /**
  * @brief Get size of additional buffer required by arm_depthwise_conv_wrapper_s8()
@@ -1148,23 +1155,23 @@ int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size(const cmsis_nn_dw_conv_par
  * @param[in]      bias_data      Bias data pointer. Data type: int32
  * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
  * @param[in, out] output_data    Output data pointer. Data type: int8
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    - Supported framework: TensorFlow Lite
  *    - q7 is used as data type eventhough it is s8 data. It is done so to be consistent with existing APIs.
  */
-arm_status arm_depthwise_conv_s8(const cmsis_nn_context *ctx,
-                                 const cmsis_nn_dw_conv_params *dw_conv_params,
-                                 const cmsis_nn_per_channel_quant_params *quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q7_t *input_data,
-                                 const cmsis_nn_dims *filter_dims,
-                                 const q7_t *filter_data,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const int32_t *bias_data,
-                                 const cmsis_nn_dims *output_dims,
-                                 q7_t *output_data);
+arm_cmsis_nn_status arm_depthwise_conv_s8(const cmsis_nn_context *ctx,
+                                          const cmsis_nn_dw_conv_params *dw_conv_params,
+                                          const cmsis_nn_per_channel_quant_params *quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q7_t *input_data,
+                                          const cmsis_nn_dims *filter_dims,
+                                          const q7_t *filter_data,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const int32_t *bias_data,
+                                          const cmsis_nn_dims *output_dims,
+                                          q7_t *output_data);
 
 /**
  * @brief Basic s16 depthwise convolution function that doesn't have any constraints on the input dimensions.
@@ -1189,23 +1196,23 @@ arm_status arm_depthwise_conv_s8(const cmsis_nn_context *ctx,
  * @param[in]      bias_data      Bias data pointer. Data type: int64
  * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
  * @param[in, out] output_data    Output data pointer. Data type: int16
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    - Supported framework: TensorFlow Lite
  *    - q15 is used as data type eventhough it is s16 data. It is done so to be consistent with existing APIs.
  */
-arm_status arm_depthwise_conv_s16(const cmsis_nn_context *ctx,
-                                  const cmsis_nn_dw_conv_params *dw_conv_params,
-                                  const cmsis_nn_per_channel_quant_params *quant_params,
-                                  const cmsis_nn_dims *input_dims,
-                                  const q15_t *input_data,
-                                  const cmsis_nn_dims *filter_dims,
-                                  const q7_t *filter_data,
-                                  const cmsis_nn_dims *bias_dims,
-                                  const int64_t *bias_data,
-                                  const cmsis_nn_dims *output_dims,
-                                  q15_t *output_data);
+arm_cmsis_nn_status arm_depthwise_conv_s16(const cmsis_nn_context *ctx,
+                                           const cmsis_nn_dw_conv_params *dw_conv_params,
+                                           const cmsis_nn_per_channel_quant_params *quant_params,
+                                           const cmsis_nn_dims *input_dims,
+                                           const q15_t *input_data,
+                                           const cmsis_nn_dims *filter_dims,
+                                           const q7_t *filter_data,
+                                           const cmsis_nn_dims *bias_dims,
+                                           const int64_t *bias_data,
+                                           const cmsis_nn_dims *output_dims,
+                                           q15_t *output_data);
 
 /**
  * @brief Optimized s8 depthwise convolution function for 3x3 kernel size with some constraints on
@@ -1213,9 +1220,9 @@ arm_status arm_depthwise_conv_s16(const cmsis_nn_context *ctx,
  *        argument details.
  *
  * @return     The function returns one of the following
- *                <code>ARM_MATH_SIZE_MISMATCH</code> - Unsupported dimension of tensors
- *                <code>ARM_MATH_ARGUMENT_ERROR</code> - Unsupported pad size along the x axis
- *                <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                <code>ARM_CMSIS_NN_ARG_ERROR</code> - Unsupported dimension of tensors
+ *                                                    - Unsupported pad size along the x axis
+ *                <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  * @details
  *   - Supported framework : TensorFlow Lite Micro
@@ -1225,26 +1232,26 @@ arm_status arm_depthwise_conv_s16(const cmsis_nn_context *ctx,
  *      -# Padding along x is either 0 or 1.
  *
  */
-arm_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
-                                     const cmsis_nn_dw_conv_params *dw_conv_params,
-                                     const cmsis_nn_per_channel_quant_params *quant_params,
-                                     const cmsis_nn_dims *input_dims,
-                                     const q7_t *input_data,
-                                     const cmsis_nn_dims *filter_dims,
-                                     const q7_t *filter_data,
-                                     const cmsis_nn_dims *bias_dims,
-                                     const int32_t *bias_data,
-                                     const cmsis_nn_dims *output_dims,
-                                     q7_t *output_data);
+arm_cmsis_nn_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
+                                              const cmsis_nn_dw_conv_params *dw_conv_params,
+                                              const cmsis_nn_per_channel_quant_params *quant_params,
+                                              const cmsis_nn_dims *input_dims,
+                                              const q7_t *input_data,
+                                              const cmsis_nn_dims *filter_dims,
+                                              const q7_t *filter_data,
+                                              const cmsis_nn_dims *bias_dims,
+                                              const int32_t *bias_data,
+                                              const cmsis_nn_dims *output_dims,
+                                              q7_t *output_data);
 
 /**
  * @brief Optimized s8 depthwise convolution function with constraint that in_channel equals out_channel.
  *        Refer arm_depthwise_conv_s8() for function argument details.
  *
  * @return     The function returns one of the following
- *                <code>ARM_MATH_SIZE_MISMATCH</code> - input channel != output channel or
+ *                <code>ARM_CMSIS_NN_ARG_ERROR</code> - input channel != output channel or
  *                                                      ch_mult != 1
- *                <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  * @note       If number of channels is not a multiple of 4, upto 3 elements outside the boundary will be read out
  *             for the following if MVE optimizations(Arm Helium Technology) are used.
@@ -1260,17 +1267,17 @@ arm_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
  *    - Reccomended when number of channels is 4 or greater.
  *
  */
-arm_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
-                                     const cmsis_nn_dw_conv_params *dw_conv_params,
-                                     const cmsis_nn_per_channel_quant_params *quant_params,
-                                     const cmsis_nn_dims *input_dims,
-                                     const q7_t *input_data,
-                                     const cmsis_nn_dims *filter_dims,
-                                     const q7_t *filter_data,
-                                     const cmsis_nn_dims *bias_dims,
-                                     const int32_t *bias_data,
-                                     const cmsis_nn_dims *output_dims,
-                                     q7_t *output_data);
+arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
+                                              const cmsis_nn_dw_conv_params *dw_conv_params,
+                                              const cmsis_nn_per_channel_quant_params *quant_params,
+                                              const cmsis_nn_dims *input_dims,
+                                              const q7_t *input_data,
+                                              const cmsis_nn_dims *filter_dims,
+                                              const q7_t *filter_data,
+                                              const cmsis_nn_dims *bias_dims,
+                                              const int32_t *bias_data,
+                                              const cmsis_nn_dims *output_dims,
+                                              q7_t *output_data);
 
 /**
  * @brief Get the required buffer size for optimized s8 depthwise convolution
@@ -1310,19 +1317,19 @@ int32_t arm_depthwise_conv_s8_opt_get_buffer_size(const cmsis_nn_dims *input_dim
  *@param[in]       bias        pointer to bias
  *@param[in,out]   pOut        pointer to output vector
  *@param[in,out]   vec_buffer  pointer to buffer space for input
- *@return     The function returns <code>ARM_MATH_SUCCESS</code>
+ *@return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
 
-arm_status arm_fully_connected_q7(const q7_t *pV,
-                                  const q7_t *pM,
-                                  const uint16_t dim_vec,
-                                  const uint16_t num_of_rows,
-                                  const uint16_t bias_shift,
-                                  const uint16_t out_shift,
-                                  const q7_t *bias,
-                                  q7_t *pOut,
-                                  q15_t *vec_buffer);
+arm_cmsis_nn_status arm_fully_connected_q7(const q7_t *pV,
+                                           const q7_t *pM,
+                                           const uint16_t dim_vec,
+                                           const uint16_t num_of_rows,
+                                           const uint16_t bias_shift,
+                                           const uint16_t out_shift,
+                                           const q7_t *bias,
+                                           q7_t *pOut,
+                                           q15_t *vec_buffer);
 
 /**
  * @brief Basic s8 Fully Connected function.
@@ -1353,23 +1360,23 @@ arm_status arm_fully_connected_q7(const q7_t *pV,
  *                                C_OUT : Output depth
  *                                H & W : Not used.
  * @param[in, out] output_data    Output data pointer. Data type: int8
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    - Supported framework: TensorFlow Lite
  *    - q7 is used as data type eventhough it is s8 data. It is done so to be consistent with existing APIs.
  */
-arm_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
-                                  const cmsis_nn_fc_params *fc_params,
-                                  const cmsis_nn_per_tensor_quant_params *quant_params,
-                                  const cmsis_nn_dims *input_dims,
-                                  const q7_t *input_data,
-                                  const cmsis_nn_dims *filter_dims,
-                                  const q7_t *filter_data,
-                                  const cmsis_nn_dims *bias_dims,
-                                  const int32_t *bias_data,
-                                  const cmsis_nn_dims *output_dims,
-                                  q7_t *output_data);
+arm_cmsis_nn_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
+                                           const cmsis_nn_fc_params *fc_params,
+                                           const cmsis_nn_per_tensor_quant_params *quant_params,
+                                           const cmsis_nn_dims *input_dims,
+                                           const q7_t *input_data,
+                                           const cmsis_nn_dims *filter_dims,
+                                           const q7_t *filter_data,
+                                           const cmsis_nn_dims *bias_dims,
+                                           const int32_t *bias_data,
+                                           const cmsis_nn_dims *output_dims,
+                                           q7_t *output_data);
 
 /**
  * @brief Get the required buffer size for S8 basic fully-connected and
@@ -1409,23 +1416,23 @@ int32_t arm_fully_connected_s8_get_buffer_size(const cmsis_nn_dims *filter_dims)
  *                                C_OUT : Output depth
  *                                H & W : Not used.
  * @param[in, out] output_data    Output data pointer. Data type: int16
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    - Supported framework: TensorFlow Lite
  *    - q15 is used as data type eventhough it is s16 data. It is done so to be consistent with existing APIs.
  */
-arm_status arm_fully_connected_s16(const cmsis_nn_context *ctx,
-                                   const cmsis_nn_fc_params *fc_params,
-                                   const cmsis_nn_per_tensor_quant_params *quant_params,
-                                   const cmsis_nn_dims *input_dims,
-                                   const q15_t *input_data,
-                                   const cmsis_nn_dims *filter_dims,
-                                   const q7_t *filter_data,
-                                   const cmsis_nn_dims *bias_dims,
-                                   const int64_t *bias_data,
-                                   const cmsis_nn_dims *output_dims,
-                                   q15_t *output_data);
+arm_cmsis_nn_status arm_fully_connected_s16(const cmsis_nn_context *ctx,
+                                            const cmsis_nn_fc_params *fc_params,
+                                            const cmsis_nn_per_tensor_quant_params *quant_params,
+                                            const cmsis_nn_dims *input_dims,
+                                            const q15_t *input_data,
+                                            const cmsis_nn_dims *filter_dims,
+                                            const q7_t *filter_data,
+                                            const cmsis_nn_dims *bias_dims,
+                                            const int64_t *bias_data,
+                                            const cmsis_nn_dims *output_dims,
+                                            q15_t *output_data);
 
 /**
  * @brief Get the required buffer size for S16 basic fully-connected and
@@ -1447,19 +1454,19 @@ int32_t arm_fully_connected_s16_get_buffer_size(const cmsis_nn_dims *filter_dims
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
 
-arm_status arm_fully_connected_q7_opt(const q7_t *pV,
-                                      const q7_t *pM,
-                                      const uint16_t dim_vec,
-                                      const uint16_t num_of_rows,
-                                      const uint16_t bias_shift,
-                                      const uint16_t out_shift,
-                                      const q7_t *bias,
-                                      q7_t *pOut,
-                                      q15_t *vec_buffer);
+arm_cmsis_nn_status arm_fully_connected_q7_opt(const q7_t *pV,
+                                               const q7_t *pM,
+                                               const uint16_t dim_vec,
+                                               const uint16_t num_of_rows,
+                                               const uint16_t bias_shift,
+                                               const uint16_t out_shift,
+                                               const q7_t *bias,
+                                               q7_t *pOut,
+                                               q15_t *vec_buffer);
 
 /**
  * @brief Q15 basic fully-connected layer function
@@ -1472,19 +1479,19 @@ arm_status arm_fully_connected_q7_opt(const q7_t *pV,
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
 
-arm_status arm_fully_connected_q15(const q15_t *pV,
-                                   const q15_t *pM,
-                                   const uint16_t dim_vec,
-                                   const uint16_t num_of_rows,
-                                   const uint16_t bias_shift,
-                                   const uint16_t out_shift,
-                                   const q15_t *bias,
-                                   q15_t *pOut,
-                                   q15_t *vec_buffer);
+arm_cmsis_nn_status arm_fully_connected_q15(const q15_t *pV,
+                                            const q15_t *pM,
+                                            const uint16_t dim_vec,
+                                            const uint16_t num_of_rows,
+                                            const uint16_t bias_shift,
+                                            const uint16_t out_shift,
+                                            const q15_t *bias,
+                                            q15_t *pOut,
+                                            q15_t *vec_buffer);
 
 /**
  * @brief Q15 opt fully-connected layer function
@@ -1497,19 +1504,19 @@ arm_status arm_fully_connected_q15(const q15_t *pV,
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
 
-arm_status arm_fully_connected_q15_opt(const q15_t *pV,
-                                       const q15_t *pM,
-                                       const uint16_t dim_vec,
-                                       const uint16_t num_of_rows,
-                                       const uint16_t bias_shift,
-                                       const uint16_t out_shift,
-                                       const q15_t *bias,
-                                       q15_t *pOut,
-                                       q15_t *vec_buffer);
+arm_cmsis_nn_status arm_fully_connected_q15_opt(const q15_t *pV,
+                                                const q15_t *pM,
+                                                const uint16_t dim_vec,
+                                                const uint16_t num_of_rows,
+                                                const uint16_t bias_shift,
+                                                const uint16_t out_shift,
+                                                const q15_t *bias,
+                                                q15_t *pOut,
+                                                q15_t *vec_buffer);
 
 /**
  * @brief Mixed Q15-Q7 fully-connected layer function
@@ -1522,19 +1529,19 @@ arm_status arm_fully_connected_q15_opt(const q15_t *pV,
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
 
-arm_status arm_fully_connected_mat_q7_vec_q15(const q15_t *pV,
-                                              const q7_t *pM,
-                                              const uint16_t dim_vec,
-                                              const uint16_t num_of_rows,
-                                              const uint16_t bias_shift,
-                                              const uint16_t out_shift,
-                                              const q7_t *bias,
-                                              q15_t *pOut,
-                                              q15_t *vec_buffer);
+arm_cmsis_nn_status arm_fully_connected_mat_q7_vec_q15(const q15_t *pV,
+                                                       const q7_t *pM,
+                                                       const uint16_t dim_vec,
+                                                       const uint16_t num_of_rows,
+                                                       const uint16_t bias_shift,
+                                                       const uint16_t out_shift,
+                                                       const q7_t *bias,
+                                                       q15_t *pOut,
+                                                       q15_t *vec_buffer);
 
 /**
  * @brief Mixed Q15-Q7 opt fully-connected layer function
@@ -1547,19 +1554,19 @@ arm_status arm_fully_connected_mat_q7_vec_q15(const q15_t *pV,
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
 
-arm_status arm_fully_connected_mat_q7_vec_q15_opt(const q15_t *pV,
-                                                  const q7_t *pM,
-                                                  const uint16_t dim_vec,
-                                                  const uint16_t num_of_rows,
-                                                  const uint16_t bias_shift,
-                                                  const uint16_t out_shift,
-                                                  const q7_t *bias,
-                                                  q15_t *pOut,
-                                                  q15_t *vec_buffer);
+arm_cmsis_nn_status arm_fully_connected_mat_q7_vec_q15_opt(const q15_t *pV,
+                                                           const q7_t *pM,
+                                                           const uint16_t dim_vec,
+                                                           const uint16_t num_of_rows,
+                                                           const uint16_t bias_shift,
+                                                           const uint16_t out_shift,
+                                                           const q7_t *bias,
+                                                           q15_t *pOut,
+                                                           q15_t *vec_buffer);
 
 /**
  * @brief Matrix-Multiplication Kernels for Convolution
@@ -1634,24 +1641,24 @@ extern "C" {
  * @param[in]       out_activation_min      minimum value to clamp output to. Min: -128
  * @param[in]       out_activation_max      maximum value to clamp output to. Max: 127
  * @param[in]       block_size              number of samples
- * @return          The function returns    ARM_MATH_SUCCESS
+ * @return          The function returns    ARM_CMSIS_NN_SUCCESS
  */
-arm_status arm_elementwise_add_s8(const int8_t *input_1_vect,
-                                  const int8_t *input_2_vect,
-                                  const int32_t input_1_offset,
-                                  const int32_t input_1_mult,
-                                  const int32_t input_1_shift,
-                                  const int32_t input_2_offset,
-                                  const int32_t input_2_mult,
-                                  const int32_t input_2_shift,
-                                  const int32_t left_shift,
-                                  int8_t *output,
-                                  const int32_t out_offset,
-                                  const int32_t out_mult,
-                                  const int32_t out_shift,
-                                  const int32_t out_activation_min,
-                                  const int32_t out_activation_max,
-                                  const int32_t block_size);
+arm_cmsis_nn_status arm_elementwise_add_s8(const int8_t *input_1_vect,
+                                           const int8_t *input_2_vect,
+                                           const int32_t input_1_offset,
+                                           const int32_t input_1_mult,
+                                           const int32_t input_1_shift,
+                                           const int32_t input_2_offset,
+                                           const int32_t input_2_mult,
+                                           const int32_t input_2_shift,
+                                           const int32_t left_shift,
+                                           int8_t *output,
+                                           const int32_t out_offset,
+                                           const int32_t out_mult,
+                                           const int32_t out_shift,
+                                           const int32_t out_activation_min,
+                                           const int32_t out_activation_max,
+                                           const int32_t block_size);
 
 /**
  * @brief s16 elementwise add of two vectors
@@ -1671,24 +1678,24 @@ arm_status arm_elementwise_add_s8(const int8_t *input_1_vect,
  * @param[in]       out_activation_min      minimum value to clamp output to. Min: -32768
  * @param[in]       out_activation_max      maximum value to clamp output to. Max: 32767
  * @param[in]       block_size              number of samples
- * @return          The function returns    ARM_MATH_SUCCESS
+ * @return          The function returns    ARM_CMSIS_NN_SUCCESS
  */
-arm_status arm_elementwise_add_s16(const int16_t *input_1_vect,
-                                   const int16_t *input_2_vect,
-                                   const int32_t input_1_offset,
-                                   const int32_t input_1_mult,
-                                   const int32_t input_1_shift,
-                                   const int32_t input_2_offset,
-                                   const int32_t input_2_mult,
-                                   const int32_t input_2_shift,
-                                   const int32_t left_shift,
-                                   int16_t *output,
-                                   const int32_t out_offset,
-                                   const int32_t out_mult,
-                                   const int32_t out_shift,
-                                   const int32_t out_activation_min,
-                                   const int32_t out_activation_max,
-                                   const int32_t block_size);
+arm_cmsis_nn_status arm_elementwise_add_s16(const int16_t *input_1_vect,
+                                            const int16_t *input_2_vect,
+                                            const int32_t input_1_offset,
+                                            const int32_t input_1_mult,
+                                            const int32_t input_1_shift,
+                                            const int32_t input_2_offset,
+                                            const int32_t input_2_mult,
+                                            const int32_t input_2_shift,
+                                            const int32_t left_shift,
+                                            int16_t *output,
+                                            const int32_t out_offset,
+                                            const int32_t out_mult,
+                                            const int32_t out_shift,
+                                            const int32_t out_activation_min,
+                                            const int32_t out_activation_max,
+                                            const int32_t block_size);
 
 /**
  * @brief s8 elementwise multiplication
@@ -1703,21 +1710,21 @@ arm_status arm_elementwise_add_s16(const int16_t *input_1_vect,
  * @param[in]       out_activation_min      minimum value to clamp output to. Min: -128
  * @param[in]       out_activation_max      maximum value to clamp output to. Max: 127
  * @param[in]       block_size              number of samples
- * @return          The function returns    ARM_MATH_SUCCESS
+ * @return          The function returns    ARM_CMSIS_NN_SUCCESS
  *
  * @details   Supported framework: TensorFlow Lite micro
  */
-arm_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
-                                  const int8_t *input_2_vect,
-                                  const int32_t input_1_offset,
-                                  const int32_t input_2_offset,
-                                  int8_t *output,
-                                  const int32_t out_offset,
-                                  const int32_t out_mult,
-                                  const int32_t out_shift,
-                                  const int32_t out_activation_min,
-                                  const int32_t out_activation_max,
-                                  const int32_t block_size);
+arm_cmsis_nn_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
+                                           const int8_t *input_2_vect,
+                                           const int32_t input_1_offset,
+                                           const int32_t input_2_offset,
+                                           int8_t *output,
+                                           const int32_t out_offset,
+                                           const int32_t out_mult,
+                                           const int32_t out_shift,
+                                           const int32_t out_activation_min,
+                                           const int32_t out_activation_max,
+                                           const int32_t block_size);
 
 /**
  * @brief s16 elementwise multiplication
@@ -1732,21 +1739,21 @@ arm_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
  * @param[in]       out_activation_min      minimum value to clamp output to. Min: -32768
  * @param[in]       out_activation_max      maximum value to clamp output to. Max: 32767
  * @param[in]       block_size              number of samples
- * @return          The function returns    ARM_MATH_SUCCESS
+ * @return          The function returns    ARM_CMSIS_NN_SUCCESS
  *
  * @details   Supported framework: TensorFlow Lite micro
  */
-arm_status arm_elementwise_mul_s16(const int16_t *input_1_vect,
-                                   const int16_t *input_2_vect,
-                                   const int32_t input_1_offset,
-                                   const int32_t input_2_offset,
-                                   int16_t *output,
-                                   const int32_t out_offset,
-                                   const int32_t out_mult,
-                                   const int32_t out_shift,
-                                   const int32_t out_activation_min,
-                                   const int32_t out_activation_max,
-                                   const int32_t block_size);
+arm_cmsis_nn_status arm_elementwise_mul_s16(const int16_t *input_1_vect,
+                                            const int16_t *input_2_vect,
+                                            const int32_t input_1_offset,
+                                            const int32_t input_2_offset,
+                                            int16_t *output,
+                                            const int32_t out_offset,
+                                            const int32_t out_mult,
+                                            const int32_t out_shift,
+                                            const int32_t out_activation_min,
+                                            const int32_t out_activation_max,
+                                            const int32_t block_size);
 
 /**
  * @defgroup Acti Activation Functions
@@ -1887,19 +1894,19 @@ void arm_avepool_q7_HWC(q7_t *Im_in,
  *                                C_OUT equals C_IN.
  * @param[in, out] output_data    Output data pointer. Data type: int8
  * @return                        The function returns
- *                                    <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                                    <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  * @details
  *    - Supported Framework: TensorFlow Lite
  *
  */
-arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
-                          const cmsis_nn_pool_params *pool_params,
-                          const cmsis_nn_dims *input_dims,
-                          const q7_t *input_data,
-                          const cmsis_nn_dims *filter_dims,
-                          const cmsis_nn_dims *output_dims,
-                          q7_t *output_data);
+arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
+                                   const cmsis_nn_pool_params *pool_params,
+                                   const cmsis_nn_dims *input_dims,
+                                   const q7_t *input_data,
+                                   const cmsis_nn_dims *filter_dims,
+                                   const cmsis_nn_dims *output_dims,
+                                   q7_t *output_data);
 
 /**
  * @brief Get the required buffer size for S8 average pooling function
@@ -1928,19 +1935,19 @@ int32_t arm_avgpool_s8_get_buffer_size(const int dim_dst_width, const int ch_src
  *                                C_OUT equals C_IN.
  * @param[in, out] output_data    Output data pointer. Data type: int16
  * @return                        The function returns
- *                                    <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                                    <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  * @details
  *    - Supported Framework: TensorFlow Lite
  *
  */
-arm_status arm_avgpool_s16(const cmsis_nn_context *ctx,
-                           const cmsis_nn_pool_params *pool_params,
-                           const cmsis_nn_dims *input_dims,
-                           const int16_t *input_data,
-                           const cmsis_nn_dims *filter_dims,
-                           const cmsis_nn_dims *output_dims,
-                           int16_t *output_data);
+arm_cmsis_nn_status arm_avgpool_s16(const cmsis_nn_context *ctx,
+                                    const cmsis_nn_pool_params *pool_params,
+                                    const cmsis_nn_dims *input_dims,
+                                    const int16_t *input_data,
+                                    const cmsis_nn_dims *filter_dims,
+                                    const cmsis_nn_dims *output_dims,
+                                    int16_t *output_data);
 
 /**
  * @brief Get the required buffer size for S16 average pooling function
@@ -1970,19 +1977,19 @@ int32_t arm_avgpool_s16_get_buffer_size(const int dim_dst_width, const int ch_sr
  *                                C_OUT equals C_IN.
  * @param[in, out] output_data    Output data pointer. Data type: int8
  * @return                        The function returns
- *                                    <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                                    <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  * @details
  *    - Supported Framework: TensorFlow Lite
  *
  */
-arm_status arm_max_pool_s8(const cmsis_nn_context *ctx,
-                           const cmsis_nn_pool_params *pool_params,
-                           const cmsis_nn_dims *input_dims,
-                           const q7_t *input_data,
-                           const cmsis_nn_dims *filter_dims,
-                           const cmsis_nn_dims *output_dims,
-                           q7_t *output_data);
+arm_cmsis_nn_status arm_max_pool_s8(const cmsis_nn_context *ctx,
+                                    const cmsis_nn_pool_params *pool_params,
+                                    const cmsis_nn_dims *input_dims,
+                                    const q7_t *input_data,
+                                    const cmsis_nn_dims *filter_dims,
+                                    const cmsis_nn_dims *output_dims,
+                                    q7_t *output_data);
 
 /**
  * @brief s16 max pooling function.
@@ -2003,19 +2010,19 @@ arm_status arm_max_pool_s8(const cmsis_nn_context *ctx,
  *                                C_OUT equals C_IN.
  * @param[in, out] dst            Output data pointer. Data type: int16
  * @return                        The function returns
- *                                    <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                                    <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  * @details
  *    - Supported Framework: TensorFlow Lite
  *
  */
-arm_status arm_max_pool_s16(const cmsis_nn_context *ctx,
-                            const cmsis_nn_pool_params *pool_params,
-                            const cmsis_nn_dims *input_dims,
-                            const int16_t *src,
-                            const cmsis_nn_dims *filter_dims,
-                            const cmsis_nn_dims *output_dims,
-                            int16_t *dst);
+arm_cmsis_nn_status arm_max_pool_s16(const cmsis_nn_context *ctx,
+                                     const cmsis_nn_pool_params *pool_params,
+                                     const cmsis_nn_dims *input_dims,
+                                     const int16_t *src,
+                                     const cmsis_nn_dims *filter_dims,
+                                     const cmsis_nn_dims *output_dims,
+                                     int16_t *dst);
 
 /**
  * @defgroup Softmax Softmax Functions
@@ -2124,19 +2131,19 @@ void arm_softmax_s8_s16(const int8_t *input,
  *                             - Lookup table for 1 / (1 + x), where x uniform distributed between [0.0 , 1.0]
  * @param[out] output          Pointer to the output tensor
  * @return                        The function returns
- *                                    <code>ARM_MATH_ARGUMENT_ERROR</code> if LUTs are NULL
- *                                    <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                                    <code>ARM_CMSIS_NN_ARG_ERROR</code> Argument error check failed
+ *                                    <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  * @note Supported framework: TensorFlow Lite micro (bit-accurate)
  *
  */
-arm_status arm_softmax_s16(const int16_t *input,
-                           const int32_t num_rows,
-                           const int32_t row_size,
-                           const int32_t mult,
-                           const int32_t shift,
-                           const cmsis_nn_softmax_lut_s16 *softmax_params,
-                           int16_t *output);
+arm_cmsis_nn_status arm_softmax_s16(const int16_t *input,
+                                    const int32_t num_rows,
+                                    const int32_t row_size,
+                                    const int32_t mult,
+                                    const int32_t shift,
+                                    const cmsis_nn_softmax_lut_s16 *softmax_params,
+                                    int16_t *output);
 
 /**
  * @brief U8 softmax function
@@ -2192,34 +2199,34 @@ void arm_softmax_u8(const uint8_t *input,
  * @param[in]     out_shift  Amount of right-shift for output
  * @param[in]     out_mult   Output multiplier for requantization
  * @return        The function returns the following
- *                <code>ARM_MATH_SUCCESS</code> - Successful operation
+ *                <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  */
-arm_status arm_depthwise_conv_u8_basic_ver1(const uint8_t *input,
-                                            const uint16_t input_x,
-                                            const uint16_t input_y,
-                                            const uint16_t input_ch,
-                                            const uint8_t *kernel,
-                                            const uint16_t kernel_x,
-                                            const uint16_t kernel_y,
-                                            const int16_t ch_mult,
-                                            const int16_t pad_x,
-                                            const int16_t pad_y,
-                                            const int16_t stride_x,
-                                            const int16_t stride_y,
-                                            const int16_t dilation_x,
-                                            const int16_t dilation_y,
-                                            const int32_t *bias,
-                                            const int32_t input_offset,
-                                            const int32_t filter_offset,
-                                            const int32_t output_offset,
-                                            uint8_t *output,
-                                            const uint16_t output_x,
-                                            const uint16_t output_y,
-                                            const int32_t output_activation_min,
-                                            const int32_t output_activation_max,
-                                            const int32_t out_shift,
-                                            const int32_t out_mult);
+arm_cmsis_nn_status arm_depthwise_conv_u8_basic_ver1(const uint8_t *input,
+                                                     const uint16_t input_x,
+                                                     const uint16_t input_y,
+                                                     const uint16_t input_ch,
+                                                     const uint8_t *kernel,
+                                                     const uint16_t kernel_x,
+                                                     const uint16_t kernel_y,
+                                                     const int16_t ch_mult,
+                                                     const int16_t pad_x,
+                                                     const int16_t pad_y,
+                                                     const int16_t stride_x,
+                                                     const int16_t stride_y,
+                                                     const int16_t dilation_x,
+                                                     const int16_t dilation_y,
+                                                     const int32_t *bias,
+                                                     const int32_t input_offset,
+                                                     const int32_t filter_offset,
+                                                     const int32_t output_offset,
+                                                     uint8_t *output,
+                                                     const uint16_t output_x,
+                                                     const uint16_t output_y,
+                                                     const int32_t output_activation_min,
+                                                     const int32_t output_activation_max,
+                                                     const int32_t out_shift,
+                                                     const int32_t out_mult);
 
 /**
  * @defgroup Reshape Reshape Functions
@@ -2452,30 +2459,30 @@ void arm_concatenation_s8_w(const int8_t *input,
  * @param[in]   output_dims Output tensor dimensions
  * @param[out]  output_data Pointer to the output tensor
  *
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    1. Supported framework: TensorFlow Lite micro
  *    2. q7 is used as data type eventhough it is s8 data. It is done so to be consistent with existing APIs.
  *
  */
-arm_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
-                       const cmsis_nn_context *output_ctx,
-                       const cmsis_nn_svdf_params *svdf_params,
-                       const cmsis_nn_per_tensor_quant_params *input_quant_params,
-                       const cmsis_nn_per_tensor_quant_params *output_quant_params,
-                       const cmsis_nn_dims *input_dims,
-                       const q7_t *input_data,
-                       const cmsis_nn_dims *state_dims,
-                       q7_t *state_data,
-                       const cmsis_nn_dims *weights_feature_dims,
-                       const q7_t *weights_feature_data,
-                       const cmsis_nn_dims *weights_time_dims,
-                       const q7_t *weights_time_data,
-                       const cmsis_nn_dims *bias_dims,
-                       const q31_t *bias_data,
-                       const cmsis_nn_dims *output_dims,
-                       q7_t *output_data);
+arm_cmsis_nn_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
+                                const cmsis_nn_context *output_ctx,
+                                const cmsis_nn_svdf_params *svdf_params,
+                                const cmsis_nn_per_tensor_quant_params *input_quant_params,
+                                const cmsis_nn_per_tensor_quant_params *output_quant_params,
+                                const cmsis_nn_dims *input_dims,
+                                const q7_t *input_data,
+                                const cmsis_nn_dims *state_dims,
+                                q7_t *state_data,
+                                const cmsis_nn_dims *weights_feature_dims,
+                                const q7_t *weights_feature_data,
+                                const cmsis_nn_dims *weights_time_dims,
+                                const q7_t *weights_time_data,
+                                const cmsis_nn_dims *bias_dims,
+                                const q31_t *bias_data,
+                                const cmsis_nn_dims *output_dims,
+                                q7_t *output_data);
 
 /**
  * @brief s8 SVDF function with 16 bit state tensor and 16 bit time weights
@@ -2500,30 +2507,30 @@ arm_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
  * @param[in]   output_dims Output tensor dimensions
  * @param[out]  output_data Pointer to the output tensor
  *
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *    1. Supported framework: TensorFlow Lite micro
  *    2. q7 is used as data type eventhough it is s8 data. It is done so to be consistent with existing APIs.
  *
  */
-arm_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
-                                 const cmsis_nn_context *output_ctx,
-                                 const cmsis_nn_svdf_params *svdf_params,
-                                 const cmsis_nn_per_tensor_quant_params *input_quant_params,
-                                 const cmsis_nn_per_tensor_quant_params *output_quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q7_t *input_data,
-                                 const cmsis_nn_dims *state_dims,
-                                 q15_t *state_data,
-                                 const cmsis_nn_dims *weights_feature_dims,
-                                 const q7_t *weights_feature_data,
-                                 const cmsis_nn_dims *weights_time_dims,
-                                 const q15_t *weights_time_data,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const q31_t *bias_data,
-                                 const cmsis_nn_dims *output_dims,
-                                 q7_t *output_data);
+arm_cmsis_nn_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
+                                          const cmsis_nn_context *output_ctx,
+                                          const cmsis_nn_svdf_params *svdf_params,
+                                          const cmsis_nn_per_tensor_quant_params *input_quant_params,
+                                          const cmsis_nn_per_tensor_quant_params *output_quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q7_t *input_data,
+                                          const cmsis_nn_dims *state_dims,
+                                          q15_t *state_data,
+                                          const cmsis_nn_dims *weights_feature_dims,
+                                          const q7_t *weights_feature_data,
+                                          const cmsis_nn_dims *weights_time_dims,
+                                          const q15_t *weights_time_data,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const q31_t *bias_data,
+                                          const cmsis_nn_dims *output_dims,
+                                          q7_t *output_data);
 
 #ifdef __cplusplus
 }

--- a/CMSIS/NN/Include/arm_nnsupportfunctions.h
+++ b/CMSIS/NN/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        19. April 2022
- * $Revision:    V.7.0.1
+ * $Date:        20. April 2022
+ * $Revision:    V.8.0.0
  *
  * Target Processor:  Cortex-M CPUs
  * -------------------------------------------------------------------- */
@@ -294,11 +294,11 @@ q15_t *arm_nn_mat_mult_kernel_s16(const q7_t *input_a,
  *          sum_col += col_base[i]
  *
  */
-arm_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
-                                     const int8_t *row_base,
-                                     const int8_t *col_base,
-                                     int32_t *const sum_col,
-                                     int32_t *const output);
+arm_cmsis_nn_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
+                                              const int8_t *row_base,
+                                              const int8_t *col_base,
+                                              int32_t *const sum_col,
+                                              int32_t *const output);
 
 /**
  * @brief Matrix-multiplication with requantization & activation function for four rows and one column
@@ -353,22 +353,22 @@ int8_t *arm_nn_mat_mul_core_4x_s8(const int32_t row_elements,
  * @param[in]  activation_min     Minimum value to clamp down the output. Range : int8
  * @param[in]  activation_max     Maximum value to clamp up the output. Range : int8
  *
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
-arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
-                                   const q7_t *rhs,
-                                   const q31_t *bias,
-                                   q7_t *dst,
-                                   const int32_t *dst_multipliers,
-                                   const int32_t *dst_shifts,
-                                   const int32_t lhs_rows,
-                                   const int32_t rhs_rows,
-                                   const int32_t rhs_cols,
-                                   const int32_t lhs_offset,
-                                   const int32_t dst_offset,
-                                   const int32_t activation_min,
-                                   const int32_t activation_max);
+arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
+                                            const q7_t *rhs,
+                                            const q31_t *bias,
+                                            q7_t *dst,
+                                            const int32_t *dst_multipliers,
+                                            const int32_t *dst_shifts,
+                                            const int32_t lhs_rows,
+                                            const int32_t rhs_rows,
+                                            const int32_t rhs_cols,
+                                            const int32_t lhs_offset,
+                                            const int32_t dst_offset,
+                                            const int32_t activation_min,
+                                            const int32_t activation_max);
 
 /**
  * @brief s8 Vector by Matrix (transposed) multiplication
@@ -390,23 +390,23 @@ arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
  * @param[in]      address_offset  Memory position offset for dst. First output is stored at 'dst', the
  *                                 second at 'dst + address_offset' and so on. Default value is typically 1.
  *
- * @return         The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return         The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
-arm_status arm_nn_vec_mat_mult_t_s8(const q7_t *lhs,
-                                    const q7_t *rhs,
-                                    const q31_t *bias,
-                                    q7_t *dst,
-                                    const int32_t lhs_offset,
-                                    const int32_t rhs_offset,
-                                    const int32_t dst_offset,
-                                    const int32_t dst_multiplier,
-                                    const int32_t dst_shift,
-                                    const int32_t rhs_cols,
-                                    const int32_t rhs_rows,
-                                    const int32_t activation_min,
-                                    const int32_t activation_max,
-                                    const int32_t address_offset);
+arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s8(const q7_t *lhs,
+                                             const q7_t *rhs,
+                                             const q31_t *bias,
+                                             q7_t *dst,
+                                             const int32_t lhs_offset,
+                                             const int32_t rhs_offset,
+                                             const int32_t dst_offset,
+                                             const int32_t dst_multiplier,
+                                             const int32_t dst_shift,
+                                             const int32_t rhs_cols,
+                                             const int32_t rhs_rows,
+                                             const int32_t activation_min,
+                                             const int32_t activation_max,
+                                             const int32_t address_offset);
 
 /**
  * @brief s16 Vector by Matrix (transposed) multiplication
@@ -422,19 +422,19 @@ arm_status arm_nn_vec_mat_mult_t_s8(const q7_t *lhs,
  * @param[in]      activation_min  Minimum value to clamp the output to. Range: int16
  * @param[in]      activation_max  Maximum value to clamp the output to. Range: int16
  *
- * @return         The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return         The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
-arm_status arm_nn_vec_mat_mult_t_s16(const q15_t *lhs,
-                                     const q7_t *rhs,
-                                     const q63_t *bias,
-                                     q15_t *dst,
-                                     const int32_t dst_multiplier,
-                                     const int32_t dst_shift,
-                                     const int32_t rhs_cols,
-                                     const int32_t rhs_rows,
-                                     const int32_t activation_min,
-                                     const int32_t activation_max);
+arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const q15_t *lhs,
+                                              const q7_t *rhs,
+                                              const q63_t *bias,
+                                              q15_t *dst,
+                                              const int32_t dst_multiplier,
+                                              const int32_t dst_shift,
+                                              const int32_t rhs_cols,
+                                              const int32_t rhs_rows,
+                                              const int32_t activation_min,
+                                              const int32_t activation_max);
 
 /**
  * @brief s8 Vector by Matrix (transposed) multiplication with s16 output
@@ -454,21 +454,21 @@ arm_status arm_nn_vec_mat_mult_t_s16(const q15_t *lhs,
  * @param[in]      activation_min  Minimum value to clamp the output to. Range: int16
  * @param[in]      activation_max  Maximum value to clamp the output to. Range: int16
  *
- * @return         The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return         The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  */
-arm_status arm_nn_vec_mat_mult_t_svdf_s8(const q7_t *lhs,
-                                         const q7_t *rhs,
-                                         q15_t *dst,
-                                         const int32_t lhs_offset,
-                                         const int32_t rhs_offset,
-                                         const int32_t scatter_offset,
-                                         const int32_t dst_multiplier,
-                                         const int32_t dst_shift,
-                                         const int32_t rhs_cols,
-                                         const int32_t rhs_rows,
-                                         const int32_t activation_min,
-                                         const int32_t activation_max);
+arm_cmsis_nn_status arm_nn_vec_mat_mult_t_svdf_s8(const q7_t *lhs,
+                                                  const q7_t *rhs,
+                                                  q15_t *dst,
+                                                  const int32_t lhs_offset,
+                                                  const int32_t rhs_offset,
+                                                  const int32_t scatter_offset,
+                                                  const int32_t dst_multiplier,
+                                                  const int32_t dst_shift,
+                                                  const int32_t rhs_cols,
+                                                  const int32_t rhs_rows,
+                                                  const int32_t activation_min,
+                                                  const int32_t activation_max);
 
 /**
  * @brief Depthwise convolution of transposed rhs matrix with 4 lhs matrices. To be used in padded cases where

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s16.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_add_s16
  * Description:  Elementwise add
  *
- * $Date:        14 Februari 2022
- * $Revision:    V.1.0.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -49,22 +49,22 @@
 
 /* Note: __SHIFT is expected to be <=0 */
 
-arm_status arm_elementwise_add_s16(const int16_t *input_1_vect,
-                                   const int16_t *input_2_vect,
-                                   const int32_t input_1_offset,
-                                   const int32_t input_1_mult,
-                                   const int32_t input_1_shift,
-                                   const int32_t input_2_offset,
-                                   const int32_t input_2_mult,
-                                   const int32_t input_2_shift,
-                                   const int32_t left_shift,
-                                   int16_t *output,
-                                   const int32_t out_offset,
-                                   const int32_t out_mult,
-                                   const int32_t out_shift,
-                                   const int32_t out_activation_min,
-                                   const int32_t out_activation_max,
-                                   const int32_t block_size)
+arm_cmsis_nn_status arm_elementwise_add_s16(const int16_t *input_1_vect,
+                                            const int16_t *input_2_vect,
+                                            const int32_t input_1_offset,
+                                            const int32_t input_1_mult,
+                                            const int32_t input_1_shift,
+                                            const int32_t input_2_offset,
+                                            const int32_t input_2_mult,
+                                            const int32_t input_2_shift,
+                                            const int32_t left_shift,
+                                            int16_t *output,
+                                            const int32_t out_offset,
+                                            const int32_t out_mult,
+                                            const int32_t out_shift,
+                                            const int32_t out_activation_min,
+                                            const int32_t out_activation_max,
+                                            const int32_t block_size)
 {
     (void)input_1_offset;
     (void)input_2_offset;
@@ -97,7 +97,7 @@ arm_status arm_elementwise_add_s16(const int16_t *input_1_vect,
         loop_count--;
     }
 
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s8.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_add_s8
  * Description:  Elementwise add
  *
- * $Date:        3 Februari 2022
- * $Revision:    V.2.6.0
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -49,22 +49,22 @@
 
 /* Note: __SHIFT is expected to be <=0 */
 
-arm_status arm_elementwise_add_s8(const int8_t *input_1_vect,
-                                  const int8_t *input_2_vect,
-                                  const int32_t input_1_offset,
-                                  const int32_t input_1_mult,
-                                  const int32_t input_1_shift,
-                                  const int32_t input_2_offset,
-                                  const int32_t input_2_mult,
-                                  const int32_t input_2_shift,
-                                  const int32_t left_shift,
-                                  int8_t *output,
-                                  const int32_t out_offset,
-                                  const int32_t out_mult,
-                                  const int32_t out_shift,
-                                  const int32_t out_activation_min,
-                                  const int32_t out_activation_max,
-                                  const int32_t block_size)
+arm_cmsis_nn_status arm_elementwise_add_s8(const int8_t *input_1_vect,
+                                           const int8_t *input_2_vect,
+                                           const int32_t input_1_offset,
+                                           const int32_t input_1_mult,
+                                           const int32_t input_1_shift,
+                                           const int32_t input_2_offset,
+                                           const int32_t input_2_mult,
+                                           const int32_t input_2_shift,
+                                           const int32_t left_shift,
+                                           int8_t *output,
+                                           const int32_t out_offset,
+                                           const int32_t out_mult,
+                                           const int32_t out_shift,
+                                           const int32_t out_activation_min,
+                                           const int32_t out_activation_max,
+                                           const int32_t block_size)
 {
 #if defined(ARM_MATH_MVEI)
     int32_t count = block_size;
@@ -226,7 +226,7 @@ arm_status arm_elementwise_add_s8(const int8_t *input_1_vect,
 
 #endif /* ARM_MATH_MVEI */
 
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s16.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_mul_s16
  * Description:  Element wise multiplication
  *
- * $Date:        14 Februari 2022
- * $Revision:    V.1.0.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -46,17 +46,17 @@
  * @note   Refer header file for details.
  *
  */
-arm_status arm_elementwise_mul_s16(const int16_t *input_1_vect,
-                                   const int16_t *input_2_vect,
-                                   const int32_t input_1_offset,
-                                   const int32_t input_2_offset,
-                                   int16_t *output,
-                                   const int32_t out_offset,
-                                   const int32_t out_mult,
-                                   const int32_t out_shift,
-                                   const int32_t out_activation_min,
-                                   const int32_t out_activation_max,
-                                   const int32_t block_size)
+arm_cmsis_nn_status arm_elementwise_mul_s16(const int16_t *input_1_vect,
+                                            const int16_t *input_2_vect,
+                                            const int32_t input_1_offset,
+                                            const int32_t input_2_offset,
+                                            int16_t *output,
+                                            const int32_t out_offset,
+                                            const int32_t out_mult,
+                                            const int32_t out_shift,
+                                            const int32_t out_activation_min,
+                                            const int32_t out_activation_max,
+                                            const int32_t block_size)
 {
     (void)input_1_offset;
     (void)input_2_offset;
@@ -87,7 +87,7 @@ arm_status arm_elementwise_mul_s16(const int16_t *input_1_vect,
         loop_count--;
     }
 
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
+++ b/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_mul_s8
  * Description:  Element wise multiplication
  *
- * $Date:        3 Februari 2022
- * $Revision:    V.1.1.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -47,17 +47,17 @@
  *
  */
 
-arm_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
-                                  const int8_t *input_2_vect,
-                                  const int32_t input_1_offset,
-                                  const int32_t input_2_offset,
-                                  int8_t *output,
-                                  const int32_t out_offset,
-                                  const int32_t out_mult,
-                                  const int32_t out_shift,
-                                  const int32_t out_activation_min,
-                                  const int32_t out_activation_max,
-                                  const int32_t block_size)
+arm_cmsis_nn_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
+                                           const int8_t *input_2_vect,
+                                           const int32_t input_1_offset,
+                                           const int32_t input_2_offset,
+                                           int8_t *output,
+                                           const int32_t out_offset,
+                                           const int32_t out_mult,
+                                           const int32_t out_shift,
+                                           const int32_t out_activation_min,
+                                           const int32_t out_activation_max,
+                                           const int32_t block_size)
 {
 
     int32_t loop_count;
@@ -192,7 +192,7 @@ arm_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
         loop_count--;
     }
 #endif
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1_x_n_s8.c
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
- * $Date:        December 14, 2021
- * $Revision:    V.2.1.0
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -47,23 +47,23 @@
  *
  */
 
-arm_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
-                                 const cmsis_nn_conv_params *conv_params,
-                                 const cmsis_nn_per_channel_quant_params *quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q7_t *input_data,
-                                 const cmsis_nn_dims *filter_dims,
-                                 const q7_t *filter_data,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const int32_t *bias_data,
-                                 const cmsis_nn_dims *output_dims,
-                                 q7_t *output_data)
+arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
+                                          const cmsis_nn_conv_params *conv_params,
+                                          const cmsis_nn_per_channel_quant_params *quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q7_t *input_data,
+                                          const cmsis_nn_dims *filter_dims,
+                                          const q7_t *filter_data,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const int32_t *bias_data,
+                                          const cmsis_nn_dims *output_dims,
+                                          q7_t *output_data)
 {
     (void)bias_dims;
-    arm_status status = ARM_MATH_SUCCESS;
+    arm_cmsis_nn_status status = ARM_CMSIS_NN_SUCCESS;
     if (output_dims->w % 4 != 0)
     {
-        status = ARM_MATH_SIZE_MISMATCH;
+        status = ARM_CMSIS_NN_ARG_ERROR;
         goto out;
     }
 

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_HWC_q7_fast_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_HWC_q7_fast_nonsquare.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1x1_HWC_q7_fast_nonsquare.c
  * Description:  Fast Q7 version of 1x1 convolution (non-square shape)
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -63,7 +63,8 @@
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is optimized for convolution with 1x1 kernel size (i.e., dim_kernel_x=1
  * and dim_kernel_y=1). It can be used for the second half of MobileNets [1] after depthwise
@@ -78,26 +79,26 @@
  * https://arxiv.org/abs/1704.04861
  */
 
-arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
-                                                  const uint16_t dim_im_in_x,
-                                                  const uint16_t dim_im_in_y,
-                                                  const uint16_t ch_im_in,
-                                                  const q7_t *wt,
-                                                  const uint16_t ch_im_out,
-                                                  const uint16_t dim_kernel_x,
-                                                  const uint16_t dim_kernel_y,
-                                                  const uint16_t padding_x,
-                                                  const uint16_t padding_y,
-                                                  const uint16_t stride_x,
-                                                  const uint16_t stride_y,
-                                                  const q7_t *bias,
-                                                  const uint16_t bias_shift,
-                                                  const uint16_t out_shift,
-                                                  q7_t *Im_out,
-                                                  const uint16_t dim_im_out_x,
-                                                  const uint16_t dim_im_out_y,
-                                                  q15_t *bufferA,
-                                                  q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
+                                                           const uint16_t dim_im_in_x,
+                                                           const uint16_t dim_im_in_y,
+                                                           const uint16_t ch_im_in,
+                                                           const q7_t *wt,
+                                                           const uint16_t ch_im_out,
+                                                           const uint16_t dim_kernel_x,
+                                                           const uint16_t dim_kernel_y,
+                                                           const uint16_t padding_x,
+                                                           const uint16_t padding_y,
+                                                           const uint16_t stride_x,
+                                                           const uint16_t stride_y,
+                                                           const q7_t *bias,
+                                                           const uint16_t bias_shift,
+                                                           const uint16_t out_shift,
+                                                           q7_t *Im_out,
+                                                           const uint16_t dim_im_out_x,
+                                                           const uint16_t dim_im_out_y,
+                                                           q15_t *bufferA,
+                                                           q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -118,7 +119,7 @@ arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
         padding_y != 0 || stride_x != 1 || stride_y != 1)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i_out_y = 0; i_out_y < dim_im_out_y; i_out_y++)
@@ -191,7 +192,7 @@ arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
         padding_y != 0 || stride_x != 1 || stride_y != 1)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i = 0; i < ch_im_out; i++)
@@ -227,7 +228,7 @@ arm_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast q7 version of 1x1 convolution (non-square shape)
  *
- * $Date:        12. November 2021
- * $Revision:    V.2.0.4
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M Processors
  *
@@ -51,22 +51,22 @@
  *
  */
 
-arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
-                                    const cmsis_nn_conv_params *conv_params,
-                                    const cmsis_nn_per_channel_quant_params *quant_params,
-                                    const cmsis_nn_dims *input_dims,
-                                    const q7_t *input_data,
-                                    const cmsis_nn_dims *filter_dims,
-                                    const q7_t *filter_data,
-                                    const cmsis_nn_dims *bias_dims,
-                                    const int32_t *bias_data,
-                                    const cmsis_nn_dims *output_dims,
-                                    q7_t *output_data)
+arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
+                                             const cmsis_nn_conv_params *conv_params,
+                                             const cmsis_nn_per_channel_quant_params *quant_params,
+                                             const cmsis_nn_dims *input_dims,
+                                             const q7_t *input_data,
+                                             const cmsis_nn_dims *filter_dims,
+                                             const q7_t *filter_data,
+                                             const cmsis_nn_dims *bias_dims,
+                                             const int32_t *bias_data,
+                                             const cmsis_nn_dims *output_dims,
+                                             q7_t *output_data)
 {
     if (input_dims->c % 4 != 0 || conv_params->padding.w != 0 || conv_params->padding.h != 0 ||
         conv_params->stride.w != 1 || conv_params->stride.h != 1)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     (void)ctx;
@@ -147,7 +147,7 @@ arm_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
 #endif
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims *input_dims)

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q15_basic.c
  * Description:  Q15 version of convolution
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -57,7 +57,7 @@
  * @param[in]       dim_im_out  output tensor dimension
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *
@@ -71,21 +71,21 @@
  * dimension.
  */
 
-arm_status arm_convolve_HWC_q15_basic(const q15_t *Im_in,
-                                      const uint16_t dim_im_in,
-                                      const uint16_t ch_im_in,
-                                      const q15_t *wt,
-                                      const uint16_t ch_im_out,
-                                      const uint16_t dim_kernel,
-                                      const uint16_t padding,
-                                      const uint16_t stride,
-                                      const q15_t *bias,
-                                      const uint16_t bias_shift,
-                                      const uint16_t out_shift,
-                                      q15_t *Im_out,
-                                      const uint16_t dim_im_out,
-                                      q15_t *bufferA,
-                                      q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q15_basic(const q15_t *Im_in,
+                                               const uint16_t dim_im_in,
+                                               const uint16_t ch_im_in,
+                                               const q15_t *wt,
+                                               const uint16_t ch_im_out,
+                                               const uint16_t dim_kernel,
+                                               const uint16_t padding,
+                                               const uint16_t stride,
+                                               const q15_t *bias,
+                                               const uint16_t bias_shift,
+                                               const uint16_t out_shift,
+                                               q15_t *Im_out,
+                                               const uint16_t dim_im_out,
+                                               q15_t *bufferA,
+                                               q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -201,7 +201,7 @@ arm_status arm_convolve_HWC_q15_basic(const q15_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q15_fast.c
  * Description:  Fast Q15 version of convolution
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -58,7 +58,8 @@
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * @details
  *
@@ -78,21 +79,21 @@
  *
  */
 
-arm_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
-                                     const uint16_t dim_im_in,
-                                     const uint16_t ch_im_in,
-                                     const q15_t *wt,
-                                     const uint16_t ch_im_out,
-                                     const uint16_t dim_kernel,
-                                     const uint16_t padding,
-                                     const uint16_t stride,
-                                     const q15_t *bias,
-                                     const uint16_t bias_shift,
-                                     const uint16_t out_shift,
-                                     q15_t *Im_out,
-                                     const uint16_t dim_im_out,
-                                     q15_t *bufferA,
-                                     q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
+                                              const uint16_t dim_im_in,
+                                              const uint16_t ch_im_in,
+                                              const q15_t *wt,
+                                              const uint16_t ch_im_out,
+                                              const uint16_t dim_kernel,
+                                              const uint16_t padding,
+                                              const uint16_t stride,
+                                              const q15_t *bias,
+                                              const uint16_t bias_shift,
+                                              const uint16_t out_shift,
+                                              q15_t *Im_out,
+                                              const uint16_t dim_im_out,
+                                              q15_t *bufferA,
+                                              q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -105,7 +106,7 @@ arm_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
     if (ch_im_in % 2 != 0 || ch_im_out % 2 != 0 || dim_im_out & 0x1)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     /* Run the following code for Cortex-M4 and Cortex-M7 */
@@ -217,7 +218,7 @@ arm_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
     if (ch_im_in % 2 != 0 || ch_im_out % 2 != 0)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i = 0; i < ch_im_out; i++)
@@ -251,7 +252,7 @@ arm_status arm_convolve_HWC_q15_fast(const q15_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q15_fast.c
  * Description:  Fast Q15 version of convolution
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -63,7 +63,8 @@
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * @details
  *
@@ -81,26 +82,26 @@
  *
  */
 
-arm_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
-                                               const uint16_t dim_im_in_x,
-                                               const uint16_t dim_im_in_y,
-                                               const uint16_t ch_im_in,
-                                               const q15_t *wt,
-                                               const uint16_t ch_im_out,
-                                               const uint16_t dim_kernel_x,
-                                               const uint16_t dim_kernel_y,
-                                               const uint16_t padding_x,
-                                               const uint16_t padding_y,
-                                               const uint16_t stride_x,
-                                               const uint16_t stride_y,
-                                               const q15_t *bias,
-                                               const uint16_t bias_shift,
-                                               const uint16_t out_shift,
-                                               q15_t *Im_out,
-                                               const uint16_t dim_im_out_x,
-                                               const uint16_t dim_im_out_y,
-                                               q15_t *bufferA,
-                                               q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
+                                                        const uint16_t dim_im_in_x,
+                                                        const uint16_t dim_im_in_y,
+                                                        const uint16_t ch_im_in,
+                                                        const q15_t *wt,
+                                                        const uint16_t ch_im_out,
+                                                        const uint16_t dim_kernel_x,
+                                                        const uint16_t dim_kernel_y,
+                                                        const uint16_t padding_x,
+                                                        const uint16_t padding_y,
+                                                        const uint16_t stride_x,
+                                                        const uint16_t stride_y,
+                                                        const q15_t *bias,
+                                                        const uint16_t bias_shift,
+                                                        const uint16_t out_shift,
+                                                        q15_t *Im_out,
+                                                        const uint16_t dim_im_out_x,
+                                                        const uint16_t dim_im_out_y,
+                                                        q15_t *bufferA,
+                                                        q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -113,7 +114,7 @@ arm_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
     if (ch_im_in % 2 != 0 || ch_im_out % 2 != 0)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     /* Run the following code for Cortex-M4 and Cortex-M7 */
@@ -227,7 +228,7 @@ arm_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
     if (ch_im_in % 2 != 0 || ch_im_out % 2 != 0)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i = 0; i < ch_im_out; i++)
@@ -262,7 +263,7 @@ arm_status arm_convolve_HWC_q15_fast_nonsquare(const q15_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q7_RGB.c
  * Description:  Q7 version of convolution for RGB image
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -58,7 +58,8 @@
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * @details
  *
@@ -77,21 +78,21 @@
  * image with RGB format.
  */
 
-arm_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
-                                   const uint16_t dim_im_in,
-                                   const uint16_t ch_im_in,
-                                   const q7_t *wt,
-                                   const uint16_t ch_im_out,
-                                   const uint16_t dim_kernel,
-                                   const uint16_t padding,
-                                   const uint16_t stride,
-                                   const q7_t *bias,
-                                   const uint16_t bias_shift,
-                                   const uint16_t out_shift,
-                                   q7_t *Im_out,
-                                   const uint16_t dim_im_out,
-                                   q15_t *bufferA,
-                                   q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
+                                            const uint16_t dim_im_in,
+                                            const uint16_t ch_im_in,
+                                            const q7_t *wt,
+                                            const uint16_t ch_im_out,
+                                            const uint16_t dim_kernel,
+                                            const uint16_t padding,
+                                            const uint16_t stride,
+                                            const q7_t *bias,
+                                            const uint16_t bias_shift,
+                                            const uint16_t out_shift,
+                                            q7_t *Im_out,
+                                            const uint16_t dim_im_out,
+                                            q15_t *bufferA,
+                                            q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -108,7 +109,7 @@ arm_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
     // check if number of input channels is 3
     if (ch_im_in != 3)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     // This part implements the im2col function
     for (i_out_y = 0; i_out_y < dim_im_out; i_out_y++)
@@ -237,7 +238,7 @@ arm_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
     // check if number of input channels is 3
     if (ch_im_in != 3)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i = 0; i < ch_im_out; i++)
@@ -272,7 +273,7 @@ arm_status arm_convolve_HWC_q7_RGB(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q7_basic.c
  * Description:	 Q7 version of convolution
  *
- * $Date:        20. July 2021
- * $Revision:    V.1.1.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -57,7 +57,7 @@
  * @param[in]       dim_im_out  output tensor dimension
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *
@@ -71,21 +71,21 @@
  * dimension.
  */
 
-arm_status arm_convolve_HWC_q7_basic(const q7_t *Im_in,
-                                     const uint16_t dim_im_in,
-                                     const uint16_t ch_im_in,
-                                     const q7_t *wt,
-                                     const uint16_t ch_im_out,
-                                     const uint16_t dim_kernel,
-                                     const uint16_t padding,
-                                     const uint16_t stride,
-                                     const q7_t *bias,
-                                     const uint16_t bias_shift,
-                                     const uint16_t out_shift,
-                                     q7_t *Im_out,
-                                     const uint16_t dim_im_out,
-                                     q15_t *bufferA,
-                                     q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q7_basic(const q7_t *Im_in,
+                                              const uint16_t dim_im_in,
+                                              const uint16_t ch_im_in,
+                                              const q7_t *wt,
+                                              const uint16_t ch_im_out,
+                                              const uint16_t dim_kernel,
+                                              const uint16_t padding,
+                                              const uint16_t stride,
+                                              const q7_t *bias,
+                                              const uint16_t bias_shift,
+                                              const uint16_t out_shift,
+                                              q7_t *Im_out,
+                                              const uint16_t dim_im_out,
+                                              q15_t *bufferA,
+                                              q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -219,7 +219,7 @@ arm_status arm_convolve_HWC_q7_basic(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q7_basic.c
  * Description:	 Q7 version of convolution
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -62,29 +62,29 @@
  * @param[in]       dim_im_out_y output tensor dimension y
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  */
 
-arm_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t *Im_in,
-                                               const uint16_t dim_im_in_x,
-                                               const uint16_t dim_im_in_y,
-                                               const uint16_t ch_im_in,
-                                               const q7_t *wt,
-                                               const uint16_t ch_im_out,
-                                               const uint16_t dim_kernel_x,
-                                               const uint16_t dim_kernel_y,
-                                               const uint16_t padding_x,
-                                               const uint16_t padding_y,
-                                               const uint16_t stride_x,
-                                               const uint16_t stride_y,
-                                               const q7_t *bias,
-                                               const uint16_t bias_shift,
-                                               const uint16_t out_shift,
-                                               q7_t *Im_out,
-                                               const uint16_t dim_im_out_x,
-                                               const uint16_t dim_im_out_y,
-                                               q15_t *bufferA,
-                                               q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t *Im_in,
+                                                        const uint16_t dim_im_in_x,
+                                                        const uint16_t dim_im_in_y,
+                                                        const uint16_t ch_im_in,
+                                                        const q7_t *wt,
+                                                        const uint16_t ch_im_out,
+                                                        const uint16_t dim_kernel_x,
+                                                        const uint16_t dim_kernel_y,
+                                                        const uint16_t padding_x,
+                                                        const uint16_t padding_y,
+                                                        const uint16_t stride_x,
+                                                        const uint16_t stride_y,
+                                                        const q7_t *bias,
+                                                        const uint16_t bias_shift,
+                                                        const uint16_t out_shift,
+                                                        q7_t *Im_out,
+                                                        const uint16_t dim_im_out_x,
+                                                        const uint16_t dim_im_out_y,
+                                                        q15_t *bufferA,
+                                                        q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -221,7 +221,7 @@ arm_status arm_convolve_HWC_q7_basic_nonsquare(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q7_fast.c
  * Description:  Fast Q7 version of convolution
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -58,7 +58,8 @@
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * @details
  *
@@ -88,21 +89,21 @@
  * the data copying performance.
  */
 
-arm_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
-                                    const uint16_t dim_im_in,
-                                    const uint16_t ch_im_in,
-                                    const q7_t *wt,
-                                    const uint16_t ch_im_out,
-                                    const uint16_t dim_kernel,
-                                    const uint16_t padding,
-                                    const uint16_t stride,
-                                    const q7_t *bias,
-                                    const uint16_t bias_shift,
-                                    const uint16_t out_shift,
-                                    q7_t *Im_out,
-                                    const uint16_t dim_im_out,
-                                    q15_t *bufferA,
-                                    q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
+                                             const uint16_t dim_im_in,
+                                             const uint16_t ch_im_in,
+                                             const q7_t *wt,
+                                             const uint16_t ch_im_out,
+                                             const uint16_t dim_kernel,
+                                             const uint16_t padding,
+                                             const uint16_t stride,
+                                             const q7_t *bias,
+                                             const uint16_t bias_shift,
+                                             const uint16_t out_shift,
+                                             q7_t *Im_out,
+                                             const uint16_t dim_im_out,
+                                             q15_t *bufferA,
+                                             q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -121,7 +122,7 @@ arm_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
     if (ch_im_in % 4 != 0 || ch_im_out % 2 != 0)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     /*
@@ -337,7 +338,7 @@ arm_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
     if (ch_im_in % 4 != 0 || ch_im_out % 2 != 0)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i = 0; i < ch_im_out; i++)
@@ -372,7 +373,7 @@ arm_status arm_convolve_HWC_q7_fast(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast_nonsquare.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_HWC_q7_fast_nonsquare.c
  * Description:  Fast Q7 version of convolution (non-sqaure shape)
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -63,7 +63,8 @@
  * @param[in,out]   bufferA      pointer to buffer space for input
  * @param[in,out]   bufferB      pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is the version with full list of optimization tricks, but with
  * some constraints:
@@ -71,26 +72,26 @@
  *   ch_im_out is multiple of 2
  */
 
-arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
-                                              const uint16_t dim_im_in_x,
-                                              const uint16_t dim_im_in_y,
-                                              const uint16_t ch_im_in,
-                                              const q7_t *wt,
-                                              const uint16_t ch_im_out,
-                                              const uint16_t dim_kernel_x,
-                                              const uint16_t dim_kernel_y,
-                                              const uint16_t padding_x,
-                                              const uint16_t padding_y,
-                                              const uint16_t stride_x,
-                                              const uint16_t stride_y,
-                                              const q7_t *bias,
-                                              const uint16_t bias_shift,
-                                              const uint16_t out_shift,
-                                              q7_t *Im_out,
-                                              const uint16_t dim_im_out_x,
-                                              const uint16_t dim_im_out_y,
-                                              q15_t *bufferA,
-                                              q7_t *bufferB)
+arm_cmsis_nn_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
+                                                       const uint16_t dim_im_in_x,
+                                                       const uint16_t dim_im_in_y,
+                                                       const uint16_t ch_im_in,
+                                                       const q7_t *wt,
+                                                       const uint16_t ch_im_out,
+                                                       const uint16_t dim_kernel_x,
+                                                       const uint16_t dim_kernel_y,
+                                                       const uint16_t padding_x,
+                                                       const uint16_t padding_y,
+                                                       const uint16_t stride_x,
+                                                       const uint16_t stride_y,
+                                                       const q7_t *bias,
+                                                       const uint16_t bias_shift,
+                                                       const uint16_t out_shift,
+                                                       q7_t *Im_out,
+                                                       const uint16_t dim_im_out_x,
+                                                       const uint16_t dim_im_out_y,
+                                                       q15_t *bufferA,
+                                                       q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -109,7 +110,7 @@ arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
     if (ch_im_in % 4 != 0 || ch_im_out % 2 != 0)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     /*
@@ -334,7 +335,7 @@ arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
     if (ch_im_in % 4 != 0 || ch_im_out % 2 != 0)
     {
         /* check if the input dimension meets the constraints */
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i = 0; i < ch_im_out; i++)
@@ -370,7 +371,7 @@ arm_status arm_convolve_HWC_q7_fast_nonsquare(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_fast_s16.c
  * Description:  Optimized s16 version of convolution.
  *
- * $Date:        12 August 2021
- * $Revision:    V.1.1.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -48,27 +48,27 @@
  *
  */
 
-arm_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
-                                 const cmsis_nn_conv_params *conv_params,
-                                 const cmsis_nn_per_channel_quant_params *quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q15_t *input_data,
-                                 const cmsis_nn_dims *filter_dims,
-                                 const q7_t *filter_data,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const int64_t *bias_data,
-                                 const cmsis_nn_dims *output_dims,
-                                 q15_t *output_data)
+arm_cmsis_nn_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
+                                          const cmsis_nn_conv_params *conv_params,
+                                          const cmsis_nn_per_channel_quant_params *quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q15_t *input_data,
+                                          const cmsis_nn_dims *filter_dims,
+                                          const q7_t *filter_data,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const int64_t *bias_data,
+                                          const cmsis_nn_dims *output_dims,
+                                          q15_t *output_data)
 {
     (void)bias_dims;
     if (filter_dims->w * filter_dims->h * input_dims->c >= 512)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     if (ctx->buf == NULL && arm_convolve_s8_get_buffer_size(input_dims, filter_dims) > 0)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     q15_t *buffer_a = (q15_t *)ctx->buf;
 
@@ -214,7 +214,7 @@ arm_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
         (void)out_activation_max;
         (void)output_mult;
         (void)output_shift;
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
 #endif
         /* Advance to the next batch */
         input_data += (input_x * input_y * input_ch);
@@ -222,7 +222,7 @@ arm_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
     }
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 int32_t arm_convolve_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s16.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_s16.c
  * Description:  s16 version of convolution using symmetric quantization.
  *
- * $Date:        January 13, 2022
- * $Revision:    V.1.1.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -48,17 +48,17 @@
  *
  */
 
-arm_status arm_convolve_s16(const cmsis_nn_context *ctx,
-                            const cmsis_nn_conv_params *conv_params,
-                            const cmsis_nn_per_channel_quant_params *quant_params,
-                            const cmsis_nn_dims *input_dims,
-                            const q15_t *input_data,
-                            const cmsis_nn_dims *filter_dims,
-                            const q7_t *filter_data,
-                            const cmsis_nn_dims *bias_dims,
-                            const int64_t *bias_data,
-                            const cmsis_nn_dims *output_dims,
-                            q15_t *output_data)
+arm_cmsis_nn_status arm_convolve_s16(const cmsis_nn_context *ctx,
+                                     const cmsis_nn_conv_params *conv_params,
+                                     const cmsis_nn_per_channel_quant_params *quant_params,
+                                     const cmsis_nn_dims *input_dims,
+                                     const q15_t *input_data,
+                                     const cmsis_nn_dims *filter_dims,
+                                     const q7_t *filter_data,
+                                     const cmsis_nn_dims *bias_dims,
+                                     const int64_t *bias_data,
+                                     const cmsis_nn_dims *output_dims,
+                                     q15_t *output_data)
 {
     (void)bias_dims;
     (void)ctx;
@@ -141,7 +141,7 @@ arm_status arm_convolve_s16(const cmsis_nn_context *ctx,
     }
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 int32_t arm_convolve_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_s8.c
  * Description:  s8 version of convolution using symmetric quantization.
  *
- * $Date:        December 14, 2021
- * $Revision:    V.2.1.0
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -48,23 +48,23 @@
  *
  */
 
-arm_status arm_convolve_s8(const cmsis_nn_context *ctx,
-                           const cmsis_nn_conv_params *conv_params,
-                           const cmsis_nn_per_channel_quant_params *quant_params,
-                           const cmsis_nn_dims *input_dims,
-                           const q7_t *input_data,
-                           const cmsis_nn_dims *filter_dims,
-                           const q7_t *filter_data,
-                           const cmsis_nn_dims *bias_dims,
-                           const int32_t *bias_data,
-                           const cmsis_nn_dims *output_dims,
-                           q7_t *output_data)
+arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
+                                    const cmsis_nn_conv_params *conv_params,
+                                    const cmsis_nn_per_channel_quant_params *quant_params,
+                                    const cmsis_nn_dims *input_dims,
+                                    const q7_t *input_data,
+                                    const cmsis_nn_dims *filter_dims,
+                                    const q7_t *filter_data,
+                                    const cmsis_nn_dims *bias_dims,
+                                    const int32_t *bias_data,
+                                    const cmsis_nn_dims *output_dims,
+                                    q7_t *output_data)
 {
     (void)bias_dims;
 
     if (ctx->buf == NULL && arm_convolve_s8_get_buffer_size(input_dims, filter_dims) > 0)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     q15_t *buffer_a = (q15_t *)ctx->buf;
 
@@ -313,7 +313,7 @@ arm_status arm_convolve_s8(const cmsis_nn_context *ctx,
     }
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 int32_t arm_convolve_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s16.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s16.c
@@ -22,8 +22,8 @@
  * Description:  s16 convolution layer wrapper function with the main purpose to call the optimal kernel available in
  * cmsis-nn to perform the convolution.
  *
- * $Date:        13 January 2022
- * $Revision:    V.1.2.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -47,17 +47,17 @@
  *
  */
 
-arm_status arm_convolve_wrapper_s16(const cmsis_nn_context *ctx,
-                                    const cmsis_nn_conv_params *conv_params,
-                                    const cmsis_nn_per_channel_quant_params *quant_params,
-                                    const cmsis_nn_dims *input_dims,
-                                    const q15_t *input_data,
-                                    const cmsis_nn_dims *filter_dims,
-                                    const q7_t *filter_data,
-                                    const cmsis_nn_dims *bias_dims,
-                                    const int64_t *bias_data,
-                                    const cmsis_nn_dims *output_dims,
-                                    q15_t *output_data)
+arm_cmsis_nn_status arm_convolve_wrapper_s16(const cmsis_nn_context *ctx,
+                                             const cmsis_nn_conv_params *conv_params,
+                                             const cmsis_nn_per_channel_quant_params *quant_params,
+                                             const cmsis_nn_dims *input_dims,
+                                             const q15_t *input_data,
+                                             const cmsis_nn_dims *filter_dims,
+                                             const q7_t *filter_data,
+                                             const cmsis_nn_dims *bias_dims,
+                                             const int64_t *bias_data,
+                                             const cmsis_nn_dims *output_dims,
+                                             q15_t *output_data)
 {
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
     if (filter_dims->w * filter_dims->h * input_dims->c < 512 &&

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,8 +22,8 @@
  * Description:  s8 convolution layer wrapper function with the main purpose to call the optimal kernel available in
  * cmsis-nn to perform the convolution.
  *
- * $Date:        02. December 2021
- * $Revision:    V.1.1.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -47,17 +47,17 @@
  *
  */
 
-arm_status arm_convolve_wrapper_s8(const cmsis_nn_context *ctx,
-                                   const cmsis_nn_conv_params *conv_params,
-                                   const cmsis_nn_per_channel_quant_params *quant_params,
-                                   const cmsis_nn_dims *input_dims,
-                                   const q7_t *input_data,
-                                   const cmsis_nn_dims *filter_dims,
-                                   const q7_t *filter_data,
-                                   const cmsis_nn_dims *bias_dims,
-                                   const int32_t *bias_data,
-                                   const cmsis_nn_dims *output_dims,
-                                   q7_t *output_data)
+arm_cmsis_nn_status arm_convolve_wrapper_s8(const cmsis_nn_context *ctx,
+                                            const cmsis_nn_conv_params *conv_params,
+                                            const cmsis_nn_per_channel_quant_params *quant_params,
+                                            const cmsis_nn_dims *input_dims,
+                                            const q7_t *input_data,
+                                            const cmsis_nn_dims *filter_dims,
+                                            const q7_t *filter_data,
+                                            const cmsis_nn_dims *bias_dims,
+                                            const int32_t *bias_data,
+                                            const cmsis_nn_dims *output_dims,
+                                            q7_t *output_data)
 {
     if ((conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (input_dims->c % 4 == 0) &&
         (conv_params->stride.w == 1) && (conv_params->stride.h == 1) && (filter_dims->w == 1) &&

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,8 +22,8 @@
  * Description:  Optimized s8 depthwise convolution function for channel
  *               multiplier of 1 and 3x3 kernel size.
  *
- * $Date:        09. October 2020
- * $Revision:    V.2.0.1
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -49,17 +49,17 @@
  *
  */
 
-arm_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
-                                     const cmsis_nn_dw_conv_params *dw_conv_params,
-                                     const cmsis_nn_per_channel_quant_params *quant_params,
-                                     const cmsis_nn_dims *input_dims,
-                                     const q7_t *input,
-                                     const cmsis_nn_dims *filter_dims,
-                                     const q7_t *kernel,
-                                     const cmsis_nn_dims *bias_dims,
-                                     const int32_t *bias,
-                                     const cmsis_nn_dims *output_dims,
-                                     q7_t *output)
+arm_cmsis_nn_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
+                                              const cmsis_nn_dw_conv_params *dw_conv_params,
+                                              const cmsis_nn_per_channel_quant_params *quant_params,
+                                              const cmsis_nn_dims *input_dims,
+                                              const q7_t *input,
+                                              const cmsis_nn_dims *filter_dims,
+                                              const q7_t *kernel,
+                                              const cmsis_nn_dims *bias_dims,
+                                              const int32_t *bias,
+                                              const cmsis_nn_dims *output_dims,
+                                              q7_t *output)
 {
     (void)ctx;
     (void)bias_dims;
@@ -84,12 +84,12 @@ arm_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
     /* Check input constraints input_ch == output_ch */
     if (input_ch != output_ch)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     /* Check input constraints pad_x <= 1 */
     if (pad_x > 1 || filter_dims->w != 3 || filter_dims->h != 3)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (int32_t in_h = -pad_y, out_h = 0, out_idx = 0; out_h < output_y; in_h += stride_y, ++out_h)
@@ -204,7 +204,7 @@ arm_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
     }
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s16.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_conv_s16.c
  * Description:  s16 version of depthwise convolution.
  *
- * $Date:        26. Jan 2022
- * $Revision:    V.1.0.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -241,17 +241,17 @@ static void depthwise_conv_s16_generic_s16(const int16_t *input,
  *  Refer header file for details.
  *
  */
-arm_status arm_depthwise_conv_s16(const cmsis_nn_context *ctx,
-                                  const cmsis_nn_dw_conv_params *dw_conv_params,
-                                  const cmsis_nn_per_channel_quant_params *quant_params,
-                                  const cmsis_nn_dims *input_dims,
-                                  const q15_t *input,
-                                  const cmsis_nn_dims *filter_dims,
-                                  const q7_t *kernel,
-                                  const cmsis_nn_dims *bias_dims,
-                                  const int64_t *bias,
-                                  const cmsis_nn_dims *output_dims,
-                                  q15_t *output)
+arm_cmsis_nn_status arm_depthwise_conv_s16(const cmsis_nn_context *ctx,
+                                           const cmsis_nn_dw_conv_params *dw_conv_params,
+                                           const cmsis_nn_per_channel_quant_params *quant_params,
+                                           const cmsis_nn_dims *input_dims,
+                                           const q15_t *input,
+                                           const cmsis_nn_dims *filter_dims,
+                                           const q7_t *kernel,
+                                           const cmsis_nn_dims *bias_dims,
+                                           const int64_t *bias,
+                                           const cmsis_nn_dims *output_dims,
+                                           q15_t *output)
 {
     const uint16_t dilation_x = dw_conv_params->dilation.w;
     const uint16_t dilation_y = dw_conv_params->dilation.h;
@@ -284,7 +284,7 @@ arm_status arm_depthwise_conv_s16(const cmsis_nn_context *ctx,
                                    dilation_y);
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_conv_s8.c
  * Description:  s8 version of depthwise convolution.
  *
- * $Date:        30. Dec 2021
- * $Revision:    V.2.7.1
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -262,17 +262,17 @@ static void depthwise_conv_s8_generic(const q7_t *input,
  *  Optimization using DSP extension is not available for the generic case where channel multiplier is > 1.
  *
  */
-arm_status arm_depthwise_conv_s8(const cmsis_nn_context *ctx,
-                                 const cmsis_nn_dw_conv_params *dw_conv_params,
-                                 const cmsis_nn_per_channel_quant_params *quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q7_t *input,
-                                 const cmsis_nn_dims *filter_dims,
-                                 const q7_t *kernel,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const int32_t *bias,
-                                 const cmsis_nn_dims *output_dims,
-                                 q7_t *output)
+arm_cmsis_nn_status arm_depthwise_conv_s8(const cmsis_nn_context *ctx,
+                                          const cmsis_nn_dw_conv_params *dw_conv_params,
+                                          const cmsis_nn_per_channel_quant_params *quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q7_t *input,
+                                          const cmsis_nn_dims *filter_dims,
+                                          const q7_t *kernel,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const int32_t *bias,
+                                          const cmsis_nn_dims *output_dims,
+                                          q7_t *output)
 {
     const uint16_t dilation_x = dw_conv_params->dilation.w;
     const uint16_t dilation_y = dw_conv_params->dilation.h;
@@ -339,7 +339,7 @@ arm_status arm_depthwise_conv_s8(const cmsis_nn_context *ctx,
     }
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,8 +22,8 @@
  * Description:  Optimized s8 depthwise separable convolution function for
  *               channel multiplier of 1.
  *
- * $Date:        January 26, 2021
- * $Revision:    V.2.0.3
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -48,17 +48,17 @@
  *
  */
 
-arm_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
-                                     const cmsis_nn_dw_conv_params *dw_conv_params,
-                                     const cmsis_nn_per_channel_quant_params *quant_params,
-                                     const cmsis_nn_dims *input_dims,
-                                     const q7_t *input,
-                                     const cmsis_nn_dims *filter_dims,
-                                     const q7_t *kernel,
-                                     const cmsis_nn_dims *bias_dims,
-                                     const int32_t *bias,
-                                     const cmsis_nn_dims *output_dims,
-                                     q7_t *output)
+arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
+                                              const cmsis_nn_dw_conv_params *dw_conv_params,
+                                              const cmsis_nn_per_channel_quant_params *quant_params,
+                                              const cmsis_nn_dims *input_dims,
+                                              const q7_t *input,
+                                              const cmsis_nn_dims *filter_dims,
+                                              const q7_t *kernel,
+                                              const cmsis_nn_dims *bias_dims,
+                                              const int32_t *bias,
+                                              const cmsis_nn_dims *output_dims,
+                                              q7_t *output)
 {
 
     const int32_t input_ch = input_dims->c;
@@ -67,12 +67,12 @@ arm_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
     /* Check input constraints input_ch == output_ch */
     if (input_ch != output_ch)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     if (ctx->buf == NULL && arm_depthwise_conv_s8_opt_get_buffer_size(input_dims, filter_dims) > 0)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 #ifdef ARM_MATH_DSP
     const int32_t input_x = input_dims->w;
@@ -411,7 +411,7 @@ arm_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
 #endif /* ARM_MATH_MVEI | ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 int32_t arm_depthwise_conv_s8_opt_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_conv_u8_basic_ver1.c
  * Description:  u8 depthwise convolution function
  *
- * $Date:        09. October 2020
- * $Revision:    V.1.1.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target :  Cortex-M CPUs
  *
@@ -236,38 +236,35 @@ static void depthwise_conv_u8_generic(const uint8_t *input,
  * @param[in]     output_shift  Amount of right-shift for output
  * @param[in]     output_mult   Output multiplier for requantization
  * @return        The function returns one of the following
- *                <code>ARM_MATH_SIZE_MISMATCH</code> - Not supported dimension of tensors
- *                <code>ARM_MATH_SUCCESS</code> - Successful operation
- *                <code>ARM_MATH_ARGUMENT_ERROR</code> - Implementation not available
- *
+ *                <code>ARM_CMSIS_NN_SUCCESS</code> - Successful operation
  *
  */
 
-arm_status arm_depthwise_conv_u8_basic_ver1(const uint8_t *input,
-                                            const uint16_t input_x,
-                                            const uint16_t input_y,
-                                            const uint16_t input_ch,
-                                            const uint8_t *kernel,
-                                            const uint16_t kernel_x,
-                                            const uint16_t kernel_y,
-                                            const int16_t ch_mult,
-                                            const int16_t pad_x,
-                                            const int16_t pad_y,
-                                            const int16_t stride_x,
-                                            const int16_t stride_y,
-                                            const int16_t dilation_x,
-                                            const int16_t dilation_y,
-                                            const int32_t *bias,
-                                            const int32_t input_offset,
-                                            const int32_t filter_offset,
-                                            const int32_t output_offset,
-                                            uint8_t *output,
-                                            const uint16_t output_x,
-                                            const uint16_t output_y,
-                                            const int32_t output_activation_min,
-                                            const int32_t output_activation_max,
-                                            const int32_t output_shift,
-                                            const int32_t output_mult)
+arm_cmsis_nn_status arm_depthwise_conv_u8_basic_ver1(const uint8_t *input,
+                                                     const uint16_t input_x,
+                                                     const uint16_t input_y,
+                                                     const uint16_t input_ch,
+                                                     const uint8_t *kernel,
+                                                     const uint16_t kernel_x,
+                                                     const uint16_t kernel_y,
+                                                     const int16_t ch_mult,
+                                                     const int16_t pad_x,
+                                                     const int16_t pad_y,
+                                                     const int16_t stride_x,
+                                                     const int16_t stride_y,
+                                                     const int16_t dilation_x,
+                                                     const int16_t dilation_y,
+                                                     const int32_t *bias,
+                                                     const int32_t input_offset,
+                                                     const int32_t filter_offset,
+                                                     const int32_t output_offset,
+                                                     uint8_t *output,
+                                                     const uint16_t output_x,
+                                                     const uint16_t output_y,
+                                                     const int32_t output_activation_min,
+                                                     const int32_t output_activation_max,
+                                                     const int32_t output_shift,
+                                                     const int32_t output_mult)
 {
     (void)dilation_x;
     (void)dilation_y;
@@ -328,7 +325,7 @@ arm_status arm_depthwise_conv_u8_basic_ver1(const uint8_t *input,
     }
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,8 +22,8 @@
  * Description:  Wrapper API to select appropriate depthwise conv API based
  *               on dimensions.
  *
- * $Date:        20. Dec 2021
- * $Revision:    V.1.4.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -46,19 +46,19 @@
  *  Refer header file for details.
  *
  */
-arm_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
-                                         const cmsis_nn_dw_conv_params *dw_conv_params,
-                                         const cmsis_nn_per_channel_quant_params *quant_params,
-                                         const cmsis_nn_dims *input_dims,
-                                         const q7_t *input,
-                                         const cmsis_nn_dims *filter_dims,
-                                         const q7_t *filter,
-                                         const cmsis_nn_dims *bias_dims,
-                                         const int32_t *bias,
-                                         const cmsis_nn_dims *output_dims,
-                                         q7_t *output)
+arm_cmsis_nn_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
+                                                  const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                  const cmsis_nn_per_channel_quant_params *quant_params,
+                                                  const cmsis_nn_dims *input_dims,
+                                                  const q7_t *input,
+                                                  const cmsis_nn_dims *filter_dims,
+                                                  const q7_t *filter,
+                                                  const cmsis_nn_dims *bias_dims,
+                                                  const int32_t *bias,
+                                                  const cmsis_nn_dims *output_dims,
+                                                  q7_t *output)
 {
-    arm_status status = ARM_MATH_SUCCESS;
+    arm_cmsis_nn_status status = ARM_CMSIS_NN_SUCCESS;
     if (1 == dw_conv_params->ch_mult && input_dims->n == 1 && dw_conv_params->dilation.w == 1 &&
         dw_conv_params->dilation.h == 1)
     {

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_separable_conv_HWC_q7.c
  * Description:  Q7 depthwise separable convolution function
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -58,7 +58,8 @@
  * @param[in,out]   bufferA     pointer to buffer space for input
  * @param[in,out]   bufferB     pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * @details
  *
@@ -79,21 +80,21 @@
  * Outer loop: loop over different output (x, y)
  */
 
-arm_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
-                                               const uint16_t dim_im_in,
-                                               const uint16_t ch_im_in,
-                                               const q7_t *wt,
-                                               const uint16_t ch_im_out,
-                                               const uint16_t dim_kernel,
-                                               const uint16_t padding,
-                                               const uint16_t stride,
-                                               const q7_t *bias,
-                                               const uint16_t bias_shift,
-                                               const uint16_t out_shift,
-                                               q7_t *Im_out,
-                                               const uint16_t dim_im_out,
-                                               q15_t *bufferA,
-                                               q7_t *bufferB)
+arm_cmsis_nn_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
+                                                        const uint16_t dim_im_in,
+                                                        const uint16_t ch_im_in,
+                                                        const q7_t *wt,
+                                                        const uint16_t ch_im_out,
+                                                        const uint16_t dim_kernel,
+                                                        const uint16_t padding,
+                                                        const uint16_t stride,
+                                                        const q7_t *bias,
+                                                        const uint16_t bias_shift,
+                                                        const uint16_t out_shift,
+                                                        q7_t *Im_out,
+                                                        const uint16_t dim_im_out,
+                                                        q15_t *bufferA,
+                                                        q7_t *bufferB)
 {
     (void)bufferB;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -111,7 +112,7 @@ arm_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
     /* do some checking here, basically ch_im_in == ch_im_out */
     if (ch_im_in != ch_im_out)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i_out_y = 0; i_out_y < dim_im_out; i_out_y++)
@@ -381,7 +382,7 @@ arm_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
     /* do some checking here, basically ch_im_in == ch_im_out */
     if (ch_im_in != ch_im_out)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i_out_y = 0; i_out_y < dim_im_out; i_out_y++)
@@ -414,7 +415,7 @@ arm_status arm_depthwise_separable_conv_HWC_q7(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7_nonsquare.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7_nonsquare.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_separable_conv_HWC_q7_nonsquare.c
  * Description:  Q7 depthwise separable convolution function (non-square shape)
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -63,7 +63,8 @@
  * @param[in,out]   bufferA       pointer to buffer space for input
  * @param[in,out]   bufferB       pointer to buffer space for output
  * @return     The function returns either
- * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+ * <code>ARM_CMSIS_NN_ARG_ERROR</code> or <code>ARM_CMSIS_NN_SUCCESS</code> based on the outcome of input arguments
+ * constraints checking.
  *
  * This function is the version with full list of optimization tricks, but with
  * some constraints:
@@ -71,26 +72,26 @@
  *
  */
 
-arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
-                                                         const uint16_t dim_im_in_x,
-                                                         const uint16_t dim_im_in_y,
-                                                         const uint16_t ch_im_in,
-                                                         const q7_t *wt,
-                                                         const uint16_t ch_im_out,
-                                                         const uint16_t dim_kernel_x,
-                                                         const uint16_t dim_kernel_y,
-                                                         const uint16_t padding_x,
-                                                         const uint16_t padding_y,
-                                                         const uint16_t stride_x,
-                                                         const uint16_t stride_y,
-                                                         const q7_t *bias,
-                                                         const uint16_t bias_shift,
-                                                         const uint16_t out_shift,
-                                                         q7_t *Im_out,
-                                                         const uint16_t dim_im_out_x,
-                                                         const uint16_t dim_im_out_y,
-                                                         q15_t *bufferA,
-                                                         q7_t *bufferB)
+arm_cmsis_nn_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
+                                                                  const uint16_t dim_im_in_x,
+                                                                  const uint16_t dim_im_in_y,
+                                                                  const uint16_t ch_im_in,
+                                                                  const q7_t *wt,
+                                                                  const uint16_t ch_im_out,
+                                                                  const uint16_t dim_kernel_x,
+                                                                  const uint16_t dim_kernel_y,
+                                                                  const uint16_t padding_x,
+                                                                  const uint16_t padding_y,
+                                                                  const uint16_t stride_x,
+                                                                  const uint16_t stride_y,
+                                                                  const q7_t *bias,
+                                                                  const uint16_t bias_shift,
+                                                                  const uint16_t out_shift,
+                                                                  q7_t *Im_out,
+                                                                  const uint16_t dim_im_out_x,
+                                                                  const uint16_t dim_im_out_y,
+                                                                  q15_t *bufferA,
+                                                                  q7_t *bufferB)
 {
 
     (void)bufferB;
@@ -119,7 +120,7 @@ arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
     /* do some checking here, basically ch_im_in == ch_im_out */
     if (ch_im_in != ch_im_out)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i_out_y = 0; i_out_y < dim_im_out_y; i_out_y++)
@@ -386,7 +387,7 @@ arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
     /* do some checking here, basically ch_im_in == ch_im_out */
     if (ch_im_in != ch_im_out)
     {
-        return ARM_MATH_SIZE_MISMATCH;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (i_out_y = 0; i_out_y < dim_im_out_y; i_out_y++)
@@ -419,7 +420,7 @@ arm_status arm_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_mat_q7_vec_q15.c
  * Description:  Mixed Q15-Q7 fully-connected layer function
  *
- * $Date:        20. July 2021
- * $Revision:    V.1.1.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -51,7 +51,7 @@
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *
@@ -65,15 +65,15 @@
  *
  */
 
-arm_status arm_fully_connected_mat_q7_vec_q15(const q15_t *pV,
-                                              const q7_t *pM,
-                                              const uint16_t dim_vec,
-                                              const uint16_t num_of_rows,
-                                              const uint16_t bias_shift,
-                                              const uint16_t out_shift,
-                                              const q7_t *bias,
-                                              q15_t *pOut,
-                                              q15_t *vec_buffer)
+arm_cmsis_nn_status arm_fully_connected_mat_q7_vec_q15(const q15_t *pV,
+                                                       const q7_t *pM,
+                                                       const uint16_t dim_vec,
+                                                       const uint16_t num_of_rows,
+                                                       const uint16_t bias_shift,
+                                                       const uint16_t out_shift,
+                                                       const q7_t *bias,
+                                                       q15_t *pOut,
+                                                       q15_t *vec_buffer)
 {
     (void)vec_buffer;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -188,8 +188,8 @@ arm_status arm_fully_connected_mat_q7_vec_q15(const q15_t *pV,
 
 #endif /* ARM_MATH_DSP */
 
-    /* Return to ARM_MATH_SUCCESS */
-    return (ARM_MATH_SUCCESS);
+    /* Return to ARM_CMSIS_NN_SUCCESS */
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15_opt.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15_opt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_mat_q7_vec_q15_opt.c
  * Description:  Mixed Q15-Q7 opt fully-connected layer function
  *
- * $Date:        20. July 2021
- * $Revision:    V.1.1.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -51,7 +51,7 @@
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *
@@ -113,15 +113,15 @@
  *
  */
 
-arm_status arm_fully_connected_mat_q7_vec_q15_opt(const q15_t *pV,
-                                                  const q7_t *pM,
-                                                  const uint16_t dim_vec,
-                                                  const uint16_t num_of_rows,
-                                                  const uint16_t bias_shift,
-                                                  const uint16_t out_shift,
-                                                  const q7_t *bias,
-                                                  q15_t *pOut,
-                                                  q15_t *vec_buffer)
+arm_cmsis_nn_status arm_fully_connected_mat_q7_vec_q15_opt(const q15_t *pV,
+                                                           const q7_t *pM,
+                                                           const uint16_t dim_vec,
+                                                           const uint16_t num_of_rows,
+                                                           const uint16_t bias_shift,
+                                                           const uint16_t out_shift,
+                                                           const q7_t *bias,
+                                                           q15_t *pOut,
+                                                           q15_t *vec_buffer)
 {
 
     (void)vec_buffer;
@@ -408,8 +408,8 @@ arm_status arm_fully_connected_mat_q7_vec_q15_opt(const q15_t *pV,
 
 #endif /* ARM_MATH_DSP */
 
-    /* Return to ARM_MATH_SUCCESS */
-    return (ARM_MATH_SUCCESS);
+    /* Return to ARM_CMSIS_NN_SUCCESS */
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_q15.c
  * Description:  Q15 basic fully-connected layer function
  *
- * $Date:        20. July 2021
- * $Revision:    V.1.1.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -51,7 +51,7 @@
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  *
  * @details
@@ -62,15 +62,15 @@
  *
  */
 
-arm_status arm_fully_connected_q15(const q15_t *pV,
-                                   const q15_t *pM,
-                                   const uint16_t dim_vec,
-                                   const uint16_t num_of_rows,
-                                   const uint16_t bias_shift,
-                                   const uint16_t out_shift,
-                                   const q15_t *bias,
-                                   q15_t *pOut,
-                                   q15_t *vec_buffer)
+arm_cmsis_nn_status arm_fully_connected_q15(const q15_t *pV,
+                                            const q15_t *pM,
+                                            const uint16_t dim_vec,
+                                            const uint16_t num_of_rows,
+                                            const uint16_t bias_shift,
+                                            const uint16_t out_shift,
+                                            const q15_t *bias,
+                                            q15_t *pOut,
+                                            q15_t *vec_buffer)
 {
     (void)vec_buffer;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -187,7 +187,7 @@ arm_status arm_fully_connected_q15(const q15_t *pV,
 #endif /* ARM_MATH_DSP */
 
     /* Return to application */
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15_opt.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15_opt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_q15_opt.c
  * Description:  Q15 opt fully-connected layer function
  *
- * $Date:        20. July 2021
- * $Revision:    V.1.1.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -51,7 +51,7 @@
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  *
  * @details
@@ -93,15 +93,15 @@
  *  | a62 | a63 |
  */
 
-arm_status arm_fully_connected_q15_opt(const q15_t *pV,
-                                       const q15_t *pM,
-                                       const uint16_t dim_vec,
-                                       const uint16_t num_of_rows,
-                                       const uint16_t bias_shift,
-                                       const uint16_t out_shift,
-                                       const q15_t *bias,
-                                       q15_t *pOut,
-                                       q15_t *vec_buffer)
+arm_cmsis_nn_status arm_fully_connected_q15_opt(const q15_t *pV,
+                                                const q15_t *pM,
+                                                const uint16_t dim_vec,
+                                                const uint16_t num_of_rows,
+                                                const uint16_t bias_shift,
+                                                const uint16_t out_shift,
+                                                const q15_t *bias,
+                                                q15_t *pOut,
+                                                q15_t *vec_buffer)
 {
     (void)vec_buffer;
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -327,8 +327,8 @@ arm_status arm_fully_connected_q15_opt(const q15_t *pV,
 
 #endif /* ARM_MATH_DSP */
 
-    /* Return to ARM_MATH_SUCCESS */
-    return (ARM_MATH_SUCCESS);
+    /* Return to ARM_CMSIS_NN_SUCCESS */
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_q7.c
  * Description:  Q7 basic fully-connected layer function
  *
- * $Date:        July 20, 2021
- * $Revision:    V.1.1.2
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -51,7 +51,7 @@
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *
@@ -64,15 +64,15 @@
  *
  */
 
-arm_status arm_fully_connected_q7(const q7_t *pV,
-                                  const q7_t *pM,
-                                  const uint16_t dim_vec,
-                                  const uint16_t num_of_rows,
-                                  const uint16_t bias_shift,
-                                  const uint16_t out_shift,
-                                  const q7_t *bias,
-                                  q7_t *pOut,
-                                  q15_t *vec_buffer)
+arm_cmsis_nn_status arm_fully_connected_q7(const q7_t *pV,
+                                           const q7_t *pM,
+                                           const uint16_t dim_vec,
+                                           const uint16_t num_of_rows,
+                                           const uint16_t bias_shift,
+                                           const uint16_t out_shift,
+                                           const q7_t *bias,
+                                           q7_t *pOut,
+                                           q15_t *vec_buffer)
 {
 
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -191,8 +191,8 @@ arm_status arm_fully_connected_q7(const q7_t *pV,
 
 #endif /* ARM_MATH_DSP */
 
-    /* Return to ARM_MATH_SUCCESS */
-    return (ARM_MATH_SUCCESS);
+    /* Return to ARM_CMSIS_NN_SUCCESS */
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7_opt.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7_opt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_q7_opt.c
  * Description:  Q7 basic fully-connected layer function
  *
- * $Date:        20. July 2021
- * $Revision:    V.1.1.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -51,7 +51,7 @@
  * @param[in]       bias        pointer to bias
  * @param[in,out]   pOut        pointer to output vector
  * @param[in,out]   vec_buffer  pointer to buffer space for input
- * @return     The function returns <code>ARM_MATH_SUCCESS</code>
+ * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
  * @details
  *
@@ -125,15 +125,15 @@
  *
  */
 
-arm_status arm_fully_connected_q7_opt(const q7_t *pV,
-                                      const q7_t *pM,
-                                      const uint16_t dim_vec,
-                                      const uint16_t num_of_rows,
-                                      const uint16_t bias_shift,
-                                      const uint16_t out_shift,
-                                      const q7_t *bias,
-                                      q7_t *pOut,
-                                      q15_t *vec_buffer)
+arm_cmsis_nn_status arm_fully_connected_q7_opt(const q7_t *pV,
+                                               const q7_t *pM,
+                                               const uint16_t dim_vec,
+                                               const uint16_t num_of_rows,
+                                               const uint16_t bias_shift,
+                                               const uint16_t out_shift,
+                                               const q7_t *bias,
+                                               q7_t *pOut,
+                                               q15_t *vec_buffer)
 {
 
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
@@ -486,8 +486,8 @@ arm_status arm_fully_connected_q7_opt(const q7_t *pV,
 
 #endif /* ARM_MATH_DSP */
 
-    /* Return to ARM_MATH_SUCCESS */
-    return (ARM_MATH_SUCCESS);
+    /* Return to ARM_CMSIS_NN_SUCCESS */
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s16.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_s16
  * Description:  Fully connected function compatible with TF Lite.
  *
- * $Date:        3. August 2021
- * $Revision:    V.1.0.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M and Cortex-A cores
  *
@@ -46,17 +46,17 @@
  * Refer header file for details.
  *
  */
-arm_status arm_fully_connected_s16(const cmsis_nn_context *ctx,
-                                   const cmsis_nn_fc_params *fc_params,
-                                   const cmsis_nn_per_tensor_quant_params *quant_params,
-                                   const cmsis_nn_dims *input_dims,
-                                   const q15_t *input,
-                                   const cmsis_nn_dims *filter_dims,
-                                   const q7_t *kernel,
-                                   const cmsis_nn_dims *bias_dims,
-                                   const int64_t *bias,
-                                   const cmsis_nn_dims *output_dims,
-                                   q15_t *output)
+arm_cmsis_nn_status arm_fully_connected_s16(const cmsis_nn_context *ctx,
+                                            const cmsis_nn_fc_params *fc_params,
+                                            const cmsis_nn_per_tensor_quant_params *quant_params,
+                                            const cmsis_nn_dims *input_dims,
+                                            const q15_t *input,
+                                            const cmsis_nn_dims *filter_dims,
+                                            const q7_t *kernel,
+                                            const cmsis_nn_dims *bias_dims,
+                                            const int64_t *bias,
+                                            const cmsis_nn_dims *output_dims,
+                                            q15_t *output)
 {
     (void)bias_dims;
     (void)ctx;
@@ -83,7 +83,7 @@ arm_status arm_fully_connected_s16(const cmsis_nn_context *ctx,
         batch_cnt--;
     }
 
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 int32_t arm_fully_connected_s16_get_buffer_size(const cmsis_nn_dims *filter_dims)

--- a/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
+++ b/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_s8
  * Description:  Fully connected function compatible with TF Lite.
  *
- * $Date:        8 April 2022
- * $Revision:    V.3.1.0
+ * $Date:        19 April 2022
+ * $Revision:    V.4.0.0
  *
  * Target Processor:  Cortex-M and Cortex-A cores
  *
@@ -47,17 +47,17 @@
  *
  */
 
-arm_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
-                                  const cmsis_nn_fc_params *fc_params,
-                                  const cmsis_nn_per_tensor_quant_params *quant_params,
-                                  const cmsis_nn_dims *input_dims,
-                                  const q7_t *input,
-                                  const cmsis_nn_dims *filter_dims,
-                                  const q7_t *kernel,
-                                  const cmsis_nn_dims *bias_dims,
-                                  const int32_t *bias,
-                                  const cmsis_nn_dims *output_dims,
-                                  q7_t *output)
+arm_cmsis_nn_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
+                                           const cmsis_nn_fc_params *fc_params,
+                                           const cmsis_nn_per_tensor_quant_params *quant_params,
+                                           const cmsis_nn_dims *input_dims,
+                                           const q7_t *input,
+                                           const cmsis_nn_dims *filter_dims,
+                                           const q7_t *kernel,
+                                           const cmsis_nn_dims *bias_dims,
+                                           const int32_t *bias,
+                                           const cmsis_nn_dims *output_dims,
+                                           q7_t *output)
 {
     (void)bias_dims;
     (void)ctx;
@@ -85,7 +85,7 @@ arm_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
         output += output_dims->c;
         batch_cnt--;
     }
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 int32_t arm_fully_connected_s8_get_buffer_size(const cmsis_nn_dims *filter_dims)

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mul_core_1x_s8.c
  * Description:  General Matrix-multiplication function
  *
- * $Date:        19. April 2022
- * $Revision:    V.1.0.3
+ * $Date:        20 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  * -------------------------------------------------------------------- */
@@ -45,11 +45,11 @@
  *
  */
 
-arm_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
-                                     const int8_t *row_base,
-                                     const int8_t *col_base,
-                                     int32_t *const sum_col,
-                                     int32_t *const output)
+arm_cmsis_nn_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
+                                              const int8_t *row_base,
+                                              const int8_t *col_base,
+                                              int32_t *const sum_col,
+                                              int32_t *const output)
 {
     int32_t acc_n0 = 0;
     int32_t sum_tmp = 0;
@@ -78,7 +78,7 @@ arm_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
 
     *sum_col = sum_tmp;
     *output = acc_n0;
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2020-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_s8_nt_t_s8
  * Description:  Matrix multiplication support function with the right-hand-side (rhs) matrix transposed
  *
- * $Date:        09. October 2020
- * $Revision:    V.1.0.3
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M
  *
@@ -45,19 +45,19 @@
  * Refer header file for details.
  *
  */
-arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
-                                   const q7_t *rhs,
-                                   const q31_t *bias,
-                                   q7_t *dst,
-                                   const int32_t *dst_multipliers,
-                                   const int32_t *dst_shifts,
-                                   const int32_t lhs_rows,
-                                   const int32_t rhs_rows,
-                                   const int32_t rhs_cols,
-                                   const int32_t lhs_offset,
-                                   const int32_t dst_offset,
-                                   const int32_t activation_min,
-                                   const int32_t activation_max)
+arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
+                                            const q7_t *rhs,
+                                            const q31_t *bias,
+                                            q7_t *dst,
+                                            const int32_t *dst_multipliers,
+                                            const int32_t *dst_shifts,
+                                            const int32_t lhs_rows,
+                                            const int32_t rhs_rows,
+                                            const int32_t rhs_cols,
+                                            const int32_t lhs_offset,
+                                            const int32_t dst_offset,
+                                            const int32_t activation_min,
+                                            const int32_t activation_max)
 {
 #if defined(ARM_MATH_DSP)
     const int32_t off0 = rhs_cols - 4;
@@ -574,7 +574,7 @@ arm_status arm_nn_mat_mult_nt_t_s8(const q7_t *lhs,
         }
     }
 #endif
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s16.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_vec_mat_mult_t_s16
  * Description:  s16 vector by matrix (transposed) multiplication
  *
- * $Date:        04. January 2022
- * $Revision:    V.1.2.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M
  *
@@ -44,16 +44,16 @@
  * Refer header file for details.
  *
  */
-arm_status arm_nn_vec_mat_mult_t_s16(const q15_t *lhs,
-                                     const q7_t *rhs,
-                                     const q63_t *bias,
-                                     q15_t *dst,
-                                     const int32_t dst_multiplier,
-                                     const int32_t dst_shift,
-                                     const int32_t rhs_cols,
-                                     const int32_t rhs_rows,
-                                     const int32_t activation_min,
-                                     const int32_t activation_max)
+arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const q15_t *lhs,
+                                              const q7_t *rhs,
+                                              const q63_t *bias,
+                                              q15_t *dst,
+                                              const int32_t dst_multiplier,
+                                              const int32_t dst_shift,
+                                              const int32_t rhs_cols,
+                                              const int32_t rhs_rows,
+                                              const int32_t activation_min,
+                                              const int32_t activation_max)
 {
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
     const int32_t row_loop_cnt = rhs_rows / 2;
@@ -203,7 +203,7 @@ arm_status arm_nn_vec_mat_mult_t_s16(const q15_t *lhs,
     }
 #endif
 
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_vec_mat_mult_t_s8
  * Description:  s8 vector by matrix (transposed) multiplication
  *
- * $Date:        28 April 2022
- * $Revision:    V.3.0.1
+ * $Date:        2 May 2022
+ * $Revision:    V.4.0.1
  *
  * Target Processor:  Cortex-M
  *
@@ -45,20 +45,20 @@
  * Refer header file for details.
  *
  */
-arm_status arm_nn_vec_mat_mult_t_s8(const q7_t *lhs,
-                                    const q7_t *rhs,
-                                    const q31_t *bias,
-                                    q7_t *dst,
-                                    const int32_t lhs_offset,
-                                    const int32_t rhs_offset,
-                                    const int32_t dst_offset,
-                                    const int32_t dst_multiplier,
-                                    const int32_t dst_shift,
-                                    const int32_t rhs_cols,
-                                    const int32_t rhs_rows,
-                                    const int32_t activation_min,
-                                    const int32_t activation_max,
-                                    const int32_t address_offset)
+arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s8(const q7_t *lhs,
+                                             const q7_t *rhs,
+                                             const q31_t *bias,
+                                             q7_t *dst,
+                                             const int32_t lhs_offset,
+                                             const int32_t rhs_offset,
+                                             const int32_t dst_offset,
+                                             const int32_t dst_multiplier,
+                                             const int32_t dst_shift,
+                                             const int32_t rhs_cols,
+                                             const int32_t rhs_rows,
+                                             const int32_t activation_min,
+                                             const int32_t activation_max,
+                                             const int32_t address_offset)
 {
     (void)rhs_offset;
 #if defined(ARM_MATH_MVEI)
@@ -394,7 +394,7 @@ arm_status arm_nn_vec_mat_mult_t_s8(const q7_t *lhs,
         rhs += rhs_cols;
     }
 #endif
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_svdf_s8.c
+++ b/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_svdf_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2021-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,8 +22,8 @@
  * Description:  s8 vector by matrix (transposed) multiplication with
  *               s16 output. Targetted at SVDF operator.
  *
- * $Date:        15. April 2021
- * $Revision:    V.1.0.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M
  *
@@ -46,23 +46,23 @@
  * Refer header file for details.
  *
  */
-arm_status arm_nn_vec_mat_mult_t_svdf_s8(const q7_t *lhs,
-                                         const q7_t *rhs,
-                                         q15_t *dst,
-                                         const int32_t lhs_offset,
-                                         const int32_t rhs_offset,
-                                         const int32_t dst_offset,
-                                         const int32_t dst_multiplier,
-                                         const int32_t dst_shift,
-                                         const int32_t rhs_cols,
-                                         const int32_t rhs_rows,
-                                         const int32_t activation_min,
-                                         const int32_t activation_max)
+arm_cmsis_nn_status arm_nn_vec_mat_mult_t_svdf_s8(const q7_t *lhs,
+                                                  const q7_t *rhs,
+                                                  q15_t *dst,
+                                                  const int32_t lhs_offset,
+                                                  const int32_t rhs_offset,
+                                                  const int32_t dst_offset,
+                                                  const int32_t dst_multiplier,
+                                                  const int32_t dst_shift,
+                                                  const int32_t rhs_cols,
+                                                  const int32_t rhs_rows,
+                                                  const int32_t activation_min,
+                                                  const int32_t activation_max)
 {
     (void)rhs_offset;
     if (rhs_cols < 0 || (NN_Q31_MAX - rhs_cols) < 16 || dst_offset < 0)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     (void)rhs_offset;
@@ -333,7 +333,7 @@ arm_status arm_nn_vec_mat_mult_t_svdf_s8(const q7_t *lhs,
     }
 #endif
 
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s16.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_avgpool_s16.c
  * Description:  Pooling function implementations
  *
- * $Date:        3. February 2022
- * $Revision:    V.1.0.1
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -46,13 +46,13 @@
  * Refer to header file for details.
  *
  */
-arm_status arm_avgpool_s16(const cmsis_nn_context *ctx,
-                           const cmsis_nn_pool_params *pool_params,
-                           const cmsis_nn_dims *input_dims,
-                           const q15_t *src,
-                           const cmsis_nn_dims *filter_dims,
-                           const cmsis_nn_dims *output_dims,
-                           q15_t *dst)
+arm_cmsis_nn_status arm_avgpool_s16(const cmsis_nn_context *ctx,
+                                    const cmsis_nn_pool_params *pool_params,
+                                    const cmsis_nn_dims *input_dims,
+                                    const q15_t *src,
+                                    const cmsis_nn_dims *filter_dims,
+                                    const cmsis_nn_dims *output_dims,
+                                    q15_t *dst)
 {
     (void)ctx;
     const int32_t input_y = input_dims->h;
@@ -101,7 +101,7 @@ arm_status arm_avgpool_s16(const cmsis_nn_context *ctx,
                 // Prevent static code issue DIVIDE_BY_ZERO.
                 if (count == 0)
                 {
-                    return ARM_MATH_ARGUMENT_ERROR;
+                    return ARM_CMSIS_NN_ARG_ERROR;
                 }
 
                 sum = sum > 0 ? (sum + count / 2) / count : (sum - count / 2) / count;
@@ -113,7 +113,7 @@ arm_status arm_avgpool_s16(const cmsis_nn_context *ctx,
         }
     }
 
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 int32_t arm_avgpool_s16_get_buffer_size(const int output_x, const int ch_src)

--- a/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_avgpool_s8.c
  * Description:  Pooling function implementations
  *
- * $Date:        01. March 2021
- * $Revision:    V.2.0.4
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -78,13 +78,13 @@ static void scale_q31_to_q7_and_clamp(const q31_t *buffer,
 
 #if defined(ARM_MATH_MVEI)
 
-arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
-                          const cmsis_nn_pool_params *pool_params,
-                          const cmsis_nn_dims *input_dims,
-                          const q7_t *src,
-                          const cmsis_nn_dims *filter_dims,
-                          const cmsis_nn_dims *output_dims,
-                          q7_t *dst)
+arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
+                                   const cmsis_nn_pool_params *pool_params,
+                                   const cmsis_nn_dims *input_dims,
+                                   const q7_t *src,
+                                   const cmsis_nn_dims *filter_dims,
+                                   const cmsis_nn_dims *output_dims,
+                                   q7_t *dst)
 {
     (void)ctx;
     const int32_t input_y = input_dims->h;
@@ -167,7 +167,7 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
                 // Prevent static code issue DIVIDE_BY_ZERO.
                 if (count == 0)
                 {
-                    return ARM_MATH_ARGUMENT_ERROR;
+                    return ARM_CMSIS_NN_ARG_ERROR;
                 }
 
                 sumV1[0] = sumV1[0] > 0 ? (sumV1[0] + count / 2) / count : (sumV1[0] - count / 2) / count;
@@ -236,7 +236,7 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
                 // Prevent static code issue DIVIDE_BY_ZERO.
                 if (count == 0)
                 {
-                    return ARM_MATH_ARGUMENT_ERROR;
+                    return ARM_CMSIS_NN_ARG_ERROR;
                 }
 
                 sum = sum > 0 ? (sum + count / 2) / count : (sum - count / 2) / count;
@@ -250,17 +250,17 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
             }
         }
     }
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 #else
-arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
-                          const cmsis_nn_pool_params *pool_params,
-                          const cmsis_nn_dims *input_dims,
-                          const q7_t *src,
-                          const cmsis_nn_dims *filter_dims,
-                          const cmsis_nn_dims *output_dims,
-                          q7_t *dst)
+arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
+                                   const cmsis_nn_pool_params *pool_params,
+                                   const cmsis_nn_dims *input_dims,
+                                   const q7_t *src,
+                                   const cmsis_nn_dims *filter_dims,
+                                   const cmsis_nn_dims *output_dims,
+                                   q7_t *dst)
 {
     const int32_t input_y = input_dims->h;
     const int32_t input_x = input_dims->w;
@@ -278,7 +278,7 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
 
     if (ctx->buf == NULL && arm_avgpool_s8_get_buffer_size(output_dims->w, input_dims->c))
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     q31_t *buffer = (q31_t *)ctx->buf;
 
@@ -329,7 +329,7 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
             // Prevent static code issue DIVIDE_BY_ZERO.
             if (count == 0)
             {
-                return ARM_MATH_ARGUMENT_ERROR;
+                return ARM_CMSIS_NN_ARG_ERROR;
             }
 
             scale_q31_to_q7_and_clamp(buffer, dst, ch_src, count, act_min, act_max);
@@ -367,7 +367,7 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
                 // Prevent static code issue DIVIDE_BY_ZERO.
                 if (count == 0)
                 {
-                    return ARM_MATH_ARGUMENT_ERROR;
+                    return ARM_CMSIS_NN_ARG_ERROR;
                 }
 
                 sum = sum > 0 ? (sum + count / 2) / count : (sum - count / 2) / count;
@@ -380,7 +380,7 @@ arm_status arm_avgpool_s8(const cmsis_nn_context *ctx,
     }
 
 #endif
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 #endif /* ARM_MATH_MVEI */

--- a/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s16.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_max_pool_s16.c
  * Description:  Pooling function implementations
  *
- * $Date:        24. January 2022
- * $Revision:    V.1.0.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -110,13 +110,13 @@ static void clamp_output(int16_t *source, int32_t length, const int16_t act_min,
  *
  */
 
-arm_status arm_max_pool_s16(const cmsis_nn_context *ctx,
-                            const cmsis_nn_pool_params *pool_params,
-                            const cmsis_nn_dims *input_dims,
-                            const int16_t *src,
-                            const cmsis_nn_dims *filter_dims,
-                            const cmsis_nn_dims *output_dims,
-                            int16_t *dst)
+arm_cmsis_nn_status arm_max_pool_s16(const cmsis_nn_context *ctx,
+                                     const cmsis_nn_pool_params *pool_params,
+                                     const cmsis_nn_dims *input_dims,
+                                     const int16_t *src,
+                                     const cmsis_nn_dims *filter_dims,
+                                     const cmsis_nn_dims *output_dims,
+                                     int16_t *dst)
 {
     const int32_t input_y = input_dims->h;
     const int32_t input_x = input_dims->w;
@@ -172,7 +172,7 @@ arm_status arm_max_pool_s16(const cmsis_nn_context *ctx,
 
     clamp_output(dst_base, output_x * output_y * channel_in, act_min, act_max);
 
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8.c
+++ b/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_max_pool_s8.c
  * Description:  Pooling function implementations
  *
- * $Date:        20. July 2021
- * $Revision:    V.2.0.3
+ * $Date:        19 April 2022
+ * $Revision:    V.3.0.0
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -159,13 +159,13 @@ static void clamp_output(q7_t *source, int32_t length, const int32_t act_min, co
  *
  */
 
-arm_status arm_max_pool_s8(const cmsis_nn_context *ctx,
-                           const cmsis_nn_pool_params *pool_params,
-                           const cmsis_nn_dims *input_dims,
-                           const q7_t *src,
-                           const cmsis_nn_dims *filter_dims,
-                           const cmsis_nn_dims *output_dims,
-                           q7_t *dst)
+arm_cmsis_nn_status arm_max_pool_s8(const cmsis_nn_context *ctx,
+                                    const cmsis_nn_pool_params *pool_params,
+                                    const cmsis_nn_dims *input_dims,
+                                    const q7_t *src,
+                                    const cmsis_nn_dims *filter_dims,
+                                    const cmsis_nn_dims *output_dims,
+                                    q7_t *dst)
 {
     const int32_t input_y = input_dims->h;
     const int32_t input_x = input_dims->w;
@@ -221,7 +221,7 @@ arm_status arm_max_pool_s8(const cmsis_nn_context *ctx,
 
     clamp_output(dst_base, output_x * output_y * channel_in, act_min, act_max);
 
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Source/SVDFunctions/arm_svdf_s8.c
+++ b/CMSIS/NN/Source/SVDFunctions/arm_svdf_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_svdf_s8.c
  * Description:  S8 basic SVDF layer function
  *
- * $Date:        28 April 2022
- * $Revision:    V.3.0.1
+ * $Date:        4 May 2022
+ * $Revision:    V.4.0.1
  *
  * Target Processor:  Cortex-M processors
  *
@@ -47,23 +47,23 @@
  *
  */
 
-arm_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
-                       const cmsis_nn_context *output_ctx,
-                       const cmsis_nn_svdf_params *svdf_params,
-                       const cmsis_nn_per_tensor_quant_params *input_quant_params,
-                       const cmsis_nn_per_tensor_quant_params *output_quant_params,
-                       const cmsis_nn_dims *input_dims,
-                       const q7_t *input_data,
-                       const cmsis_nn_dims *state_dims,
-                       q7_t *state_data,
-                       const cmsis_nn_dims *weights_feature_dims,
-                       const q7_t *weights_feature_data,
-                       const cmsis_nn_dims *weights_time_dims,
-                       const q7_t *weights_time_data,
-                       const cmsis_nn_dims *bias_dims,
-                       const q31_t *bias_data,
-                       const cmsis_nn_dims *output_dims,
-                       q7_t *output_data)
+arm_cmsis_nn_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
+                                const cmsis_nn_context *output_ctx,
+                                const cmsis_nn_svdf_params *svdf_params,
+                                const cmsis_nn_per_tensor_quant_params *input_quant_params,
+                                const cmsis_nn_per_tensor_quant_params *output_quant_params,
+                                const cmsis_nn_dims *input_dims,
+                                const q7_t *input_data,
+                                const cmsis_nn_dims *state_dims,
+                                q7_t *state_data,
+                                const cmsis_nn_dims *weights_feature_dims,
+                                const q7_t *weights_feature_data,
+                                const cmsis_nn_dims *weights_time_dims,
+                                const q7_t *weights_time_data,
+                                const cmsis_nn_dims *bias_dims,
+                                const q31_t *bias_data,
+                                const cmsis_nn_dims *output_dims,
+                                q7_t *output_data)
 {
     (void)bias_dims;
     (void)state_dims;
@@ -89,13 +89,13 @@ arm_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
 
     if (input_ctx->buf == NULL)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     q31_t *buffer_a = (q31_t *)input_ctx->buf;
 
     if (output_ctx->buf == NULL)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     q31_t *buffer_b = (q31_t *)output_ctx->buf;
 
@@ -111,22 +111,22 @@ arm_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
         const q7_t *weight = weights_feature_data;
         const q7_t *input = input_data + i_batch * input_height;
 
-        arm_status res = arm_nn_vec_mat_mult_t_s8(input,
-                                                  weight,
-                                                  NULL,
-                                                  res_ptr,
-                                                  -zp_in,
-                                                  0,
-                                                  0,
-                                                  multiplier_in,
-                                                  shift_in,
-                                                  input_height,
-                                                  feature_batches,
-                                                  in_activation_min,
-                                                  in_activation_max,
-                                                  time_batches);
+        arm_cmsis_nn_status res = arm_nn_vec_mat_mult_t_s8(input,
+                                                           weight,
+                                                           NULL,
+                                                           res_ptr,
+                                                           -zp_in,
+                                                           0,
+                                                           0,
+                                                           multiplier_in,
+                                                           shift_in,
+                                                           input_height,
+                                                           feature_batches,
+                                                           in_activation_min,
+                                                           in_activation_max,
+                                                           time_batches);
 
-        if (res != ARM_MATH_SUCCESS)
+        if (res != ARM_CMSIS_NN_SUCCESS)
         {
             return res;
         }
@@ -263,7 +263,7 @@ arm_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
     }
 #endif
 
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/SVDFunctions/arm_svdf_state_s16_s8.c
+++ b/CMSIS/NN/Source/SVDFunctions/arm_svdf_state_s16_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_svdf_s8.c
  * Description:  S8 basic SVDF layer function with s16 state tensor
  *
- * $Date:        28 April 2022
- * $Revision:    V.1.0.1
+ * $Date:        4 May 2022
+ * $Revision:    V.2.0.1
  *
  * Target Processor:  Cortex-M processors
  *
@@ -47,23 +47,23 @@
  *
  */
 
-arm_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
-                                 const cmsis_nn_context *output_ctx,
-                                 const cmsis_nn_svdf_params *svdf_params,
-                                 const cmsis_nn_per_tensor_quant_params *input_quant_params,
-                                 const cmsis_nn_per_tensor_quant_params *output_quant_params,
-                                 const cmsis_nn_dims *input_dims,
-                                 const q7_t *input_data,
-                                 const cmsis_nn_dims *state_dims,
-                                 q15_t *state_data,
-                                 const cmsis_nn_dims *weights_feature_dims,
-                                 const q7_t *weights_feature_data,
-                                 const cmsis_nn_dims *weights_time_dims,
-                                 const q15_t *weights_time_data,
-                                 const cmsis_nn_dims *bias_dims,
-                                 const q31_t *bias_data,
-                                 const cmsis_nn_dims *output_dims,
-                                 q7_t *output_data)
+arm_cmsis_nn_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
+                                          const cmsis_nn_context *output_ctx,
+                                          const cmsis_nn_svdf_params *svdf_params,
+                                          const cmsis_nn_per_tensor_quant_params *input_quant_params,
+                                          const cmsis_nn_per_tensor_quant_params *output_quant_params,
+                                          const cmsis_nn_dims *input_dims,
+                                          const q7_t *input_data,
+                                          const cmsis_nn_dims *state_dims,
+                                          q15_t *state_data,
+                                          const cmsis_nn_dims *weights_feature_dims,
+                                          const q7_t *weights_feature_data,
+                                          const cmsis_nn_dims *weights_time_dims,
+                                          const q15_t *weights_time_data,
+                                          const cmsis_nn_dims *bias_dims,
+                                          const q31_t *bias_data,
+                                          const cmsis_nn_dims *output_dims,
+                                          q7_t *output_data)
 {
     (void)bias_dims;
     (void)state_dims;
@@ -89,13 +89,13 @@ arm_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
 
     if (input_ctx->buf == NULL)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     q31_t *buffer_a = (q31_t *)input_ctx->buf;
 
     if (output_ctx->buf == NULL)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
     q31_t *buffer_b = (q31_t *)output_ctx->buf;
 
@@ -111,20 +111,20 @@ arm_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
         const q7_t *weight = weights_feature_data;
         const q7_t *input = input_data + i_batch * input_height;
 
-        arm_status res = arm_nn_vec_mat_mult_t_svdf_s8(input,
-                                                       weight,
-                                                       res_ptr,
-                                                       -zp_in,
-                                                       0,
-                                                       time_batches,
-                                                       multiplier_in,
-                                                       shift_in,
-                                                       input_height,
-                                                       feature_batches,
-                                                       in_activation_min,
-                                                       in_activation_max);
+        arm_cmsis_nn_status res = arm_nn_vec_mat_mult_t_svdf_s8(input,
+                                                                weight,
+                                                                res_ptr,
+                                                                -zp_in,
+                                                                0,
+                                                                time_batches,
+                                                                multiplier_in,
+                                                                shift_in,
+                                                                input_height,
+                                                                feature_batches,
+                                                                in_activation_min,
+                                                                in_activation_max);
 
-        if (res != ARM_MATH_SUCCESS)
+        if (res != ARM_CMSIS_NN_SUCCESS)
         {
             return res;
         }
@@ -259,7 +259,7 @@ arm_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
     }
 #endif
 
-    return (ARM_MATH_SUCCESS);
+    return (ARM_CMSIS_NN_SUCCESS);
 }
 
 /**

--- a/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_s16.c
+++ b/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_softmax_s16.c
  * Description:  S16 softmax function
  *
- * $Date:        9 March 2022
- * $Revision:    V.1.0.0
+ * $Date:        19 April 2022
+ * $Revision:    V.2.0.0
  *
  * Target Processor:  Cortex-M cores
  *
@@ -36,20 +36,20 @@
  * @{
  */
 
-arm_status arm_softmax_s16(const int16_t *input,
-                           const int32_t num_rows,
-                           const int32_t row_size,
-                           const int32_t mult,
-                           const int32_t shift,
-                           const cmsis_nn_softmax_lut_s16 *softmax_params,
-                           int16_t *output)
+arm_cmsis_nn_status arm_softmax_s16(const int16_t *input,
+                                    const int32_t num_rows,
+                                    const int32_t row_size,
+                                    const int32_t mult,
+                                    const int32_t shift,
+                                    const cmsis_nn_softmax_lut_s16 *softmax_params,
+                                    int16_t *output)
 {
     int32_t col = 0;
     int32_t row_idx;
 
     if (softmax_params->exp_lut == NULL || softmax_params->one_by_one_lut == NULL)
     {
-        return ARM_MATH_ARGUMENT_ERROR;
+        return ARM_CMSIS_NN_ARG_ERROR;
     }
 
     for (row_idx = 0; row_idx < num_rows; ++row_idx)
@@ -114,7 +114,7 @@ arm_status arm_softmax_s16(const int16_t *input,
         input += row_size;
     }
 
-    return ARM_MATH_SUCCESS;
+    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_avgpool_s16/test_arm_avgpool_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_avgpool_s16/test_arm_avgpool_s16.c
@@ -24,7 +24,7 @@
 
 void avgpooling_int16_arm_avgpool_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q15_t output[AVGPOOLING_INT16_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -56,7 +56,7 @@ void avgpooling_int16_arm_avgpool_s16(void)
     ctx.size = arm_avgpool_s16_get_buffer_size(AVGPOOLING_INT16_OUTPUT_W, AVGPOOLING_INT16_IN_CH);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result =
+    arm_cmsis_nn_status result =
         arm_avgpool_s16(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
     free(ctx.buf);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_avgpool_s8/test_arm_avgpool_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_avgpool_s8/test_arm_avgpool_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,7 +29,7 @@
 
 void avgpooling_arm_avgpool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[AVGPOOLING_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -61,7 +61,8 @@ void avgpooling_arm_avgpool_s8(void)
     ctx.size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_OUTPUT_W, AVGPOOLING_IN_CH);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
+    arm_cmsis_nn_status result =
+        arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -70,7 +71,7 @@ void avgpooling_arm_avgpool_s8(void)
 
 void avgpooling_1_arm_avgpool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[AVGPOOLING_1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -102,7 +103,8 @@ void avgpooling_1_arm_avgpool_s8(void)
     ctx.size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_1_OUTPUT_W, AVGPOOLING_1_IN_CH);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
+    arm_cmsis_nn_status result =
+        arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -111,7 +113,7 @@ void avgpooling_1_arm_avgpool_s8(void)
 
 void avgpooling_2_arm_avgpool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[AVGPOOLING_2_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -143,7 +145,8 @@ void avgpooling_2_arm_avgpool_s8(void)
     ctx.size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_2_OUTPUT_W, AVGPOOLING_2_IN_CH);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
+    arm_cmsis_nn_status result =
+        arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -152,7 +155,7 @@ void avgpooling_2_arm_avgpool_s8(void)
 
 void avgpooling_3_arm_avgpool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[AVGPOOLING_3_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -184,7 +187,8 @@ void avgpooling_3_arm_avgpool_s8(void)
     ctx.size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_3_OUTPUT_W, AVGPOOLING_3_IN_CH);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
+    arm_cmsis_nn_status result =
+        arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -193,7 +197,7 @@ void avgpooling_3_arm_avgpool_s8(void)
 
 void avgpooling_4_arm_avgpool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[AVGPOOLING_4_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -225,7 +229,8 @@ void avgpooling_4_arm_avgpool_s8(void)
     ctx.size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_4_OUTPUT_W, AVGPOOLING_4_IN_CH);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
+    arm_cmsis_nn_status result =
+        arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -234,7 +239,7 @@ void avgpooling_4_arm_avgpool_s8(void)
 
 void avgpooling_5_arm_avgpool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[AVGPOOLING_5_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -266,7 +271,8 @@ void avgpooling_5_arm_avgpool_s8(void)
     ctx.size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_5_OUTPUT_W, AVGPOOLING_5_IN_CH);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
+    arm_cmsis_nn_status result =
+        arm_avgpool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/test_arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/test_arm_convolve_1x1_s8_fast.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@
 
 void kernel1x1_arm_convolve_1x1_s8_fast(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[KERNEL1X1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -65,17 +65,17 @@ void kernel1x1_arm_convolve_1x1_s8_fast(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_1x1_s8_fast(&ctx,
-                                                 &conv_params,
-                                                 &quant_params,
-                                                 &input_dims,
-                                                 input_data,
-                                                 &filter_dims,
-                                                 kernel1x1_weights,
-                                                 &bias_dims,
-                                                 bias_data,
-                                                 &output_dims,
-                                                 output);
+    arm_cmsis_nn_status result = arm_convolve_1x1_s8_fast(&ctx,
+                                                          &conv_params,
+                                                          &quant_params,
+                                                          &input_dims,
+                                                          input_data,
+                                                          &filter_dims,
+                                                          kernel1x1_weights,
+                                                          &bias_dims,
+                                                          bias_data,
+                                                          &output_dims,
+                                                          output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/test_arm_convolve_fast_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/test_arm_convolve_fast_s16.c
@@ -70,20 +70,20 @@ void int16xint8_arm_convolve_fast_s16(void)
     int buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_wrapper_s16(&ctx,
-                                                 &conv_params,
-                                                 &quant_params,
-                                                 &input_dims,
-                                                 input_data,
-                                                 &filter_dims,
-                                                 kernel_data,
-                                                 &bias_dims,
-                                                 bias_data,
-                                                 &output_dims,
-                                                 output);
+    arm_cmsis_nn_status result = arm_convolve_wrapper_s16(&ctx,
+                                                          &conv_params,
+                                                          &quant_params,
+                                                          &input_dims,
+                                                          input_data,
+                                                          &filter_dims,
+                                                          kernel_data,
+                                                          &bias_dims,
+                                                          bias_data,
+                                                          &output_dims,
+                                                          output);
     free(ctx.buf);
 
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 
     buf_size = arm_convolve_fast_s16_get_buffer_size(&input_dims, &filter_dims);
@@ -102,10 +102,10 @@ void int16xint8_arm_convolve_fast_s16(void)
                                    output);
     free(ctx.buf);
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 #else
-    TEST_ASSERT_EQUAL(ARM_MATH_ARGUMENT_ERROR, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_ARG_ERROR, result);
 #endif
 }
 
@@ -154,20 +154,20 @@ void requantize_s64_arm_convolve_fast_s16(void)
     int buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_wrapper_s16(&ctx,
-                                                 &conv_params,
-                                                 &quant_params,
-                                                 &input_dims,
-                                                 input_data,
-                                                 &filter_dims,
-                                                 kernel_data,
-                                                 &bias_dims,
-                                                 bias_data,
-                                                 &output_dims,
-                                                 output);
+    arm_cmsis_nn_status result = arm_convolve_wrapper_s16(&ctx,
+                                                          &conv_params,
+                                                          &quant_params,
+                                                          &input_dims,
+                                                          input_data,
+                                                          &filter_dims,
+                                                          kernel_data,
+                                                          &bias_dims,
+                                                          bias_data,
+                                                          &output_dims,
+                                                          output);
 
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 
     buf_size = arm_convolve_fast_s16_get_buffer_size(&input_dims, &filter_dims);
@@ -186,9 +186,9 @@ void requantize_s64_arm_convolve_fast_s16(void)
                                    output);
     free(ctx.buf);
 #if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 #else
-    TEST_ASSERT_EQUAL(ARM_MATH_ARGUMENT_ERROR, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_ARG_ERROR, result);
 #endif
 }

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s16/test_arm_convolve_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s16/test_arm_convolve_s16.c
@@ -73,19 +73,19 @@ void int16xint8_arm_convolve_s16(void)
     int buf_size = arm_convolve_s16_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s16(&ctx,
-                                         &conv_params,
-                                         &quant_params,
-                                         &input_dims,
-                                         input_data,
-                                         &filter_dims,
-                                         kernel_data,
-                                         &bias_dims,
-                                         bias_data,
-                                         &output_dims,
-                                         output);
+    arm_cmsis_nn_status result = arm_convolve_s16(&ctx,
+                                                  &conv_params,
+                                                  &quant_params,
+                                                  &input_dims,
+                                                  input_data,
+                                                  &filter_dims,
+                                                  kernel_data,
+                                                  &bias_dims,
+                                                  bias_data,
+                                                  &output_dims,
+                                                  output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
@@ -104,7 +104,7 @@ void int16xint8_arm_convolve_s16(void)
                                       output);
 
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 }
 
@@ -153,19 +153,19 @@ void requantize_s64_arm_convolve_s16(void)
     int buf_size = arm_convolve_s16_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s16(&ctx,
-                                         &conv_params,
-                                         &quant_params,
-                                         &input_dims,
-                                         input_data,
-                                         &filter_dims,
-                                         kernel_data,
-                                         &bias_dims,
-                                         bias_data,
-                                         &output_dims,
-                                         output);
+    arm_cmsis_nn_status result = arm_convolve_s16(&ctx,
+                                                  &conv_params,
+                                                  &quant_params,
+                                                  &input_dims,
+                                                  input_data,
+                                                  &filter_dims,
+                                                  kernel_data,
+                                                  &bias_dims,
+                                                  bias_data,
+                                                  &output_dims,
+                                                  output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
@@ -184,7 +184,7 @@ void requantize_s64_arm_convolve_s16(void)
                                       output);
 
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 }
 
@@ -233,19 +233,19 @@ void int16xint8_dilation_1_arm_convolve_s16(void)
     int buf_size = arm_convolve_s16_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s16(&ctx,
-                                         &conv_params,
-                                         &quant_params,
-                                         &input_dims,
-                                         input_data,
-                                         &filter_dims,
-                                         kernel_data,
-                                         &bias_dims,
-                                         bias_data,
-                                         &output_dims,
-                                         output);
+    arm_cmsis_nn_status result = arm_convolve_s16(&ctx,
+                                                  &conv_params,
+                                                  &quant_params,
+                                                  &input_dims,
+                                                  input_data,
+                                                  &filter_dims,
+                                                  kernel_data,
+                                                  &bias_dims,
+                                                  bias_data,
+                                                  &output_dims,
+                                                  output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
@@ -264,7 +264,7 @@ void int16xint8_dilation_1_arm_convolve_s16(void)
                                       output);
 
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 }
 
@@ -313,19 +313,19 @@ void int16xint8_dilation_2_arm_convolve_s16(void)
     int buf_size = arm_convolve_s16_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s16(&ctx,
-                                         &conv_params,
-                                         &quant_params,
-                                         &input_dims,
-                                         input_data,
-                                         &filter_dims,
-                                         kernel_data,
-                                         &bias_dims,
-                                         bias_data,
-                                         &output_dims,
-                                         output);
+    arm_cmsis_nn_status result = arm_convolve_s16(&ctx,
+                                                  &conv_params,
+                                                  &quant_params,
+                                                  &input_dims,
+                                                  input_data,
+                                                  &filter_dims,
+                                                  kernel_data,
+                                                  &bias_dims,
+                                                  bias_data,
+                                                  &output_dims,
+                                                  output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
@@ -344,7 +344,7 @@ void int16xint8_dilation_2_arm_convolve_s16(void)
                                       output);
 
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 }
 
@@ -393,19 +393,19 @@ void int16xint8_dilation_3_arm_convolve_s16(void)
     int buf_size = arm_convolve_s16_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s16(&ctx,
-                                         &conv_params,
-                                         &quant_params,
-                                         &input_dims,
-                                         input_data,
-                                         &filter_dims,
-                                         kernel_data,
-                                         &bias_dims,
-                                         bias_data,
-                                         &output_dims,
-                                         output);
+    arm_cmsis_nn_status result = arm_convolve_s16(&ctx,
+                                                  &conv_params,
+                                                  &quant_params,
+                                                  &input_dims,
+                                                  input_data,
+                                                  &filter_dims,
+                                                  kernel_data,
+                                                  &bias_dims,
+                                                  bias_data,
+                                                  &output_dims,
+                                                  output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
@@ -424,6 +424,6 @@ void int16xint8_dilation_3_arm_convolve_s16(void)
                                       output);
 
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 }

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s8/test_arm_convolve_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s8/test_arm_convolve_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -40,7 +40,7 @@
 
 void basic_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[BASIC_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -85,17 +85,17 @@ void basic_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -124,7 +124,7 @@ void basic_arm_convolve_s8(void)
 
 void stride2pad1_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[STRIDE2PAD1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -169,17 +169,17 @@ void stride2pad1_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -208,7 +208,7 @@ void stride2pad1_arm_convolve_s8(void)
 
 void conv_2_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[CONV_2_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -253,17 +253,17 @@ void conv_2_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        conv_2_weights,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 conv_2_weights,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -292,7 +292,7 @@ void conv_2_arm_convolve_s8(void)
 
 void conv_3_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[CONV_3_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -337,17 +337,17 @@ void conv_3_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        conv_3_weights,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 conv_3_weights,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -376,7 +376,7 @@ void conv_3_arm_convolve_s8(void)
 
 void conv_4_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[CONV_4_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -421,17 +421,17 @@ void conv_4_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        conv_4_weights,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 conv_4_weights,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -460,7 +460,7 @@ void conv_4_arm_convolve_s8(void)
 
 void conv_1_x_n_1_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SIZE_MISMATCH;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
     q7_t output[CONV_1_X_N_1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -505,17 +505,17 @@ void conv_1_x_n_1_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_1_x_n_s8(&ctx,
-                                              &conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_convolve_1_x_n_s8(&ctx,
+                                                       &conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -535,13 +535,13 @@ void conv_1_x_n_1_arm_convolve_s8(void)
                              &output_dims,
                              output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
 }
 
 void conv_1_x_n_2_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SIZE_MISMATCH;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
     q7_t output[CONV_1_X_N_2_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -586,17 +586,17 @@ void conv_1_x_n_2_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_1_x_n_s8(&ctx,
-                                              &conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_convolve_1_x_n_s8(&ctx,
+                                                       &conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -616,13 +616,13 @@ void conv_1_x_n_2_arm_convolve_s8(void)
                              &output_dims,
                              output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
 }
 
 void conv_1_x_n_3_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SIZE_MISMATCH;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
     q7_t output[CONV_1_X_N_3_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -667,17 +667,17 @@ void conv_1_x_n_3_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_1_x_n_s8(&ctx,
-                                              &conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_convolve_1_x_n_s8(&ctx,
+                                                       &conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -697,13 +697,13 @@ void conv_1_x_n_3_arm_convolve_s8(void)
                              &output_dims,
                              output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
 }
 
 void conv_out_activation_arm_convolve_s8(void)
 {
-    const arm_status expected = ARM_MATH_SIZE_MISMATCH;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
     q7_t output[CONV_OUT_ACTIVATION_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -748,17 +748,17 @@ void conv_out_activation_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_1_x_n_s8(&ctx,
-                                              &conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_convolve_1_x_n_s8(&ctx,
+                                                       &conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -778,7 +778,7 @@ void conv_out_activation_arm_convolve_s8(void)
                              &output_dims,
                              output);
     free(ctx.buf);
-    TEST_ASSERT_EQUAL(ARM_MATH_SUCCESS, result);
+    TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
 }
 
@@ -794,7 +794,7 @@ void conv_2x2_dilation_arm_convolve_s8(void)
     cmsis_nn_dims bias_dims;
     cmsis_nn_dims output_dims;
 
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     const q31_t *bias_data = conv_2x2_dilation_biases;
     const q7_t *kernel_data = conv_2x2_dilation_weights;
     const q7_t *input_data = conv_2x2_dilation_input;
@@ -829,17 +829,17 @@ void conv_2x2_dilation_arm_convolve_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = 0;
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -883,7 +883,7 @@ void conv_2x2_dilation_5x5_input_arm_convolve_s8(void)
     const q7_t *input_data = conv_2x2_dilation_5x5_input_input;
     const q7_t *output_ref = conv_2x2_dilation_5x5_input_output_ref;
     const int32_t output_ref_size = CONV_2X2_DILATION_5X5_INPUT_DST_SIZE;
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
 
     input_dims.n = CONV_2X2_DILATION_5X5_INPUT_INPUT_BATCHES;
     input_dims.w = CONV_2X2_DILATION_5X5_INPUT_INPUT_W;
@@ -912,17 +912,17 @@ void conv_2x2_dilation_5x5_input_arm_convolve_s8(void)
     int32_t buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
@@ -965,7 +965,7 @@ void conv_3x3_dilation_5x5_input_arm_convolve_s8(void)
     const q7_t *input_data = conv_3x3_dilation_5x5_input_input;
     const q7_t *output_ref = conv_3x3_dilation_5x5_input_output_ref;
     const int32_t output_ref_size = CONV_3X3_DILATION_5X5_INPUT_DST_SIZE;
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
 
     input_dims.n = CONV_3X3_DILATION_5X5_INPUT_INPUT_BATCHES;
     input_dims.w = CONV_3X3_DILATION_5X5_INPUT_INPUT_W;
@@ -994,17 +994,17 @@ void conv_3x3_dilation_5x5_input_arm_convolve_s8(void)
     int32_t buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
@@ -1047,7 +1047,7 @@ void conv_2x3_dilation_arm_convolve_s8(void)
     const q7_t *input_data = conv_2x3_dilation_input;
     const q7_t *output_ref = conv_2x3_dilation_output_ref;
     const int32_t output_ref_size = CONV_2X3_DILATION_DST_SIZE;
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
 
     input_dims.n = CONV_2X3_DILATION_INPUT_BATCHES;
     input_dims.w = CONV_2X3_DILATION_INPUT_W;
@@ -1076,17 +1076,17 @@ void conv_2x3_dilation_arm_convolve_s8(void)
     int32_t buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
@@ -1129,7 +1129,7 @@ void conv_3x2_dilation_arm_convolve_s8(void)
     const q7_t *input_data = conv_3x2_dilation_input;
     const q7_t *output_ref = conv_3x2_dilation_output_ref;
     const int32_t output_ref_size = CONV_3X2_DILATION_DST_SIZE;
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
 
     input_dims.n = CONV_3X2_DILATION_INPUT_BATCHES;
     input_dims.w = CONV_3X2_DILATION_INPUT_W;
@@ -1158,17 +1158,17 @@ void conv_3x2_dilation_arm_convolve_s8(void)
     int32_t buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
@@ -1211,7 +1211,7 @@ void conv_dilation_golden_arm_convolve_s8(void)
     const q7_t *input_data = conv_dilation_golden_input;
     const q7_t *output_ref = conv_dilation_golden_output_ref;
     const int32_t output_ref_size = CONV_DILATION_GOLDEN_DST_SIZE;
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
 
     input_dims.n = CONV_DILATION_GOLDEN_INPUT_BATCHES;
     input_dims.w = CONV_DILATION_GOLDEN_INPUT_W;
@@ -1240,17 +1240,17 @@ void conv_dilation_golden_arm_convolve_s8(void)
     int32_t buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
 
-    arm_status result = arm_convolve_s8(&ctx,
-                                        &conv_params,
-                                        &quant_params,
-                                        &input_dims,
-                                        input_data,
-                                        &filter_dims,
-                                        kernel_data,
-                                        &bias_dims,
-                                        bias_data,
-                                        &output_dims,
-                                        output);
+    arm_cmsis_nn_status result = arm_convolve_s8(&ctx,
+                                                 &conv_params,
+                                                 &quant_params,
+                                                 &input_dims,
+                                                 input_data,
+                                                 &filter_dims,
+                                                 kernel_data,
+                                                 &bias_dims,
+                                                 bias_data,
+                                                 &output_dims,
+                                                 output);
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/test_arm_depthwise_conv_3x3_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/test_arm_depthwise_conv_3x3_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -27,7 +27,7 @@ static const uint16_t dilation = 1;
 
 void depthwise_kernel_3x3_arm_depthwise_conv_3x3_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_KERNEL_3X3_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -71,17 +71,17 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_3x3_s8(&ctx,
-                                                  &dw_conv_params,
-                                                  &quant_params,
-                                                  &input_dims,
-                                                  input_data,
-                                                  &filter_dims,
-                                                  kernel_data,
-                                                  &bias_dims,
-                                                  bias_data,
-                                                  &output_dims,
-                                                  output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_3x3_s8(&ctx,
+                                                           &dw_conv_params,
+                                                           &quant_params,
+                                                           &input_dims,
+                                                           input_data,
+                                                           &filter_dims,
+                                                           kernel_data,
+                                                           &bias_dims,
+                                                           bias_data,
+                                                           &output_dims,
+                                                           output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -110,7 +110,7 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_s8(void)
 
 void depthwise_kernel_3x3_arm_depthwise_conv_3x3_1_s8(void)
 {
-    const arm_status expected = ARM_MATH_ARGUMENT_ERROR;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
     q7_t output[DEPTHWISE_KERNEL_3X3_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -154,22 +154,22 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_1_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_3x3_s8(&ctx,
-                                                  &dw_conv_params,
-                                                  &quant_params,
-                                                  &input_dims,
-                                                  input_data,
-                                                  &filter_dims,
-                                                  kernel_data,
-                                                  &bias_dims,
-                                                  bias_data,
-                                                  &output_dims,
-                                                  output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_3x3_s8(&ctx,
+                                                           &dw_conv_params,
+                                                           &quant_params,
+                                                           &input_dims,
+                                                           input_data,
+                                                           &filter_dims,
+                                                           kernel_data,
+                                                           &bias_dims,
+                                                           bias_data,
+                                                           &output_dims,
+                                                           output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
 
-    const arm_status expected_wrapper = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected_wrapper = ARM_CMSIS_NN_SUCCESS;
     const int32_t buf_size =
         arm_depthwise_conv_wrapper_s8_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -193,7 +193,7 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_1_s8(void)
 
 void depthwise_kernel_3x3_arm_depthwise_conv_3x3_2_s8(void)
 {
-    const arm_status expected = ARM_MATH_ARGUMENT_ERROR;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
     q7_t output[DEPTHWISE_KERNEL_3X3_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -237,17 +237,17 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_2_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_3x3_s8(&ctx,
-                                                  &dw_conv_params,
-                                                  &quant_params,
-                                                  &input_dims,
-                                                  input_data,
-                                                  &filter_dims,
-                                                  kernel_data,
-                                                  &bias_dims,
-                                                  bias_data,
-                                                  &output_dims,
-                                                  output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_3x3_s8(&ctx,
+                                                           &dw_conv_params,
+                                                           &quant_params,
+                                                           &input_dims,
+                                                           input_data,
+                                                           &filter_dims,
+                                                           kernel_data,
+                                                           &bias_dims,
+                                                           bias_data,
+                                                           &output_dims,
+                                                           output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/test_arm_depthwise_conv_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/test_arm_depthwise_conv_s16.c
@@ -26,7 +26,7 @@
 
 void dw_int16xint8_arm_depthwise_conv_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q15_t output[DW_INT16XINT8_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -69,17 +69,17 @@ void dw_int16xint8_arm_depthwise_conv_s16(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s16(&ctx,
-                                               &dw_conv_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               dw_int16xint8_weights,
-                                               &bias_dims,
-                                               bias_data,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s16(&ctx,
+                                                        &dw_conv_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        dw_int16xint8_weights,
+                                                        &bias_dims,
+                                                        bias_data,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -88,7 +88,7 @@ void dw_int16xint8_arm_depthwise_conv_s16(void)
 
 void dw_int16xint8_dilation_arm_depthwise_conv_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q15_t output[DW_INT16XINT8_DILATION_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -131,17 +131,17 @@ void dw_int16xint8_dilation_arm_depthwise_conv_s16(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s16(&ctx,
-                                               &dw_conv_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               dw_int16xint8_dilation_weights,
-                                               &bias_dims,
-                                               bias_data,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s16(&ctx,
+                                                        &dw_conv_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        dw_int16xint8_dilation_weights,
+                                                        &bias_dims,
+                                                        bias_data,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -150,7 +150,7 @@ void dw_int16xint8_dilation_arm_depthwise_conv_s16(void)
 
 void dw_int16xint8_mult4_arm_depthwise_conv_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q15_t output[DW_INT16XINT8_MULT4_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -193,17 +193,17 @@ void dw_int16xint8_mult4_arm_depthwise_conv_s16(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s16(&ctx,
-                                               &dw_conv_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               dw_int16xint8_mult4_weights,
-                                               &bias_dims,
-                                               bias_data,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s16(&ctx,
+                                                        &dw_conv_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        dw_int16xint8_mult4_weights,
+                                                        &bias_dims,
+                                                        bias_data,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/test_arm_depthwise_conv_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/test_arm_depthwise_conv_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -45,7 +45,7 @@ const int32_t *get_bias_address(const int32_t *bias, int32_t size)
 
 void basic_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[BASIC_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -88,17 +88,17 @@ void basic_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              basic_weights,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       basic_weights,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -127,7 +127,7 @@ void basic_arm_depthwise_conv_s8(void)
 
 void stride2pad1_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[STRIDE2PAD1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -171,17 +171,17 @@ void stride2pad1_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -210,7 +210,7 @@ void stride2pad1_arm_depthwise_conv_s8(void)
 
 void depthwise_2_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_2_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -254,17 +254,17 @@ void depthwise_2_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -294,7 +294,7 @@ void depthwise_2_arm_depthwise_conv_s8(void)
 
 void depthwise_out_activation_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_OUT_ACTIVATION_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -337,17 +337,17 @@ void depthwise_out_activation_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -375,7 +375,7 @@ void depthwise_out_activation_arm_depthwise_conv_s8(void)
 
 void depthwise_mult_batches_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_MULT_BATCHES_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -419,17 +419,17 @@ void depthwise_mult_batches_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -457,7 +457,7 @@ void depthwise_mult_batches_arm_depthwise_conv_s8(void)
 
 void depthwise_null_bias_0_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_NULL_BIAS_0_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -501,17 +501,17 @@ void depthwise_null_bias_0_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -520,7 +520,7 @@ void depthwise_null_bias_0_arm_depthwise_conv_s8(void)
 
 void depthwise_null_bias_1_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_NULL_BIAS_1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -564,17 +564,17 @@ void depthwise_null_bias_1_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -583,7 +583,7 @@ void depthwise_null_bias_1_arm_depthwise_conv_s8(void)
 
 void depthwise_dilation_arm_depthwise_conv_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_DILATION_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -627,17 +627,17 @@ void depthwise_dilation_arm_depthwise_conv_s8(void)
     ctx.buf = NULL;
     ctx.size = 0;
 
-    arm_status result = arm_depthwise_conv_s8(&ctx,
-                                              &dw_conv_params,
-                                              &quant_params,
-                                              &input_dims,
-                                              input_data,
-                                              &filter_dims,
-                                              kernel_data,
-                                              &bias_dims,
-                                              bias_data,
-                                              &output_dims,
-                                              output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8(&ctx,
+                                                       &dw_conv_params,
+                                                       &quant_params,
+                                                       &input_dims,
+                                                       input_data,
+                                                       &filter_dims,
+                                                       kernel_data,
+                                                       &bias_dims,
+                                                       bias_data,
+                                                       &output_dims,
+                                                       output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/test_arm_depthwise_conv_s8_opt.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/test_arm_depthwise_conv_s8_opt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -30,7 +30,7 @@ static const uint16_t dilation = 1;
 
 void basic_arm_depthwise_conv_s8_opt(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[BASIC_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -74,17 +74,17 @@ void basic_arm_depthwise_conv_s8_opt(void)
     ctx.size = arm_depthwise_conv_s8_opt_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_depthwise_conv_s8_opt(&ctx,
-                                                  &dw_conv_params,
-                                                  &quant_params,
-                                                  &input_dims,
-                                                  input_data,
-                                                  &filter_dims,
-                                                  kernel_data,
-                                                  &bias_dims,
-                                                  bias_data,
-                                                  &output_dims,
-                                                  output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8_opt(&ctx,
+                                                           &dw_conv_params,
+                                                           &quant_params,
+                                                           &input_dims,
+                                                           input_data,
+                                                           &filter_dims,
+                                                           kernel_data,
+                                                           &bias_dims,
+                                                           bias_data,
+                                                           &output_dims,
+                                                           output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -93,7 +93,7 @@ void basic_arm_depthwise_conv_s8_opt(void)
 
 void stride2pad1_arm_depthwise_conv_s8_opt(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[STRIDE2PAD1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -137,17 +137,17 @@ void stride2pad1_arm_depthwise_conv_s8_opt(void)
     ctx.size = arm_depthwise_conv_s8_opt_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_depthwise_conv_s8_opt(&ctx,
-                                                  &dw_conv_params,
-                                                  &quant_params,
-                                                  &input_dims,
-                                                  input_data,
-                                                  &filter_dims,
-                                                  kernel_data,
-                                                  &bias_dims,
-                                                  bias_data,
-                                                  &output_dims,
-                                                  output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8_opt(&ctx,
+                                                           &dw_conv_params,
+                                                           &quant_params,
+                                                           &input_dims,
+                                                           input_data,
+                                                           &filter_dims,
+                                                           kernel_data,
+                                                           &bias_dims,
+                                                           bias_data,
+                                                           &output_dims,
+                                                           output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -156,7 +156,7 @@ void stride2pad1_arm_depthwise_conv_s8_opt(void)
 
 void depthwise_eq_in_out_ch_arm_depthwise_conv_s8_opt(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[DEPTHWISE_EQ_IN_OUT_CH_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -200,17 +200,17 @@ void depthwise_eq_in_out_ch_arm_depthwise_conv_s8_opt(void)
     ctx.size = arm_depthwise_conv_s8_opt_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(ctx.size);
 
-    arm_status result = arm_depthwise_conv_s8_opt(&ctx,
-                                                  &dw_conv_params,
-                                                  &quant_params,
-                                                  &input_dims,
-                                                  input_data,
-                                                  &filter_dims,
-                                                  kernel_data,
-                                                  &bias_dims,
-                                                  bias_data,
-                                                  &output_dims,
-                                                  output);
+    arm_cmsis_nn_status result = arm_depthwise_conv_s8_opt(&ctx,
+                                                           &dw_conv_params,
+                                                           &quant_params,
+                                                           &input_dims,
+                                                           input_data,
+                                                           &filter_dims,
+                                                           kernel_data,
+                                                           &bias_dims,
+                                                           bias_data,
+                                                           &output_dims,
+                                                           output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_add_s16/test_arm_elementwise_add_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_add_s16/test_arm_elementwise_add_s16.c
@@ -24,7 +24,7 @@
 
 void add_s16_arm_elementwise_add_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int16_t output[ADD_S16_DST_SIZE] = {0};
 
     const int16_t *input_data1 = add_s16_input1;
@@ -46,22 +46,22 @@ void add_s16_arm_elementwise_add_s16(void)
     const int32_t out_activation_min = ADD_S16_OUT_ACTIVATION_MIN;
     const int32_t out_activation_max = ADD_S16_OUT_ACTIVATION_MAX;
 
-    arm_status result = arm_elementwise_add_s16(input_data1,
-                                                input_data2,
-                                                input_1_offset,
-                                                input_1_mult,
-                                                input_1_shift,
-                                                input_2_offset,
-                                                input_2_mult,
-                                                input_2_shift,
-                                                left_shift,
-                                                output,
-                                                out_offset,
-                                                out_mult,
-                                                out_shift,
-                                                out_activation_min,
-                                                out_activation_max,
-                                                ADD_S16_DST_SIZE);
+    arm_cmsis_nn_status result = arm_elementwise_add_s16(input_data1,
+                                                         input_data2,
+                                                         input_1_offset,
+                                                         input_1_mult,
+                                                         input_1_shift,
+                                                         input_2_offset,
+                                                         input_2_mult,
+                                                         input_2_shift,
+                                                         left_shift,
+                                                         output,
+                                                         out_offset,
+                                                         out_mult,
+                                                         out_shift,
+                                                         out_activation_min,
+                                                         out_activation_max,
+                                                         ADD_S16_DST_SIZE);
 
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, add_s16_output_ref, ADD_S16_DST_SIZE));

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_add_s8/test_arm_elementwise_add_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_add_s8/test_arm_elementwise_add_s8.c
@@ -24,7 +24,7 @@
 
 void add_arm_elementwise_add_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int8_t output[ADD_DST_SIZE] = {0};
 
     const int8_t *input_data1 = add_input1;
@@ -46,22 +46,22 @@ void add_arm_elementwise_add_s8(void)
     const int32_t out_activation_min = ADD_OUT_ACTIVATION_MIN;
     const int32_t out_activation_max = ADD_OUT_ACTIVATION_MAX;
 
-    arm_status result = arm_elementwise_add_s8(input_data1,
-                                               input_data2,
-                                               input_1_offset,
-                                               input_1_mult,
-                                               input_1_shift,
-                                               input_2_offset,
-                                               input_2_mult,
-                                               input_2_shift,
-                                               left_shift,
-                                               output,
-                                               out_offset,
-                                               out_mult,
-                                               out_shift,
-                                               out_activation_min,
-                                               out_activation_max,
-                                               ADD_DST_SIZE);
+    arm_cmsis_nn_status result = arm_elementwise_add_s8(input_data1,
+                                                        input_data2,
+                                                        input_1_offset,
+                                                        input_1_mult,
+                                                        input_1_shift,
+                                                        input_2_offset,
+                                                        input_2_mult,
+                                                        input_2_shift,
+                                                        left_shift,
+                                                        output,
+                                                        out_offset,
+                                                        out_mult,
+                                                        out_shift,
+                                                        out_activation_min,
+                                                        out_activation_max,
+                                                        ADD_DST_SIZE);
 
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, add_output_ref, ADD_DST_SIZE));

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_mul_s16/test_arm_elementwise_mul_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_mul_s16/test_arm_elementwise_mul_s16.c
@@ -24,7 +24,7 @@
 
 void mul_s16_arm_elementwise_mul_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int16_t output[MUL_S16_DST_SIZE] = {0};
 
     const int16_t *input_data1 = mul_s16_input1;
@@ -40,17 +40,17 @@ void mul_s16_arm_elementwise_mul_s16(void)
     const int32_t out_activation_min = MUL_S16_OUT_ACTIVATION_MIN;
     const int32_t out_activation_max = MUL_S16_OUT_ACTIVATION_MAX;
 
-    arm_status result = arm_elementwise_mul_s16(input_data1,
-                                                input_data2,
-                                                input_1_offset,
-                                                input_2_offset,
-                                                output,
-                                                out_offset,
-                                                out_mult,
-                                                out_shift,
-                                                out_activation_min,
-                                                out_activation_max,
-                                                MUL_S16_DST_SIZE);
+    arm_cmsis_nn_status result = arm_elementwise_mul_s16(input_data1,
+                                                         input_data2,
+                                                         input_1_offset,
+                                                         input_2_offset,
+                                                         output,
+                                                         out_offset,
+                                                         out_mult,
+                                                         out_shift,
+                                                         out_activation_min,
+                                                         out_activation_max,
+                                                         MUL_S16_DST_SIZE);
 
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, mul_s16_output_ref, MUL_S16_DST_SIZE));

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_mul_s8/test_arm_elementwise_mul_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_elementwise_mul_s8/test_arm_elementwise_mul_s8.c
@@ -24,7 +24,7 @@
 
 void mul_arm_elementwise_mul_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int8_t output[MUL_DST_SIZE] = {0};
 
     const int8_t *input_data1 = mul_input1;
@@ -40,17 +40,17 @@ void mul_arm_elementwise_mul_s8(void)
     const int32_t out_activation_min = MUL_OUT_ACTIVATION_MIN;
     const int32_t out_activation_max = MUL_OUT_ACTIVATION_MAX;
 
-    arm_status result = arm_elementwise_mul_s8(input_data1,
-                                               input_data2,
-                                               input_1_offset,
-                                               input_2_offset,
-                                               output,
-                                               out_offset,
-                                               out_mult,
-                                               out_shift,
-                                               out_activation_min,
-                                               out_activation_max,
-                                               MUL_DST_SIZE);
+    arm_cmsis_nn_status result = arm_elementwise_mul_s8(input_data1,
+                                                        input_data2,
+                                                        input_1_offset,
+                                                        input_2_offset,
+                                                        output,
+                                                        out_offset,
+                                                        out_mult,
+                                                        out_shift,
+                                                        out_activation_min,
+                                                        out_activation_max,
+                                                        MUL_DST_SIZE);
 
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, mul_output_ref, MUL_DST_SIZE));

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_fully_connected_s16/test_arm_fully_connected_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_fully_connected_s16/test_arm_fully_connected_s16.c
@@ -27,7 +27,7 @@
 
 void fully_connected_int16_arm_fully_connected_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q15_t output[FULLY_CONNECTED_INT16_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -68,17 +68,17 @@ void fully_connected_int16_arm_fully_connected_s16(void)
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
 
-    arm_status result = arm_fully_connected_s16(&ctx,
-                                                &fc_params,
-                                                &quant_params,
-                                                &input_dims,
-                                                input_data,
-                                                &filter_dims,
-                                                kernel_data,
-                                                &bias_dims,
-                                                bias_data,
-                                                &output_dims,
-                                                output);
+    arm_cmsis_nn_status result = arm_fully_connected_s16(&ctx,
+                                                         &fc_params,
+                                                         &quant_params,
+                                                         &input_dims,
+                                                         input_data,
+                                                         &filter_dims,
+                                                         kernel_data,
+                                                         &bias_dims,
+                                                         bias_data,
+                                                         &output_dims,
+                                                         output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -87,7 +87,7 @@ void fully_connected_int16_arm_fully_connected_s16(void)
 
 void fully_connected_int16_big_arm_fully_connected_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q15_t output[FULLY_CONNECTED_INT16_BIG_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -128,17 +128,17 @@ void fully_connected_int16_big_arm_fully_connected_s16(void)
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
 
-    arm_status result = arm_fully_connected_s16(&ctx,
-                                                &fc_params,
-                                                &quant_params,
-                                                &input_dims,
-                                                input_data,
-                                                &filter_dims,
-                                                kernel_data,
-                                                &bias_dims,
-                                                bias_data,
-                                                &output_dims,
-                                                output);
+    arm_cmsis_nn_status result = arm_fully_connected_s16(&ctx,
+                                                         &fc_params,
+                                                         &quant_params,
+                                                         &input_dims,
+                                                         input_data,
+                                                         &filter_dims,
+                                                         kernel_data,
+                                                         &bias_dims,
+                                                         bias_data,
+                                                         &output_dims,
+                                                         output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -147,7 +147,7 @@ void fully_connected_int16_big_arm_fully_connected_s16(void)
 
 void fc_int16_slow_arm_fully_connected_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q15_t output[FC_INT16_SLOW_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -188,17 +188,17 @@ void fc_int16_slow_arm_fully_connected_s16(void)
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
 
-    arm_status result = arm_fully_connected_s16(&ctx,
-                                                &fc_params,
-                                                &quant_params,
-                                                &input_dims,
-                                                input_data,
-                                                &filter_dims,
-                                                kernel_data,
-                                                &bias_dims,
-                                                bias_data,
-                                                &output_dims,
-                                                output);
+    arm_cmsis_nn_status result = arm_fully_connected_s16(&ctx,
+                                                         &fc_params,
+                                                         &quant_params,
+                                                         &input_dims,
+                                                         input_data,
+                                                         &filter_dims,
+                                                         kernel_data,
+                                                         &bias_dims,
+                                                         bias_data,
+                                                         &output_dims,
+                                                         output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_fully_connected_s8/test_arm_fully_connected_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_fully_connected_s8/test_arm_fully_connected_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,7 +29,7 @@
 
 void fully_connected_arm_fully_connected_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[FULLY_CONNECTED_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -68,17 +68,17 @@ void fully_connected_arm_fully_connected_s8(void)
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
 
-    arm_status result = arm_fully_connected_s8(&ctx,
-                                               &fc_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               kernel_data,
-                                               &bias_dims,
-                                               bias_data,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_fully_connected_s8(&ctx,
+                                                        &fc_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        kernel_data,
+                                                        &bias_dims,
+                                                        bias_data,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -87,7 +87,7 @@ void fully_connected_arm_fully_connected_s8(void)
 
 void fully_connected_mve_0_arm_fully_connected_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[FULLY_CONNECTED_MVE_0_DST_SIZE] = {0};
     cmsis_nn_context ctx;
     cmsis_nn_fc_params fc_params;
@@ -120,17 +120,17 @@ void fully_connected_mve_0_arm_fully_connected_s8(void)
     int32_t buf_size = arm_fully_connected_s8_get_buffer_size(&filter_dims);
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
-    arm_status result = arm_fully_connected_s8(&ctx,
-                                               &fc_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               kernel_data,
-                                               &bias_dims,
-                                               bias_data,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_fully_connected_s8(&ctx,
+                                                        &fc_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        kernel_data,
+                                                        &bias_dims,
+                                                        bias_data,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -139,7 +139,7 @@ void fully_connected_mve_0_arm_fully_connected_s8(void)
 
 void fully_connected_mve_1_arm_fully_connected_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[FULLY_CONNECTED_MVE_1_DST_SIZE] = {0};
     cmsis_nn_context ctx;
     cmsis_nn_fc_params fc_params;
@@ -172,17 +172,17 @@ void fully_connected_mve_1_arm_fully_connected_s8(void)
     int32_t buf_size = arm_fully_connected_s8_get_buffer_size(&filter_dims);
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
-    arm_status result = arm_fully_connected_s8(&ctx,
-                                               &fc_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               kernel_data,
-                                               &bias_dims,
-                                               bias_data,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_fully_connected_s8(&ctx,
+                                                        &fc_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        kernel_data,
+                                                        &bias_dims,
+                                                        bias_data,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -191,7 +191,7 @@ void fully_connected_mve_1_arm_fully_connected_s8(void)
 
 void fully_connected_null_bias_0_arm_fully_connected_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[FULLY_CONNECTED_NULL_BIAS_0_DST_SIZE] = {0};
     cmsis_nn_context ctx;
     cmsis_nn_fc_params fc_params;
@@ -221,12 +221,12 @@ void fully_connected_null_bias_0_arm_fully_connected_s8(void)
     quant_params.multiplier = FULLY_CONNECTED_NULL_BIAS_0_OUTPUT_MULTIPLIER;
     quant_params.shift = FULLY_CONNECTED_NULL_BIAS_0_OUTPUT_SHIFT;
 
-    arm_status ip_check = ARM_MATH_SUCCESS;
+    arm_cmsis_nn_status ip_check = ARM_CMSIS_NN_SUCCESS;
     for (int i = 0; i < FULLY_CONNECTED_NULL_BIAS_0_OUT_CH; i++)
     {
         if (bias_data[i] != 0)
         {
-            ip_check = ARM_MATH_ARGUMENT_ERROR;
+            ip_check = ARM_CMSIS_NN_ARG_ERROR;
             break;
         }
     }
@@ -235,17 +235,17 @@ void fully_connected_null_bias_0_arm_fully_connected_s8(void)
     int32_t buf_size = arm_fully_connected_s8_get_buffer_size(&filter_dims);
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
-    arm_status result = arm_fully_connected_s8(&ctx,
-                                               &fc_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               kernel_data,
-                                               &bias_dims,
-                                               NULL,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_fully_connected_s8(&ctx,
+                                                        &fc_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        kernel_data,
+                                                        &bias_dims,
+                                                        NULL,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);
@@ -254,7 +254,7 @@ void fully_connected_null_bias_0_arm_fully_connected_s8(void)
 
 void fully_connected_out_activation_arm_fully_connected_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[FULLY_CONNECTED_OUT_ACTIVATION_DST_SIZE] = {0};
     cmsis_nn_context ctx;
     cmsis_nn_fc_params fc_params;
@@ -287,17 +287,17 @@ void fully_connected_out_activation_arm_fully_connected_s8(void)
     int32_t buf_size = arm_fully_connected_s8_get_buffer_size(&filter_dims);
     ctx.buf = malloc(buf_size);
     ctx.size = buf_size;
-    arm_status result = arm_fully_connected_s8(&ctx,
-                                               &fc_params,
-                                               &quant_params,
-                                               &input_dims,
-                                               input_data,
-                                               &filter_dims,
-                                               kernel_data,
-                                               &bias_dims,
-                                               bias_data,
-                                               &output_dims,
-                                               output);
+    arm_cmsis_nn_status result = arm_fully_connected_s8(&ctx,
+                                                        &fc_params,
+                                                        &quant_params,
+                                                        &input_dims,
+                                                        input_data,
+                                                        &filter_dims,
+                                                        kernel_data,
+                                                        &bias_dims,
+                                                        bias_data,
+                                                        &output_dims,
+                                                        output);
 
     free(ctx.buf);
     TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_max_pool_s16/test_arm_max_pool_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_max_pool_s16/test_arm_max_pool_s16.c
@@ -28,7 +28,7 @@
 
 void maxpool_int16_arm_max_pool_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int16_t output[MAXPOOL_INT16_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -59,7 +59,7 @@ void maxpool_int16_arm_max_pool_s16(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s16(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -69,7 +69,7 @@ void maxpool_int16_arm_max_pool_s16(void)
 
 void maxpool_int16_1_arm_max_pool_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int16_t output[MAXPOOL_INT16_1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -100,7 +100,7 @@ void maxpool_int16_1_arm_max_pool_s16(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s16(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -110,7 +110,7 @@ void maxpool_int16_1_arm_max_pool_s16(void)
 
 void maxpool_int16_2_arm_max_pool_s16(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int16_t output[MAXPOOL_INT16_2_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -141,7 +141,7 @@ void maxpool_int16_2_arm_max_pool_s16(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s16(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_max_pool_s8/test_arm_max_pool_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_max_pool_s8/test_arm_max_pool_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2022 Arm Limited or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -33,7 +33,7 @@
 
 void maxpooling_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -64,7 +64,7 @@ void maxpooling_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -74,7 +74,7 @@ void maxpooling_arm_max_pool_s8(void)
 
 void maxpooling_1_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -105,7 +105,7 @@ void maxpooling_1_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -115,7 +115,7 @@ void maxpooling_1_arm_max_pool_s8(void)
 
 void maxpooling_2_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_2_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -146,7 +146,7 @@ void maxpooling_2_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -156,7 +156,7 @@ void maxpooling_2_arm_max_pool_s8(void)
 
 void maxpooling_3_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_3_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -187,7 +187,7 @@ void maxpooling_3_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -197,7 +197,7 @@ void maxpooling_3_arm_max_pool_s8(void)
 
 void maxpooling_4_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_4_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -228,7 +228,7 @@ void maxpooling_4_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -238,7 +238,7 @@ void maxpooling_4_arm_max_pool_s8(void)
 
 void maxpooling_5_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_5_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -269,7 +269,7 @@ void maxpooling_5_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -279,7 +279,7 @@ void maxpooling_5_arm_max_pool_s8(void)
 
 void maxpooling_6_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_6_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -310,7 +310,7 @@ void maxpooling_6_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);
@@ -320,7 +320,7 @@ void maxpooling_6_arm_max_pool_s8(void)
 
 void maxpooling_7_arm_max_pool_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     q7_t output[MAXPOOLING_7_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -351,7 +351,7 @@ void maxpooling_7_arm_max_pool_s8(void)
 
     for (int i = 0; i < REPEAT_NUM; i++)
     {
-        arm_status result =
+        arm_cmsis_nn_status result =
             arm_max_pool_s8(&ctx, &pool_params, &input_dims, input_data, &filter_dims, &output_dims, output);
 
         TEST_ASSERT_EQUAL(expected, result);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_svdf_state_s16_s8/test_arm_svdf_state_s16_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_svdf_state_s16_s8/test_arm_svdf_state_s16_s8.c
@@ -43,7 +43,7 @@ static bool check_null_bias(const int32_t *bias, int32_t size)
 
 void svdf_arm_svdf_state_s16_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     cmsis_nn_context input_ctx;
     cmsis_nn_context output_ctx;
     cmsis_nn_svdf_params svdf_params;
@@ -99,23 +99,23 @@ void svdf_arm_svdf_state_s16_s8(void)
         for (int j = 0; j < number_inputs; j++)
         {
             memcpy(input_data, svdf_input_sequence + j * input_round_size, input_round_size);
-            arm_status result = arm_svdf_state_s16_s8(&input_ctx,
-                                                      &output_ctx,
-                                                      &svdf_params,
-                                                      &input_quant_params,
-                                                      &output_quant_params,
-                                                      &input_dims,
-                                                      input_data,
-                                                      &state_dims,
-                                                      state_data,
-                                                      &weights_feature_dims,
-                                                      weights_feature_data,
-                                                      &weights_time_dims,
-                                                      weights_time_data,
-                                                      &bias_dims,
-                                                      null_bias == true ? NULL : svdf_biases,
-                                                      &output_dims,
-                                                      output_data);
+            arm_cmsis_nn_status result = arm_svdf_state_s16_s8(&input_ctx,
+                                                               &output_ctx,
+                                                               &svdf_params,
+                                                               &input_quant_params,
+                                                               &output_quant_params,
+                                                               &input_dims,
+                                                               input_data,
+                                                               &state_dims,
+                                                               state_data,
+                                                               &weights_feature_dims,
+                                                               weights_feature_data,
+                                                               &weights_time_dims,
+                                                               weights_time_data,
+                                                               &bias_dims,
+                                                               null_bias == true ? NULL : svdf_biases,
+                                                               &output_dims,
+                                                               output_data);
             TEST_ASSERT_EQUAL(expected, result);
         }
 
@@ -129,7 +129,7 @@ void svdf_arm_svdf_state_s16_s8(void)
 
 void svdf_1_arm_svdf_state_s16_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     cmsis_nn_context input_ctx;
     cmsis_nn_context output_ctx;
     cmsis_nn_svdf_params svdf_1_params;
@@ -184,23 +184,23 @@ void svdf_1_arm_svdf_state_s16_s8(void)
         for (int j = 0; j < number_inputs; j++)
         {
             memcpy(input_data, svdf_1_input_sequence + j * input_round_size, input_round_size);
-            arm_status result = arm_svdf_state_s16_s8(&input_ctx,
-                                                      &output_ctx,
-                                                      &svdf_1_params,
-                                                      &input_quant_params,
-                                                      &output_quant_params,
-                                                      &input_dims,
-                                                      input_data,
-                                                      &state_dims,
-                                                      state_data,
-                                                      &weights_feature_dims,
-                                                      weights_feature_data,
-                                                      &weights_time_dims,
-                                                      weights_time_data,
-                                                      &bias_dims,
-                                                      null_bias == true ? NULL : svdf_1_biases,
-                                                      &output_dims,
-                                                      output_data);
+            arm_cmsis_nn_status result = arm_svdf_state_s16_s8(&input_ctx,
+                                                               &output_ctx,
+                                                               &svdf_1_params,
+                                                               &input_quant_params,
+                                                               &output_quant_params,
+                                                               &input_dims,
+                                                               input_data,
+                                                               &state_dims,
+                                                               state_data,
+                                                               &weights_feature_dims,
+                                                               weights_feature_data,
+                                                               &weights_time_dims,
+                                                               weights_time_data,
+                                                               &bias_dims,
+                                                               null_bias == true ? NULL : svdf_1_biases,
+                                                               &output_dims,
+                                                               output_data);
             TEST_ASSERT_EQUAL(expected, result);
         }
 
@@ -214,7 +214,7 @@ void svdf_1_arm_svdf_state_s16_s8(void)
 
 void svdf_2_arm_svdf_state_s16_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     cmsis_nn_context input_ctx;
     cmsis_nn_context output_ctx;
     cmsis_nn_svdf_params svdf_2_params;
@@ -269,23 +269,23 @@ void svdf_2_arm_svdf_state_s16_s8(void)
         for (int j = 0; j < number_inputs; j++)
         {
             memcpy(input_data, svdf_2_input_sequence + j * input_round_size, input_round_size);
-            arm_status result = arm_svdf_state_s16_s8(&input_ctx,
-                                                      &output_ctx,
-                                                      &svdf_2_params,
-                                                      &input_quant_params,
-                                                      &output_quant_params,
-                                                      &input_dims,
-                                                      input_data,
-                                                      &state_dims,
-                                                      state_data,
-                                                      &weights_feature_dims,
-                                                      weights_feature_data,
-                                                      &weights_time_dims,
-                                                      weights_time_data,
-                                                      &bias_dims,
-                                                      null_bias == true ? NULL : svdf_2_biases,
-                                                      &output_dims,
-                                                      output_data);
+            arm_cmsis_nn_status result = arm_svdf_state_s16_s8(&input_ctx,
+                                                               &output_ctx,
+                                                               &svdf_2_params,
+                                                               &input_quant_params,
+                                                               &output_quant_params,
+                                                               &input_dims,
+                                                               input_data,
+                                                               &state_dims,
+                                                               state_data,
+                                                               &weights_feature_dims,
+                                                               weights_feature_data,
+                                                               &weights_time_dims,
+                                                               weights_time_data,
+                                                               &bias_dims,
+                                                               null_bias == true ? NULL : svdf_2_biases,
+                                                               &output_dims,
+                                                               output_data);
             TEST_ASSERT_EQUAL(expected, result);
         }
 
@@ -299,7 +299,7 @@ void svdf_2_arm_svdf_state_s16_s8(void)
 
 void svdf_3_arm_svdf_state_s16_s8(void)
 {
-    const arm_status expected = ARM_MATH_SUCCESS;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     cmsis_nn_context input_ctx;
     cmsis_nn_context output_ctx;
     cmsis_nn_svdf_params svdf_3_params;
@@ -354,23 +354,23 @@ void svdf_3_arm_svdf_state_s16_s8(void)
         for (int j = 0; j < number_inputs; j++)
         {
             memcpy(input_data, svdf_3_input_sequence + j * input_round_size, input_round_size);
-            arm_status result = arm_svdf_state_s16_s8(&input_ctx,
-                                                      &output_ctx,
-                                                      &svdf_3_params,
-                                                      &input_quant_params,
-                                                      &output_quant_params,
-                                                      &input_dims,
-                                                      input_data,
-                                                      &state_dims,
-                                                      state_data,
-                                                      &weights_feature_dims,
-                                                      weights_feature_data,
-                                                      &weights_time_dims,
-                                                      weights_time_data,
-                                                      &bias_dims,
-                                                      null_bias == true ? NULL : svdf_3_biases,
-                                                      &output_dims,
-                                                      output_data);
+            arm_cmsis_nn_status result = arm_svdf_state_s16_s8(&input_ctx,
+                                                               &output_ctx,
+                                                               &svdf_3_params,
+                                                               &input_quant_params,
+                                                               &output_quant_params,
+                                                               &input_dims,
+                                                               input_data,
+                                                               &state_dims,
+                                                               state_data,
+                                                               &weights_feature_dims,
+                                                               weights_feature_data,
+                                                               &weights_time_dims,
+                                                               weights_time_data,
+                                                               &bias_dims,
+                                                               null_bias == true ? NULL : svdf_3_biases,
+                                                               &output_dims,
+                                                               output_data);
             TEST_ASSERT_EQUAL(expected, result);
         }
 


### PR DESCRIPTION
Replaces ARM_MATH_SIZE_MISMATCH with ARM_CMSIS_NN_ARG_ERROR.
Replaces ARM_MATH_SUCCESS with ARM_CMSIS_NN_SUCCESS.
Replaces ARM_MATH_ARGUMENT_ERROR with ARM_CMSIS_NN_ARG_ERROR.

This is changing the return type for all APIs.