### PR TITLE
Core(M): Fix endless loop issue with non-optimized IAR builds

### DIFF
--- a/CMSIS/Core/Include/cachel1_armv7.h
+++ b/CMSIS/Core/Include/cachel1_armv7.h
@@ -2,7 +2,7 @@
  * @file     cachel1_armv7.h
  * @brief    CMSIS Level 1 Cache API for Armv7-M and later
  * @version  V1.0.2
- * @date     22. June 2022
+ * @date     17. March 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2020-2021 Arm Limited. All rights reserved.

--- a/CMSIS/Core/Include/cachel1_armv7.h
+++ b/CMSIS/Core/Include/cachel1_armv7.h
@@ -197,12 +197,12 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
     SCB->CCR &= ~(uint32_t)SCB_CCR_DC_Msk;  /* disable D-Cache */
     __DSB();
 
-    #if ((defined(__GNUC__) || defined(__clang__)) && !defined(__OPTIMIZE__))
+    #if !defined(__OPTIMIZE__)
       /*
-       * For the endless loop issue with GCC and clang with O0.
+       * For the endless loop issue with no optimization builds.
        * More details, see https://github.com/ARM-software/CMSIS_5/issues/620
        *
-       * The issue only happens when local variables are in stack (GCC/clang O0). If
+       * The issue only happens when local variables are in stack. If
        * local variables are saved in general purpose register, then the function
        * is OK.
        *
@@ -210,7 +210,14 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
        * local variables cache line for data consistency.
        */
       /* Clean and invalidate the local variable cache. */
+    #if defined(__ICCARM__)
+    /* As we can't align the stack to the cache line size, invalidate each of the variables */
+      SCB->DCCIMVAC = (uint32_t)&locals.sets;
+      SCB->DCCIMVAC = (uint32_t)&locals.ways;
+      SCB->DCCIMVAC = (uint32_t)&locals.ccsidr;
+    #else
       SCB->DCCIMVAC = (uint32_t)&locals;
+    #endif
       __DSB();
       __ISB();
     #endif

--- a/CMSIS/Core/Include/cachel1_armv7.h
+++ b/CMSIS/Core/Include/cachel1_armv7.h
@@ -1,8 +1,8 @@
 /******************************************************************************
  * @file     cachel1_armv7.h
  * @brief    CMSIS Level 1 Cache API for Armv7-M and later
- * @version  V1.0.2
- * @date     22. June 2022
+ * @version  V1.0.3
+ * @date     17. March 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2020-2021 Arm Limited. All rights reserved.


### PR DESCRIPTION
This is an IAR fix for the problem described in
https://github.com/ARM-software/CMSIS_5/issues/620

IAR builds can not align the stack to the cache line size and thus the invalidation is done in separate steps for the three variables.

Fix validated on STM32H7 HW.