### PR TITLE
Fix `arm_convolve_1x1_s8_fast` comment

### DIFF
--- a/CMSIS/NN/Include/arm_nnfunctions.h
+++ b/CMSIS/NN/Include/arm_nnfunctions.h
@@ -739,7 +739,6 @@ arm_cmsis_nn_status arm_convolve_1x1_HWC_q7_fast_nonsquare(const q7_t *Im_in,
  * @details
  *   - Supported framework : TensorFlow Lite Micro
  *   - The following constrains on the arguments apply
- *      -# input_dims->c is a multiple of 4
  *      -# conv_params->padding.w = conv_params->padding.h = 0
  *      -# conv_params->stride.w = conv_params->stride.h = 1
  *


### PR DESCRIPTION
The comment for `arm_convolve_1x1_s8_fast` in `arm_nnfunctions.h` deviates from what is required in the [code](https://github.com/ARM-software/CMSIS_5/blob/7f6a7b6b870dbb990b65868f7f54cc2a6dab41e1/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c#L63). 
```
...
 if (conv_params->padding.w != 0 || conv_params->padding.h != 0 || conv_params->stride.w != 1 ||
        conv_params->stride.h != 1)
    {
        return ARM_CMSIS_NN_ARG_ERROR;
    }
...
```

It mentions that `input_dims` has to be a multiple of 4 but the code does not have this restriction. 


FYI: @SebastianBoblest @UlrikHjort @vdkhoi