### PR TITLE
Make the IRQ Table extern definable.

### DIFF
--- a/ARM.CMSIS.pdsc
+++ b/ARM.CMSIS.pdsc
@@ -2207,7 +2207,7 @@ and 8-bit Java bytecodes in Jazelle state.
     </component>
 
     <!-- IRQ Controller -->
-    <component Cclass="Device" Cgroup="IRQ Controller" Csub="GIC" Capiversion="1.0.0" Cversion="1.0.1" condition="ARMv7-A Device">
+    <component Cclass="Device" Cgroup="IRQ Controller" Csub="GIC" Capiversion="1.0.0" Cversion="1.2.0" condition="ARMv7-A Device">
       <description>IRQ Controller implementation using GIC</description>
       <files>
         <file category="sourceC" name="CMSIS/Core_A/Source/irq_ctrl_gic.c"/>

--- a/CMSIS/Core_A/Source/irq_ctrl_gic.c
+++ b/CMSIS/Core_A/Source/irq_ctrl_gic.c
@@ -1,11 +1,11 @@
 /**************************************************************************//**
  * @file     irq_ctrl_gic.c
  * @brief    Interrupt controller handling implementation for GIC
- * @version  V1.1.1
- * @date     29. March 2021
+ * @version  V1.2.0
+ * @date     30. October 2022
  ******************************************************************************/
 /*
- * Copyright (c) 2017-2021 ARM Limited. All rights reserved.
+ * Copyright (c) 2017-2022 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -36,17 +36,23 @@
 #define IRQ_GIC_LINE_COUNT      (1020U)
 #endif
 
+#ifndef IRQ_GIC_EXTERN_IRQ_TABLE
 static IRQHandler_t IRQTable[IRQ_GIC_LINE_COUNT] = { 0U };
+#else
+extern IRQHandler_t IRQTable[IRQ_GIC_LINE_COUNT];
+#endif
 static uint32_t     IRQ_ID0;
 
 /// Initialize interrupt controller.
 __WEAK int32_t IRQ_Initialize (void) {
-  uint32_t i;
+  #ifndef IRQ_GIC_EXTERN_IRQ_TABLE
+    uint32_t i;
 
-  for (i = 0U; i < IRQ_GIC_LINE_COUNT; i++) {
-    IRQTable[i] = (IRQHandler_t)NULL;
-  }
-  GIC_Enable();
+    for (i = 0U; i < IRQ_GIC_LINE_COUNT; i++) {
+      IRQTable[i] = (IRQHandler_t)NULL;
+    }
+    GIC_Enable();
+  #endif
   return (0);
 }
 
@@ -63,6 +69,15 @@ __WEAK int32_t IRQ_SetHandler (IRQn_ID_t irqn, IRQHandler_t handler) {
   }
 
   return (status);
+}
+
+/// The Interrupt Handler.
+__WEAK void IRQ_Handler (void) {
+  IRQn_Type irqn = GIC_AcknowledgePending ();
+  if (irqn < (IRQn_Type)IRQ_GIC_LINE_COUNT) {
+    IrqTable[irqn]();
+  }
+  GIC_EndInterrupt (irqn);
 }
 
 


### PR DESCRIPTION
This makes the IRQ-table extern definable. With this it is possible to define Interrupt Service Routines in the CMSIS way with week defined IRQ-Routines which can be overridden in the application code.

Example:
// …
\_\_attribute__ ((weak, alias("InteruptDefaultHandler"))) void CoreTimer_IRQHandler (void);
// …

IRQHandler_t IRQTable [IRQ_GIC_LINE_COUNT] =
{
// …
CoreTimer_IRQHandler
// …
};

In Addition a default IRQ-Handler is implemented which calls the Interrupt-Service-Routine.