### PR TITLE
CMSIS-NN: Remove leftover kernel size defines

### DIFF
--- a/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -32,9 +32,6 @@
 #include "arm_nnsupportfunctions.h"
 #include <stdio.h>
 
-#define DIM_KER_X (1U)
-#define DIM_KER_Y (1U)
-
 /**
  *  @ingroup groupNN
  */


### PR DESCRIPTION
Last use of these defines was removed in [`c51d250`](https://github.com/ARM-software/CMSIS_5/commit/c51d25035044644d9aa1e5a4910461cdf090a18f).