### PR TITLE
CMSIS-DAP: fix point overrun in `DAP_SWD_Transfer`

### DIFF
--- a/CMSIS/DAP/Firmware/Source/DAP.c
+++ b/CMSIS/DAP/Firmware/Source/DAP.c
@@ -893,6 +893,11 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
     }
   }
 
+  if(request_count != 0u) {
+    // revert canceled requests
+    request--;
+  }
+
   for (; request_count != 0U; request_count--) {
     // Process canceled requests
     request_value = *request++;


### PR DESCRIPTION
I think there is a point overrun error in `DAP_SWD_Transfer` function.
when swd transfer failed, `request` point will overrun.

## test pattern:
1. send [DAP_Connect](https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Connect.html) to SWD.
  > 0x02 0x01
2. send [DAP_Transfer](https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Transfer.html) to read reg.
  > 0x05 0x00 0x01 0x02

## problem i met

I make a test project here：
https://github.com/feilongfl/CMSIS_5/commit/c1c6763fee45ac642446c690eaf041b5019b00e5

when commit in this PR is revert, you will got
```
req[02] 2 bytes, resp 2 bytes.
SWD_Transfer ret: 0
req[05] 9 bytes, resp 3 bytes.
```

I think it should be
```
req[02] 2 bytes, resp 2 bytes.
SWD_Transfer ret: 0
req[05] 4 bytes, resp 3 bytes.
```

## what this PR do

I find that there have a [loop](https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/DAP/Firmware/Source/DAP.c#L896) to resolve canceled requests, when the loop before this loop was transfer failed, `requests` is loading a mistake value.

So I restore the `request` address between the two loops.
