### PR TITLE
Fix undefined identifier in system_x headers

### DIFF
--- a/Device/ARM/ARMCM0/Include/system_ARMCM0.h
+++ b/Device/ARM/ARMCM0/Include/system_ARMCM0.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM0.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM0 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM0plus/Include/system_ARMCM0plus.h
+++ b/Device/ARM/ARMCM0plus/Include/system_ARMCM0plus.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM0plus.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM0 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM1/Include/system_ARMCM1.h
+++ b/Device/ARM/ARMCM1/Include/system_ARMCM1.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM1.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM1 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM23/Include/system_ARMCM23.h
+++ b/Device/ARM/ARMCM23/Include/system_ARMCM23.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM23.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM23 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM3/Include/system_ARMCM3.h
+++ b/Device/ARM/ARMCM3/Include/system_ARMCM3.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM3.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM3 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM33/Include/system_ARMCM33.h
+++ b/Device/ARM/ARMCM33/Include/system_ARMCM33.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM33.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM33 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM35P/Include/system_ARMCM35P.h
+++ b/Device/ARM/ARMCM35P/Include/system_ARMCM35P.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM35P.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM35P Device
- * @version  V1.0.1
- * @date     15. November 2019
+ * @version  V1.0.2
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM4/Include/system_ARMCM4.h
+++ b/Device/ARM/ARMCM4/Include/system_ARMCM4.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM4.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM4 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM55/Include/system_ARMCM55.h
+++ b/Device/ARM/ARMCM55/Include/system_ARMCM55.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM55.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM55 Device
- * @version  V1.0.0
- * @date     20. February 2020
+ * @version  V1.0.1
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2020 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM7/Include/system_ARMCM7.h
+++ b/Device/ARM/ARMCM7/Include/system_ARMCM7.h
@@ -2,11 +2,11 @@
  * @file     system_ARMCM7.h
  * @brief    CMSIS Device System Header File for
  *           ARMCM7 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMCM85/Include/system_ARMCM85.h
+++ b/Device/ARM/ARMCM85/Include/system_ARMCM85.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     system_ARMCM85.h
  * @brief    CMSIS Device System Header File for ARMCM85 Device
- * @version  V1.0.0
- * @date     07. February 2022
+ * @version  V1.0.1
+ * @date     11. July 2022
  ******************************************************************************/
 /*
  * Copyright (c) 2022 Arm Limited. All rights reserved.
@@ -28,6 +28,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMSC000/Include/system_ARMSC000.h
+++ b/Device/ARM/ARMSC000/Include/system_ARMSC000.h
@@ -2,11 +2,11 @@
  * @file     system_ARMSC000.h
  * @brief    CMSIS Device System Header File for
  *           ARMSC000 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMSC300/Include/system_ARMSC300.h
+++ b/Device/ARM/ARMSC300/Include/system_ARMSC300.h
@@ -2,11 +2,11 @@
  * @file     system_ARMSC300.h
  * @brief    CMSIS Device System Header File for
  *           ARMSC300 Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMv81MML/Include/system_ARMv81MML.h
+++ b/Device/ARM/ARMv81MML/Include/system_ARMv81MML.h
@@ -2,11 +2,11 @@
  * @file     system_ARMv81MML.h
  * @brief    CMSIS Device System Header File for
  *           Armv8.1-M Mainline Device Series
- * @version  V1.0.1
- * @date     15. Novemer 2019
+ * @version  V1.0.2
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMv8MBL/Include/system_ARMv8MBL.h
+++ b/Device/ARM/ARMv8MBL/Include/system_ARMv8MBL.h
@@ -2,11 +2,11 @@
  * @file     system_ARMv8MBL.h
  * @brief    CMSIS Device System Header File for
  *           ARMv8MBL Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/ARM/ARMv8MML/Include/system_ARMv8MML.h
+++ b/Device/ARM/ARMv8MML/Include/system_ARMv8MML.h
@@ -2,11 +2,11 @@
  * @file     system_ARMv8MML.h
  * @brief    CMSIS Device System Header File for
  *           ARMv8MML Device
- * @version  V5.3.2
- * @date     15. November 2019
+ * @version  V5.3.3
+ * @date     11. July 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype

--- a/Device/_Template_Vendor/Vendor/Device/Include/system_Device.h
+++ b/Device/_Template_Vendor/Vendor/Device/Include/system_Device.h
@@ -2,11 +2,11 @@
  * @file     system_<Device>.h
  * @brief    CMSIS-Core(M) Device Peripheral Access Layer Header File for
  *           Device <Device>
- * @version  V1.0.0
- * @date     20. January 2021
+ * @version  V1.0.1
+ * @date     11. July 2022
  *****************************************************************************/
 /*
- * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,6 +29,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
 
 /**
   \brief Exception / Interrupt Handler Function Prototype


### PR DESCRIPTION
All header files present in `Device/ARM/x/Include/system_x.h` path declare `SystemCoreClock` as `uint32_t` but some of them fail to provide a typedef for `uint32_t`. As a result, one can only use these headers after providing a definition of the type.

Add a missing include directive for `stdint.h` and fix the following error:

> Device/ARM/ARMCM85/Include/system_ARMCM85.h:40:8: error:unknown type name 'uint32_t'
>    40 | extern uint32_t SystemCoreClock;