### PR TITLE
Replacing secrets to plain text

### DIFF
--- a/.github/workflows/corevalidation.yml
+++ b/.github/workflows/corevalidation.yml
@@ -1,11 +1,3 @@
-# The repository needs to provide the following secrets
-# - AWS_DEFAULT_REGION          The data center region to be used.
-# - AWS_S3_BUCKET_NAME          The name of the S3 storage bucket to be used for data exchange.
-# - AWS_IAM_PROFILE             The IAM profile to be used.
-# - AWS_ASSUME_ROLE             The AWS access role to be assumed.
-# - AWS_SECURITY_GROUP_ID       The id of the security group to add the EC2 instance to.
-# - AWS_SUBNET_ID               The id of the network subnet to connect the EC2 instance to.
-
 name: CoreValidation
 on:
   push:
@@ -19,11 +11,15 @@ on:
       - Device/ARM/**/*
   workflow_dispatch:
 
+# The env variables relate to an ARM AWS account for CMSIS_5
+# If you are forking CMSIS_5 repo, please use your own info.
 env:
-  AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
-  AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
-  AWS_SECURITY_GROUP_ID: ${{ secrets.AWS_SECURITY_GROUP_ID }}
-  AWS_SUBNET_ID: ${{ secrets.AWS_SUBNET_ID }}
+  AWS_ASSUME_ROLE: arn:aws:iam::720528183931:role/Proj-vht-assume-role
+  AWS_DEFAULT_REGION: eu-west-1
+  AWS_IAM_PROFILE: Proj-vht-limited-actions
+  AWS_S3_BUCKET_NAME: gh-cmsis-5
+  AWS_SECURITY_GROUP_ID: sg-03afe5ec007b4bcb0
+  AWS_SUBNET_ID: subnet-025b7baebd743a68b
 jobs:
   ci_test:
     runs-on: ubuntu-latest
@@ -49,10 +45,10 @@ jobs:
     - uses: ammaraskar/gcc-problem-matcher@master
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
-        role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
-        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+        role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
     - name: Run tests
       id: avh


### PR DESCRIPTION
This change allows fork-based PR to trigger Actions without failing due to the unavailability of secrets.