### PR TITLE
Address unsupported nested external declaration #617

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
  * @brief    CMSIS compiler GCC header file
- * @version  V5.4.1
- * @date     27. May 2021
+ * @version  V5.4.2
+ * @date     17. December 2022
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
@@ -132,13 +132,13 @@ __STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
 {
   extern void _start(void) __NO_RETURN;
 
-  typedef struct {
+  typedef struct __copy_table {
     uint32_t const* src;
     uint32_t* dest;
     uint32_t  wlen;
   } __copy_table_t;
 
-  typedef struct {
+  typedef struct __zero_table {
     uint32_t* dest;
     uint32_t  wlen;
   } __zero_table_t;


### PR DESCRIPTION
This should address an issue #617 for Clang compilers.

This change is mutually exclusive with #1596 