### PR TITLE
[WIP] QE-2941: Replace Jenkins master label to built-in

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,7 @@ VERSION = null
 artifactory = new ArtifactoryHelper(this)
 
 pipeline {
-    agent { label 'master' }
+    agent { label 'build-in' }
     options {
         timestamps()
         timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
New Jenkins controllers 'master' node is now called 'built-in'