### PR TITLE
CMSIS_DSP: arm_fir_example accessing past the end of firStateF32

### DIFF
--- a/CMSIS/DSP/Examples/ARM/arm_fir_example/arm_fir_example_f32.c
+++ b/CMSIS/DSP/Examples/ARM/arm_fir_example/arm_fir_example_f32.c
@@ -171,9 +171,9 @@ static float32_t testOutput[TEST_LENGTH_SAMPLES];
  * Declare State buffer of size (numTaps + blockSize - 1)
  * ------------------------------------------------------------------- */
 #if defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE)
-static float32_t firStateF32[2 * BLOCK_SIZE + NUM_TAPS - 1];
+static float32_t firStateF32[2 * BLOCK_SIZE + NUM_TAPS_ARRAY_SIZE - 1];
 #else
-static float32_t firStateF32[BLOCK_SIZE + NUM_TAPS - 1];
+static float32_t firStateF32[BLOCK_SIZE + NUM_TAPS_ARRAY_SIZE - 1];
 #endif 
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
When built with `ARM_MATH_MVEF`, `arm_fir_f32()` is accessing 3 elements past the end of `firStateF32` in the arm_fir_example.