### PR TITLE
Harmonize compiler settings for Cortex-M and Cortex-A

### DIFF
--- a/CMSIS/Core_A/Include/cmsis_armcc.h
+++ b/CMSIS/Core_A/Include/cmsis_armcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armcc.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.0.5
- * @date     05. May 2021
+ * @brief    CMSIS compiler ARMCC (Arm Compiler 5) header file
+ * @version  V1.0.6
+ * @date     13. November 2022
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
@@ -24,6 +24,7 @@
 
 #ifndef __CMSIS_ARMCC_H
 #define __CMSIS_ARMCC_H
+
 
 #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 400677)
   #error "Please use Arm Compiler Toolchain V4.0.677 or later!"
@@ -68,6 +69,12 @@
 #ifndef   __PACKED_STRUCT
   #define __PACKED_STRUCT                        __packed struct
 #endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         __packed union
+#endif
+#ifndef   __UNALIGNED_UINT32        /* deprecated */
+  #define __UNALIGNED_UINT32(x)                  (*((__packed uint32_t *)(x)))
+#endif
 #ifndef   __UNALIGNED_UINT16_WRITE
   #define __UNALIGNED_UINT16_WRITE(addr, val)    ((*((__packed uint16_t *)(addr))) = (val))
 #endif
@@ -83,8 +90,8 @@
 #ifndef   __ALIGNED
   #define __ALIGNED(x)                           __attribute__((aligned(x)))
 #endif
-#ifndef   __PACKED
-  #define __PACKED                               __attribute__((packed))
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
 #endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __memory_changed()
@@ -93,38 +100,55 @@
 /* ##########################  Core Instruction Access  ######################### */
 /**
   \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
  */
 #define __NOP                             __nop
 
+
 /**
   \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
  */
 #define __WFI                             __wfi
 
+
 /**
   \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
  */
 #define __WFE                             __wfe
 
+
 /**
   \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
  */
 #define __SEV                             __sev
 
+
 /**
   \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
  */
 #define __ISB()                           __isb(0xF)
 
 /**
   \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
  */
 #define __DSB()                           __dsb(0xF)
 
 /**
   \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
  */
 #define __DMB()                           __dmb(0xF)
+
 
 /**
   \brief   Reverse byte order (32 bit)
@@ -133,6 +157,7 @@
   \return               Reversed value
  */
 #define __REV                             __rev
+
 
 /**
   \brief   Reverse byte order (16 bit)
@@ -148,6 +173,7 @@ __attribute__((section(".rev16_text"))) __STATIC_INLINE __ASM uint32_t __REV16(u
 }
 #endif
 
+
 /**
   \brief   Reverse byte order (16 bit)
   \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
@@ -162,23 +188,30 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
 }
 #endif
 
+
 /**
   \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
   \param [in]    op1  Value to rotate
   \param [in]    op2  Number of Bits to rotate
   \return               Rotated value
  */
 #define __ROR                             __ror
 
+
 /**
   \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
   \param [in]    value  is ignored by the processor.
                  If required, a debugger can use it to store additional information about the breakpoint.
  */
 #define __BKPT(value)                     __breakpoint(value)
 
+
 /**
   \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
   \param [in]    value  Value to reverse
   \return               Reversed value
  */
@@ -186,6 +219,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
 
 /**
   \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
   \param [in]  value  Value to count the leading zeros
   \return             number of leading zeros in value
  */
@@ -203,6 +237,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
   #define __LDREXB(ptr)          _Pragma("push") _Pragma("diag_suppress 3731") ((uint8_t ) __ldrex(ptr))  _Pragma("pop")
 #endif
 
+
 /**
   \brief   LDR Exclusive (16 bit)
   \details Executes a exclusive LDR instruction for 16 bit values.
@@ -215,6 +250,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
   #define __LDREXH(ptr)          _Pragma("push") _Pragma("diag_suppress 3731") ((uint16_t) __ldrex(ptr))  _Pragma("pop")
 #endif
 
+
 /**
   \brief   LDR Exclusive (32 bit)
   \details Executes a exclusive LDR instruction for 32 bit values.
@@ -226,6 +262,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
 #else
   #define __LDREXW(ptr)          _Pragma("push") _Pragma("diag_suppress 3731") ((uint32_t ) __ldrex(ptr))  _Pragma("pop")
 #endif
+
 
 /**
   \brief   STR Exclusive (8 bit)
@@ -241,6 +278,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
   #define __STREXB(value, ptr)   _Pragma("push") _Pragma("diag_suppress 3731") __strex(value, ptr)        _Pragma("pop")
 #endif
 
+
 /**
   \brief   STR Exclusive (16 bit)
   \details Executes a exclusive STR instruction for 16 bit values.
@@ -255,6 +293,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
   #define __STREXH(value, ptr)   _Pragma("push") _Pragma("diag_suppress 3731") __strex(value, ptr)        _Pragma("pop")
 #endif
 
+
 /**
   \brief   STR Exclusive (32 bit)
   \details Executes a exclusive STR instruction for 32 bit values.
@@ -268,6 +307,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
 #else
   #define __STREXW(value, ptr)   _Pragma("push") _Pragma("diag_suppress 3731") __strex(value, ptr)        _Pragma("pop")
 #endif
+
 
 /**
   \brief   Remove the exclusive lock
@@ -285,6 +325,7 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
  */
 #define __SSAT                            __ssat
 
+
 /**
   \brief   Unsigned Saturate
   \details Saturates an unsigned value.
@@ -298,14 +339,15 @@ __attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int16_t __REVSH(in
 
 /**
   \brief   Enable IRQ Interrupts
-  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
            Can only be executed in Privileged modes.
  */
 /* intrinsic void __enable_irq(); */
 
+
 /**
   \brief   Disable IRQ Interrupts
-  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
   Can only be executed in Privileged modes.
  */
 /* intrinsic void __disable_irq(void); */

--- a/CMSIS/Core_A/Include/cmsis_armclang.h
+++ b/CMSIS/Core_A/Include/cmsis_armclang.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.2.1
- * @date     05. May 2021
+ * @brief    CMSIS compiler armclang (Arm Compiler 6) header file
+ * @version  V1.2.2
+ * @date     13. November 2022
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
@@ -105,38 +105,55 @@
 /* ##########################  Core Instruction Access  ######################### */
 /**
   \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
  */
 #define __NOP                             __builtin_arm_nop
 
 /**
   \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
  */
 #define __WFI                             __builtin_arm_wfi
 
+
 /**
   \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
  */
 #define __WFE                             __builtin_arm_wfe
 
+
 /**
   \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
  */
 #define __SEV                             __builtin_arm_sev
 
+
 /**
   \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
  */
 #define __ISB()                           __builtin_arm_isb(0xF)
 
 /**
   \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
  */
 #define __DSB()                           __builtin_arm_dsb(0xF)
 
+
 /**
   \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
  */
 #define __DMB()                           __builtin_arm_dmb(0xF)
+
 
 /**
   \brief   Reverse byte order (32 bit)
@@ -145,6 +162,7 @@
   \return               Reversed value
  */
 #define __REV(value)   __builtin_bswap32(value)
+
 
 /**
   \brief   Reverse byte order (16 bit)
@@ -184,13 +202,17 @@ __STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
 
 /**
   \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
   \param [in]    value  is ignored by the processor.
                  If required, a debugger can use it to store additional information about the breakpoint.
  */
 #define __BKPT(value)   __ASM volatile ("bkpt "#value)
 
+
 /**
   \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
   \param [in]    value  Value to reverse
   \return               Reversed value
  */
@@ -198,6 +220,7 @@ __STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
 
 /**
   \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
   \param [in]  value  Value to count the leading zeros
   \return             number of leading zeros in value
  */
@@ -236,6 +259,7 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
  */
 #define __LDREXH        (uint16_t)__builtin_arm_ldrex
 
+
 /**
   \brief   LDR Exclusive (32 bit)
   \details Executes a exclusive LDR instruction for 32 bit values.
@@ -243,6 +267,7 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
   \return        value of type uint32_t at (*ptr)
  */
 #define __LDREXW        (uint32_t)__builtin_arm_ldrex
+
 
 /**
   \brief   STR Exclusive (8 bit)
@@ -254,6 +279,7 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
  */
 #define __STREXB        (uint32_t)__builtin_arm_strex
 
+
 /**
   \brief   STR Exclusive (16 bit)
   \details Executes a exclusive STR instruction for 16 bit values.
@@ -264,6 +290,7 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
  */
 #define __STREXH        (uint32_t)__builtin_arm_strex
 
+
 /**
   \brief   STR Exclusive (32 bit)
   \details Executes a exclusive STR instruction for 32 bit values.
@@ -273,6 +300,7 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
   \return          1  Function failed
  */
 #define __STREXW        (uint32_t)__builtin_arm_strex
+
 
 /**
   \brief   Remove the exclusive lock
@@ -288,6 +316,7 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
   \return             Saturated value
  */
 #define __SSAT             __builtin_arm_ssat
+
 
 /**
   \brief   Unsigned Saturate
@@ -390,7 +419,7 @@ __STATIC_FORCEINLINE void __disable_irq(void)
 
 /**
   \brief   Enable FIQ
-  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
 __STATIC_FORCEINLINE void __enable_fault_irq(void)
@@ -398,9 +427,10 @@ __STATIC_FORCEINLINE void __enable_fault_irq(void)
   __ASM volatile ("cpsie f" : : : "memory");
 }
 
+
 /**
   \brief   Disable FIQ
-  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
 __STATIC_FORCEINLINE void __disable_fault_irq(void)

--- a/CMSIS/Core_A/Include/cmsis_compiler.h
+++ b/CMSIS/Core_A/Include/cmsis_compiler.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_compiler.h
  * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.0.2
- * @date     10. January 2018
+ * @version  V1.0.3
+ * @date     13. November 2022
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -35,9 +35,15 @@
 
 
 /*
- * Arm Compiler 6 (armclang)
+ * Arm Compiler 6.6 LTM (armclang)
  */
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) && (__ARMCC_VERSION < 6100100)
+  #include "cmsis_armclang_ltm.h"
+
+  /*
+ * Arm Compiler above 6.10.1 (armclang)
+ */
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
   #include "cmsis_armclang.h"
 
 
@@ -52,7 +58,7 @@
  * IAR Compiler
  */
 #elif defined ( __ICCARM__ )
-  #include "cmsis_iccarm.h"
+  #include <cmsis_iccarm.h>
 
 
 /*
@@ -66,9 +72,6 @@
   #endif
   #ifndef   __INLINE
     #define __INLINE                  inline
-  #endif
-  #ifndef   __STATIC_INLINE
-    #define __STATIC_INLINE           static inline
   #endif
   #ifndef   __STATIC_INLINE
     #define __STATIC_INLINE           static inline
@@ -88,15 +91,24 @@
   #ifndef   __WEAK
     #define __WEAK                    __attribute__((weak))
   #endif
-  #ifndef   __UNALIGNED_UINT32
+  #ifndef   __PACKED
+    #define __PACKED                               __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __attribute__((packed))
+  #endif
+  #ifndef   __UNALIGNED_UINT32        /* deprecated */
     struct __attribute__((packed)) T_UINT32 { uint32_t v; };
     #define __UNALIGNED_UINT32(x)     (((struct T_UINT32 *)(x))->v)
   #endif
   #ifndef   __ALIGNED
     #define __ALIGNED(x)              __attribute__((aligned(x)))
   #endif
-  #ifndef   __PACKED
-    #define __PACKED                  __attribute__((packed))
+  #ifndef   __RESTRICT
+    #define __RESTRICT                             __restrict
   #endif
   #ifndef   __COMPILER_BARRIER
     #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
@@ -138,15 +150,25 @@
   #ifndef   __WEAK
     #define __WEAK                    __attribute__((weak))
   #endif
-  #ifndef   __UNALIGNED_UINT32
+  #ifndef   __PACKED
+    #define __PACKED                               __packed__
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __packed__
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __packed__
+  #endif
+  #ifndef   __UNALIGNED_UINT32        /* deprecated */
     struct __packed__ T_UINT32 { uint32_t v; };
     #define __UNALIGNED_UINT32(x)     (((struct T_UINT32 *)(x))->v)
   #endif
   #ifndef   __ALIGNED
     #define __ALIGNED(x)              __align(x)
   #endif
-  #ifndef   __PACKED
-    #define __PACKED                  __packed__
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
   #endif
   #ifndef   __COMPILER_BARRIER
     #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
@@ -187,7 +209,16 @@
   #ifndef   __WEAK
     #define __WEAK                    __weak
   #endif
-  #ifndef   __UNALIGNED_UINT32
+  #ifndef   __PACKED
+    #define __PACKED                               @packed
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        @packed struct
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         @packed union
+  #endif
+  #ifndef   __UNALIGNED_UINT32        /* deprecated */
     @packed struct T_UINT32 { uint32_t v; };
     #define __UNALIGNED_UINT32(x)     (((struct T_UINT32 *)(x))->v)
   #endif
@@ -195,8 +226,9 @@
     #warning No compiler specific solution for __ALIGNED. __ALIGNED is ignored.
     #define __ALIGNED(x)
   #endif
-  #ifndef   __PACKED
-    #define __PACKED                  @packed
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
   #endif
   #ifndef   __COMPILER_BARRIER
     #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.

--- a/CMSIS/Core_A/Include/cmsis_gcc.h
+++ b/CMSIS/Core_A/Include/cmsis_gcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
- * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.3.2
- * @date     24. March 2022
+ * @brief    CMSIS compiler GCC header file
+ * @version  V1.3.3
+ * @date     13. November 2022
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
@@ -73,7 +73,7 @@
 #ifndef   __UNALIGNED_UINT16_WRITE
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wpacked"
-/*lint -esym(9058, T_UINT16_WRITE)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT16_WRITE */
+  #pragma GCC diagnostic ignored "-Wattributes"
   __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
   #pragma GCC diagnostic pop
   #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
@@ -81,7 +81,7 @@
 #ifndef   __UNALIGNED_UINT16_READ
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wpacked"
-/*lint -esym(9058, T_UINT16_READ)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT16_READ */
+  #pragma GCC diagnostic ignored "-Wattributes"
   __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
   #pragma GCC diagnostic pop
   #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
@@ -89,7 +89,7 @@
 #ifndef   __UNALIGNED_UINT32_WRITE
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wpacked"
-/*lint -esym(9058, T_UINT32_WRITE)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT32_WRITE */
+  #pragma GCC diagnostic ignored "-Wattributes"
   __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
   #pragma GCC diagnostic pop
   #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
@@ -97,6 +97,7 @@
 #ifndef   __UNALIGNED_UINT32_READ
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
   __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
   #pragma GCC diagnostic pop
   #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
@@ -104,245 +105,42 @@
 #ifndef   __ALIGNED
   #define __ALIGNED(x)                           __attribute__((aligned(x)))
 #endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
 #ifndef   __COMPILER_BARRIER
   #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
 #endif
 
 
-__STATIC_FORCEINLINE uint32_t __QSUB16(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("qsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-
-__STATIC_FORCEINLINE uint32_t __QSUB8(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("qsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-
-__STATIC_FORCEINLINE uint32_t __QADD16(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("qadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __QADD8(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("qadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE  int32_t __QADD( int32_t op1,  int32_t op2)
-{
-  int32_t result;
-
-  __ASM volatile ("qadd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __QSAX(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM ("qsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SHSAX(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM ("shsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint64_t __SMLALD (uint32_t op1, uint32_t op2, uint64_t acc)
-{
-  union llreg_u{
-    uint32_t w32[2];
-    uint64_t w64;
-  } llr;
-  llr.w64 = acc;
-
-#ifndef __ARMEB__   /* Little endian */
-  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
-#else               /* Big endian */
-  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
-#endif
-
-  return(llr.w64);
-}
-
-__STATIC_FORCEINLINE  int32_t __QSUB( int32_t op1,  int32_t op2)
-{
-  int32_t result;
-
-  __ASM volatile ("qsub %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SXTB16(uint32_t op1)
-{
-  uint32_t result;
-
-  __ASM ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
-  return(result);
-}
-
-
-__STATIC_FORCEINLINE uint32_t __SMUAD  (uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("smuad %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-
-
-#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
-                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
-
-#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
-                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
-
-__STATIC_FORCEINLINE uint32_t __SMLAD (uint32_t op1, uint32_t op2, uint32_t op3)
-{
-  uint32_t result;
-
-  __ASM volatile ("smlad %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SMUADX (uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("smuadx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SMLADX (uint32_t op1, uint32_t op2, uint32_t op3)
-{
-  uint32_t result;
-
-  __ASM volatile ("smladx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint64_t __SMLALDX (uint32_t op1, uint32_t op2, uint64_t acc)
-{
-  union llreg_u{
-    uint32_t w32[2];
-    uint64_t w64;
-  } llr;
-  llr.w64 = acc;
-
-#ifndef __ARMEB__   /* Little endian */
-  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
-#else               /* Big endian */
-  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
-#endif
-
-  return(llr.w64);
-}
-
-__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
-{
- int32_t result;
-
- __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
- return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SMUSD  (uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("smusd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SMUSDX (uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM volatile ("smusdx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __QASX(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM ("qasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SHADD16(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM ("shadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SHSUB16(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM ("shsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SHASX(uint32_t op1, uint32_t op2)
-{
-  uint32_t result;
-
-  __ASM ("shasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
-  return(result);
-}
-
-__STATIC_FORCEINLINE uint32_t __SMLSDX (uint32_t op1, uint32_t op2, uint32_t op3)
-{
-  uint32_t result;
-
-  __ASM volatile ("smlsdx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
-  return(result);
-}
-
-
 /* ##########################  Core Instruction Access  ######################### */
 /**
   \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
  */
 #define __NOP()                             __ASM volatile ("nop")
 
 /**
   \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
  */
 #define __WFI()                             __ASM volatile ("wfi":::"memory")
 
+
 /**
   \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
  */
 #define __WFE()                             __ASM volatile ("wfe":::"memory")
 
+
 /**
   \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
  */
 #define __SEV()                             __ASM volatile ("sev")
+
 
 /**
   \brief   Instruction Synchronization Barrier
@@ -366,6 +164,7 @@ __STATIC_FORCEINLINE  void __DSB(void)
   __ASM volatile ("dsb 0xF":::"memory");
 }
 
+
 /**
   \brief   Data Memory Barrier
   \details Ensures the apparent order of the explicit memory operations before
@@ -375,6 +174,7 @@ __STATIC_FORCEINLINE  void __DMB(void)
 {
   __ASM volatile ("dmb 0xF":::"memory");
 }
+
 
 /**
   \brief   Reverse byte order (32 bit)
@@ -394,6 +194,7 @@ __STATIC_FORCEINLINE  uint32_t __REV(uint32_t value)
 #endif
 }
 
+
 /**
   \brief   Reverse byte order (16 bit)
   \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
@@ -406,6 +207,7 @@ __STATIC_FORCEINLINE uint32_t __REV16(uint32_t value)
   __ASM ("rev16 %0, %1" : "=r" (result) : "r" (value));
   return result;
 }
+
 
 /**
   \brief   Reverse byte order (16 bit)
@@ -424,6 +226,7 @@ __STATIC_FORCEINLINE  int16_t __REVSH(int16_t value)
   return result;
 #endif
 }
+
 
 /**
   \brief   Rotate Right in unsigned value (32 bit)
@@ -445,10 +248,13 @@ __STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
 
 /**
   \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
   \param [in]    value  is ignored by the processor.
                  If required, a debugger can use it to store additional information about the breakpoint.
  */
 #define __BKPT(value)   __ASM volatile ("bkpt "#value)
+
 
 /**
   \brief   Reverse bit order of value
@@ -463,8 +269,10 @@ __STATIC_FORCEINLINE  uint32_t __RBIT(uint32_t value)
   return result;
 }
 
+
 /**
   \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
   \param [in]  value  Value to count the leading zeros
   \return             number of leading zeros in value
  */
@@ -608,8 +416,8 @@ __STATIC_FORCEINLINE  void __CLREX(void)
 /**
   \brief   Signed Saturate
   \details Saturates a signed value.
-  \param [in]  value  Value to be saturated
-  \param [in]    sat  Bit position to saturate to (1..32)
+  \param [in]  ARG1  Value to be saturated
+  \param [in]  ARG2  Bit position to saturate to (1..32)
   \return             Saturated value
  */
 #define __SSAT(ARG1, ARG2) \
@@ -624,8 +432,8 @@ __extension__ \
 /**
   \brief   Unsigned Saturate
   \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
-  \param [in]    sat  Bit position to saturate to (0..31)
+  \param [in]  ARG1  Value to be saturated
+  \param [in]  ARG2  Bit position to saturate to (0..31)
   \return             Saturated value
  */
 #define __USAT(ARG1, ARG2) \
@@ -637,10 +445,14 @@ __extension__ \
  })
 
 /* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
 
 /**
   \brief   Enable IRQ Interrupts
-  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
            Can only be executed in Privileged modes.
  */
 __STATIC_FORCEINLINE void __enable_irq(void)
@@ -648,9 +460,10 @@ __STATIC_FORCEINLINE void __enable_irq(void)
   __ASM volatile ("cpsie i" : : : "memory");
 }
 
+
 /**
   \brief   Disable IRQ Interrupts
-  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
   Can only be executed in Privileged modes.
  */
 __STATIC_FORCEINLINE void __disable_irq(void)
@@ -660,7 +473,7 @@ __STATIC_FORCEINLINE void __disable_irq(void)
 
 /**
   \brief   Enable FIQ
-  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
 __STATIC_FORCEINLINE void __enable_fault_irq(void)
@@ -668,9 +481,10 @@ __STATIC_FORCEINLINE void __enable_fault_irq(void)
   __ASM volatile ("cpsie f" : : : "memory");
 }
 
+
 /**
   \brief   Disable FIQ
-  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
            Can only be executed in Privileged modes.
  */
 __STATIC_FORCEINLINE void __disable_fault_irq(void)
@@ -703,6 +517,7 @@ __STATIC_FORCEINLINE  uint32_t __get_FPSCR(void)
   #endif
 }
 
+
 /**
   \brief   Set FPSCR
   \details Assigns the given value to the Floating Point Status/Control register.
@@ -724,6 +539,238 @@ __STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
     (void)fpscr;
   #endif
 }
+
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+__STATIC_FORCEINLINE uint32_t __QADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("qadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__STATIC_FORCEINLINE uint32_t __QSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("qsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__STATIC_FORCEINLINE uint32_t __QADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("qadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("shadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __QSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("qsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("shsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __QASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("qasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("shasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __QSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("qsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM ("shsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMUADX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuadx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLADX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smladx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint64_t __SMLALD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__STATIC_FORCEINLINE uint64_t __SMLALDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMUSD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMUSDX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusdx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLSDX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsdx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE  int32_t __QADD( int32_t op1,  int32_t op2)
+{
+  int32_t result;
+
+  __ASM volatile ("qadd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE  int32_t __QSUB( int32_t op1,  int32_t op2)
+{
+  int32_t result;
+
+  __ASM volatile ("qsub %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__STATIC_FORCEINLINE uint32_t __SMUAD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuad %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+ int32_t result;
+
+ __ASM ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+ return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLAD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlad %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+/*@} end of group CMSIS_SIMD_intrinsics */
+
+
+
+/** \defgroup CMSIS_Core_intrinsics CMSIS Core Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
 
 /** \brief  Get CPSR Register
     \return               CPSR Register value
@@ -911,6 +958,8 @@ __STATIC_INLINE void __FPU_Enable(void)
     : : : "cc", "r1", "r2"
   );
 }
+
+/*@} end of group CMSIS_Core_intrinsics */
 
 #pragma GCC diagnostic pop
 

--- a/CMSIS/Core_A/Include/cmsis_iccarm.h
+++ b/CMSIS/Core_A/Include/cmsis_iccarm.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_iccarm.h
  * @brief    CMSIS compiler ICCARM (IAR Compiler for Arm) header file
- * @version  V5.0.7
- * @date     15. May 2019
+ * @version  V5.0.8
+ * @date     13. November 2022
  ******************************************************************************/
 
 //------------------------------------------------------------------------------
@@ -89,28 +89,28 @@
 #endif
 
 #ifndef   __PACKED
-  /* Needs IAR language extensions */
   #if __ICCARM_V8
     #define __PACKED __attribute__((packed, aligned(1)))
   #else
+    /* Needs IAR language extensions */
     #define __PACKED __packed
   #endif
 #endif
 
 #ifndef   __PACKED_STRUCT
-  /* Needs IAR language extensions */
   #if __ICCARM_V8
     #define __PACKED_STRUCT struct __attribute__((packed, aligned(1)))
   #else
+    /* Needs IAR language extensions */
     #define __PACKED_STRUCT __packed struct
   #endif
 #endif
 
 #ifndef   __PACKED_UNION
-  /* Needs IAR language extensions */
   #if __ICCARM_V8
     #define __PACKED_UNION union __attribute__((packed, aligned(1)))
   #else
+    /* Needs IAR language extensions */
     #define __PACKED_UNION __packed union
   #endif
 #endif
@@ -236,20 +236,20 @@
 
   #include "iccarm_builtin.h"
 
-  #define __enable_irq        __iar_builtin_enable_interrupt
+  #define __disable_fault_irq   __iar_builtin_disable_fiq
   #define __disable_irq       __iar_builtin_disable_interrupt
   #define __enable_fault_irq    __iar_builtin_enable_fiq
-  #define __disable_fault_irq   __iar_builtin_disable_fiq
+  #define __enable_irq        __iar_builtin_enable_interrupt
   #define __arm_rsr           __iar_builtin_rsr
   #define __arm_wsr           __iar_builtin_wsr
 
-  #if __FPU_PRESENT
+  #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
     #define __get_FPSCR()             (__arm_rsr("FPSCR"))
+    #define __set_FPSCR(VALUE)        (__arm_wsr("FPSCR", (VALUE)))
   #else
     #define __get_FPSCR()             ( 0 )
+    #define __set_FPSCR(VALUE)        ((void)VALUE)
   #endif
-
-  #define __set_FPSCR(VALUE)          (__arm_wsr("FPSCR", VALUE))
 
   #define __get_CPSR()                (__arm_rsr("CPSR"))
   #define __get_mode()                (__get_CPSR() & 0x1FU)
@@ -378,8 +378,8 @@
 
 #else /* __ICCARM_INTRINSICS_VERSION__ == 2 */
 
-  #if !__FPU_PRESENT
-  #define __get_FPSCR __cmsis_iar_get_FPSR_not_active
+  #if !((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
+    #define __get_FPSCR __cmsis_iar_get_FPSR_not_active
   #endif
 
   #ifdef __INTRINSICS_INCLUDED
@@ -388,8 +388,8 @@
 
   #include <intrinsics.h>
 
-  #if !__FPU_PRESENT
-  #define __get_FPSCR() (0)
+  #if !((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
+    #define __get_FPSCR() (0)
   #endif
 
   #pragma diag_suppress=Pe940
@@ -434,7 +434,7 @@
 
   __IAR_FT uint32_t __get_FPEXC(void)
   {
-  #if (__FPU_PRESENT == 1)
+  #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
     uint32_t result;
     __ASM volatile("VMRS %0, fpexc" : "=r" (result) : : "memory");
     return(result);
@@ -445,7 +445,7 @@
 
   __IAR_FT void __set_FPEXC(uint32_t fpexc)
   {
-  #if (__FPU_PRESENT == 1)
+  #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
     __ASM volatile ("VMSR fpexc, %0" : : "r" (fpexc) : "memory");
   #endif
   }

--- a/CMSIS/Core_A/Include/core_ca.h
+++ b/CMSIS/Core_A/Include/core_ca.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     core_ca.h
  * @brief    CMSIS Cortex-A Core Peripheral Access Layer Header File
- * @version  V1.0.4
- * @date     27. October 2022
+ * @version  V1.0.5
+ * @date     13. November 2022
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2022 ARM Limited. All rights reserved.
@@ -46,8 +46,8 @@
                                    __CA_CMSIS_VERSION_SUB          )       /*!< \brief CMSIS-Core(A) version number         */
 
 #if defined ( __CC_ARM )
-  #if defined __TARGET_FPU_VFP
-    #if (__FPU_PRESENT == 1)
+  #if defined (__TARGET_FPU_VFP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else
       #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
@@ -58,7 +58,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_FP
+  #if defined (__ARM_FP)
     #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else
@@ -70,8 +70,8 @@
   #endif
 
 #elif defined ( __ICCARM__ )
-  #if defined __ARMVFP__
-    #if (__FPU_PRESENT == 1)
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else
       #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
@@ -83,7 +83,7 @@
 
 #elif defined ( __TMS470__ )
   #if defined __TI_VFP_SUPPORT__
-    #if (__FPU_PRESENT == 1)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else
       #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
@@ -95,7 +95,7 @@
 
 #elif defined ( __GNUC__ )
   #if defined (__VFP_FP__) && !defined(__SOFTFP__)
-    #if (__FPU_PRESENT == 1)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else
       #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
@@ -106,8 +106,8 @@
   #endif
 
 #elif defined ( __TASKING__ )
-  #if defined __FPU_VFP__
-    #if (__FPU_PRESENT == 1)
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else
       #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"


### PR DESCRIPTION
Both versions (Cortex-M and Cortex-A) are better comparable now.
This brings no functional change

The compiler specific abstractions seem to have been copied from the Core_M implementation to the Core_A implementation sometime in the past and developed apart. With this pull request I tried to aligned them again. But I think it would be best to have only one generic implementation to avoid code duplication. Core specific implementations could still be in separate files, but the most part of it could be generic.
What do you think, is it worth to work in this direction? Why has it been copied in the first place?
