### PR TITLE
CMSIS-DAP: DAP_XXX_Transfer() counts too much in case of break in the first loop

### DIFF
--- a/CMSIS/DAP/Firmware/Source/DAP.c
+++ b/CMSIS/DAP/Firmware/Source/DAP.c
@@ -712,7 +712,8 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
 
   request_count = *request++;
 
-  for (; request_count != 0U; request_count--) {
+  while (request_count != 0) {
+    request_count--;
     request_value = *request++;
     if ((request_value & DAP_TRANSFER_RnW) != 0U) {
       // Read register
@@ -893,7 +894,8 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
     }
   }
 
-  for (; request_count != 0U; request_count--) {
+  while (request_count != 0) {
+    request_count--;
     // Process canceled requests
     request_value = *request++;
     if ((request_value & DAP_TRANSFER_RnW) != 0U) {
@@ -986,7 +988,8 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
 
   request_count = *request++;
 
-  for (; request_count != 0U; request_count--) {
+  while (request_count != 0) {
+    request_count--;
     request_value = *request++;
     request_ir = (request_value & DAP_TRANSFER_APnDP) ? JTAG_APACC : JTAG_DPACC;
     if ((request_value & DAP_TRANSFER_RnW) != 0U) {
@@ -1163,7 +1166,8 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
     }
   }
 
-  for (; request_count != 0U; request_count--) {
+  while (request_count != 0) {
+    request_count--;
     // Process canceled requests
     request_value = *request++;
     if ((request_value & DAP_TRANSFER_RnW) != 0U) {


### PR DESCRIPTION
Bug is, that parsing in the DAP_XXX_Transfer() functions overflow the input stream if there is a "DAP_TransferAbort".  In this case "request" is incremented, but "request_count" is not decremented as it should be.

The fix solves this by using another loop construct which always decrements "request_count".

This bug is present in all versions of CMSIS!

This is a modified version of https://github.com/ARM-software/CMSIS_5/pull/1503 which also takes DAP_JTAG_Transfer() into account.

