### PR TITLE
Doxygen: Fix virtual timer tutorial.

### DIFF
--- a/CMSIS/DoxyGen/RTOS2/src/cmsis_os2_Tutorial.txt
+++ b/CMSIS/DoxyGen/RTOS2/src/cmsis_os2_Tutorial.txt
@@ -422,15 +422,15 @@ The CMSIS-RTOS API can be used to define any number of virtual timers which act 
 will run a user call-back function to perform a specific action. Each timer can be configured as a one shot or repeat timer.
 A virtual timer is created by first defining a timer structure:
 \code
-static const osThreadAttr_t ThreadAttr_app_main = {
-  const char * name // symbolic name of the timer
-  uin32_t attr_bits // None
-  void* cb_mem      // pointer to memory for control block
-  uint32_t cb_size  // size of memory control block
+static const struct osTimerAttr_t timerAttr_timer0 = {
+  const char* name;      ///< name of the timer
+  uint32_t    attr_bits; ///< attribute bits
+  void*       cb_mem;    ///< memory for control block
+  uint32_t    cb_size;   ///< size of provided memory for control block
 }
 \endcode
-This defines a name for the timer and the name of the call back function. The timer must then be instantiated by an RTOS
-thread:
+This defines a name for the timer. The timer must then be instantiated by an RTOS
+thread providing a pointer to the callback function and its parameter.:
 \code
 osTimerId_t timer0_handle;
 timer0_handle = osTimerNew(&callback, osTimerPeriodic,(void *)<parameter>, &timerAttr_timer0);


### PR DESCRIPTION
Describe osTimerAttr_t instead of osThreadAttr_t.