### PR TITLE
CMSIS-NN : Clear output buffer in unit tests if reused

### DIFF
--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/test_arm_convolve_fast_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/test_arm_convolve_fast_s16.c
@@ -91,6 +91,7 @@ void int16xint8_arm_convolve_fast_s16(void)
 
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_fast_s16_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
@@ -183,6 +184,7 @@ void requantize_s64_arm_convolve_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_fast_s16_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s16/test_arm_convolve_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s16/test_arm_convolve_s16.c
@@ -93,6 +93,7 @@ void int16xint8_arm_convolve_s16(void)
     }
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -181,6 +182,7 @@ void requantize_s64_arm_convolve_s16(void)
     }
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -269,6 +271,7 @@ void int16xint8_dilation_1_arm_convolve_s16(void)
     }
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -357,6 +360,7 @@ void int16xint8_dilation_2_arm_convolve_s16(void)
     }
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -445,6 +449,7 @@ void int16xint8_dilation_3_arm_convolve_s16(void)
     }
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s8/test_arm_convolve_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_convolve_s8/test_arm_convolve_s8.c
@@ -106,6 +106,7 @@ void basic_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -198,6 +199,7 @@ void stride2pad1_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -290,6 +292,7 @@ void conv_2_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -382,6 +385,7 @@ void conv_3_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -474,6 +478,7 @@ void conv_4_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -566,6 +571,7 @@ void conv_1_x_n_1_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
@@ -655,6 +661,7 @@ void conv_1_x_n_2_arm_convolve_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
@@ -744,6 +751,7 @@ void conv_1_x_n_3_arm_convolve_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
     ctx.buf = malloc(buf_size);
@@ -899,6 +907,7 @@ void conv_2x2_dilation_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -989,6 +998,7 @@ void conv_2x2_dilation_5x5_input_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -1079,6 +1089,7 @@ void conv_3x3_dilation_5x5_input_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -1169,6 +1180,7 @@ void conv_2x3_dilation_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -1259,6 +1271,7 @@ void conv_3x2_dilation_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -1349,6 +1362,7 @@ void conv_dilation_golden_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -1441,6 +1455,7 @@ void conv_5_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/test_arm_depthwise_conv_3x3_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/test_arm_depthwise_conv_3x3_s8.c
@@ -51,6 +51,7 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_s8(void)
     cmsis_nn_dims bias_dims = {};
     cmsis_nn_dims output_dims;
 
+    const int32_t output_ref_size = DEPTHWISE_KERNEL_3X3_DST_SIZE;
     const q31_t *bias_data = depthwise_kernel_3x3_biases;
     const q7_t *kernel_data = depthwise_kernel_3x3_weights;
     const q7_t *input_data = depthwise_kernel_3x3_input;
@@ -103,7 +104,8 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, depthwise_kernel_3x3_output_ref, DEPTHWISE_KERNEL_3X3_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_kernel_3x3_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     const int32_t buf_size =
         arm_depthwise_conv_wrapper_s8_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
@@ -127,7 +129,7 @@ void depthwise_kernel_3x3_arm_depthwise_conv_3x3_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, depthwise_kernel_3x3_output_ref, DEPTHWISE_KERNEL_3X3_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_kernel_3x3_output_ref, output_ref_size));
 }
 
 // Negative check to see non 3x3 dimensions return an error
@@ -235,6 +237,7 @@ void depthwise_kernel_3x3_null_bias_arm_depthwise_conv_3x3_null_bias_s8(void)
     cmsis_nn_dims bias_dims = {};
     cmsis_nn_dims output_dims;
 
+    const int32_t output_ref_size = DEPTHWISE_KERNEL_3X3_NULL_BIAS_DST_SIZE;
     const q31_t *bias_data = depthwise_kernel_3x3_null_bias_biases;
     // get_bias_address(depthwise_kernel_3x3_null_bias_biases, DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUT_CH);
     const q7_t *kernel_data = depthwise_kernel_3x3_null_bias_weights;
@@ -287,8 +290,8 @@ void depthwise_kernel_3x3_null_bias_arm_depthwise_conv_3x3_null_bias_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(
-        validate(output, depthwise_kernel_3x3_null_bias_output_ref, DEPTHWISE_KERNEL_3X3_NULL_BIAS_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_kernel_3x3_null_bias_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     const arm_cmsis_nn_status expected_wrapper = ARM_CMSIS_NN_SUCCESS;
     const int32_t buf_size =
@@ -314,6 +317,5 @@ void depthwise_kernel_3x3_null_bias_arm_depthwise_conv_3x3_null_bias_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected_wrapper, result);
-    TEST_ASSERT_TRUE(
-        validate(output, depthwise_kernel_3x3_null_bias_output_ref, DEPTHWISE_KERNEL_3X3_NULL_BIAS_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_kernel_3x3_null_bias_output_ref, output_ref_size));
 }

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_fast_s16/test_arm_depthwise_conv_fast_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_fast_s16/test_arm_depthwise_conv_fast_s16.c
@@ -112,6 +112,7 @@ void dw_int16xint8_fast_arm_depthwise_conv_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -204,6 +205,7 @@ void dw_int16xint8_fast_spill_arm_depthwise_conv_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -296,6 +298,7 @@ void dw_int16xint8_fast_stride_arm_depthwise_conv_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -389,6 +392,7 @@ void dw_int16xint8_fast_null_bias_arm_depthwise_conv_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -482,6 +486,7 @@ void dw_int16xint8_fast_stride_null_bias_arm_depthwise_conv_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -575,6 +580,7 @@ void dw_int16xint8_fast_spill_null_bias_arm_depthwise_conv_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -668,6 +674,7 @@ void dw_int16xint8_fast_test_bias_arm_depthwise_conv_fast_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -761,6 +768,7 @@ void dw_int16xint8_fast_multiple_batches_uneven_buffers_arm_depthwise_conv_fast_
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);
@@ -854,6 +862,7 @@ void dw_int16xint8_fast_multiple_batches_uneven_buffers_null_bias_arm_depthwise_
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     buf_size = arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
     ctx.buf = malloc(buf_size);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/test_arm_depthwise_conv_s16.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/test_arm_depthwise_conv_s16.c
@@ -91,6 +91,7 @@ void dw_int16xint8_arm_depthwise_conv_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     int buf_size =
         arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
@@ -184,6 +185,7 @@ void dw_int16xint8_dilation_arm_depthwise_conv_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     int buf_size =
         arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
@@ -277,6 +279,7 @@ void dw_int16xint8_mult4_arm_depthwise_conv_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     int buf_size =
         arm_depthwise_conv_wrapper_s16_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);

--- a/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/test_arm_depthwise_conv_s8.c
+++ b/CMSIS/NN/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/test_arm_depthwise_conv_s8.c
@@ -59,6 +59,7 @@ void basic_arm_depthwise_conv_s8(void)
     const q31_t *bias_data = get_bias_address(basic_biases, BASIC_OUT_CH);
     const q7_t *input_data = basic_input;
 
+    const int32_t output_ref_size = BASIC_DST_SIZE;
     input_dims.n = BASIC_INPUT_BATCHES;
     input_dims.w = BASIC_INPUT_W;
     input_dims.h = BASIC_INPUT_H;
@@ -107,7 +108,8 @@ void basic_arm_depthwise_conv_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, basic_output_ref, BASIC_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, basic_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     const int32_t buf_size =
         arm_depthwise_conv_wrapper_s8_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
@@ -147,6 +149,7 @@ void stride2pad1_arm_depthwise_conv_s8(void)
     cmsis_nn_dims bias_dims = {};
     cmsis_nn_dims output_dims;
 
+    const int32_t output_ref_size = STRIDE2PAD1_DST_SIZE;
     const q31_t *bias_data = get_bias_address(stride2pad1_biases, STRIDE2PAD1_OUT_CH);
     const q7_t *kernel_data = stride2pad1_weights;
     const q7_t *input_data = stride2pad1_input;
@@ -198,7 +201,8 @@ void stride2pad1_arm_depthwise_conv_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, stride2pad1_output_ref, STRIDE2PAD1_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, stride2pad1_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     const int32_t buf_size =
         arm_depthwise_conv_wrapper_s8_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
@@ -222,7 +226,7 @@ void stride2pad1_arm_depthwise_conv_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, stride2pad1_output_ref, STRIDE2PAD1_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, stride2pad1_output_ref, output_ref_size));
 }
 
 void depthwise_2_arm_depthwise_conv_s8(void)
@@ -238,6 +242,7 @@ void depthwise_2_arm_depthwise_conv_s8(void)
     cmsis_nn_dims bias_dims = {};
     cmsis_nn_dims output_dims;
 
+    const int32_t output_ref_size = DEPTHWISE_2_DST_SIZE;
     const q31_t *bias_data = get_bias_address(depthwise_2_biases, DEPTHWISE_2_OUT_CH);
     const q7_t *kernel_data = depthwise_2_weights;
     const q7_t *input_data = depthwise_2_input;
@@ -289,7 +294,8 @@ void depthwise_2_arm_depthwise_conv_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, depthwise_2_output_ref, DEPTHWISE_2_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_2_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     const int32_t buf_size =
         arm_depthwise_conv_wrapper_s8_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
@@ -330,6 +336,7 @@ void depthwise_out_activation_arm_depthwise_conv_s8(void)
     cmsis_nn_dims bias_dims = {};
     cmsis_nn_dims output_dims;
 
+    const int32_t output_ref_size = DEPTHWISE_OUT_ACTIVATION_DST_SIZE;
     const q31_t *bias_data = get_bias_address(depthwise_out_activation_biases, DEPTHWISE_OUT_ACTIVATION_OUT_CH);
     const q7_t *kernel_data = depthwise_out_activation_weights;
     const q7_t *input_data = depthwise_out_activation_input;
@@ -380,7 +387,8 @@ void depthwise_out_activation_arm_depthwise_conv_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, depthwise_out_activation_output_ref, DEPTHWISE_OUT_ACTIVATION_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_out_activation_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     ctx.buf = NULL;
     ctx.size = 0;
@@ -419,6 +427,7 @@ void depthwise_mult_batches_arm_depthwise_conv_s8(void)
     cmsis_nn_dims bias_dims = {};
     cmsis_nn_dims output_dims;
 
+    const int32_t output_ref_size = DEPTHWISE_MULT_BATCHES_DST_SIZE;
     const q31_t *bias_data = get_bias_address(depthwise_mult_batches_biases, DEPTHWISE_MULT_BATCHES_OUT_CH);
     const q7_t *kernel_data = depthwise_mult_batches_weights;
     const q7_t *input_data = depthwise_mult_batches_input;
@@ -470,7 +479,8 @@ void depthwise_mult_batches_arm_depthwise_conv_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, depthwise_mult_batches_output_ref, DEPTHWISE_MULT_BATCHES_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_mult_batches_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     ctx.buf = NULL;
     ctx.size = 0;
@@ -643,6 +653,7 @@ void depthwise_dilation_arm_depthwise_conv_s8(void)
     cmsis_nn_dims bias_dims = {};
     cmsis_nn_dims output_dims;
 
+    const int32_t output_ref_size = DEPTHWISE_DILATION_DST_SIZE;
     const q31_t *bias_data = get_bias_address(depthwise_dilation_biases, DEPTHWISE_DILATION_OUT_CH);
     const q7_t *kernel_data = depthwise_dilation_weights;
     const q7_t *input_data = depthwise_dilation_input;
@@ -694,7 +705,8 @@ void depthwise_dilation_arm_depthwise_conv_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, depthwise_dilation_output_ref, DEPTHWISE_DILATION_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_dilation_output_ref, output_ref_size));
+    memset(output, 0, sizeof(output));
 
     const int32_t buf_size =
         arm_depthwise_conv_wrapper_s8_get_buffer_size(&dw_conv_params, &input_dims, &filter_dims, &output_dims);
@@ -711,5 +723,5 @@ void depthwise_dilation_arm_depthwise_conv_s8(void)
                                            &output_dims,
                                            output);
     TEST_ASSERT_EQUAL(expected, result);
-    TEST_ASSERT_TRUE(validate(output, depthwise_dilation_output_ref, DEPTHWISE_DILATION_DST_SIZE));
+    TEST_ASSERT_TRUE(validate(output, depthwise_dilation_output_ref, output_ref_size));
 }


### PR DESCRIPTION
Clear the output buffers within a test case if the same
buffer is reused.

Fixes #1532