### PR TITLE
Adding MPU macros and improving docs

### DIFF
--- a/CMSIS/Core/Include/mpu_armv8.h
+++ b/CMSIS/Core/Include/mpu_armv8.h
@@ -38,10 +38,10 @@
 #define ARM_MPU_ATTR_NON_CACHEABLE                    ( 4U )
 
 /** \brief Attribute for Normal memory, Outer and Inner cacheability.
-* \param NT Non-Transient: Set to 1 for non-transient data. Set to 0 for transient data.
-* \param WB Write-Back: Set to 1 to use write-back update policy. Set to 0 to use non-write-back update policy.
-* \param RA Read Allocation: Set to 1 to use cache allocation on read miss. Set to 0 to not use cache allocation on read miss.
-* \param WA Write Allocation: Set to 1 to use cache allocation on write miss. Set to 0 to not use cache allocation on write miss.
+* \param NT Non-Transient: Set to 1 for Non-transient data. Set to 0 for Transient data.
+* \param WB Write-Back: Set to 1 to use a Write-Back policy. Set to 0 to use a Write-Through policy.
+* \param RA Read Allocation: Set to 1 to enable cache allocation on read miss. Set to 0 to disable cache allocation on read miss.
+* \param WA Write Allocation: Set to 1 to enable cache allocation on write miss. Set to 0 to disable cache allocation on write miss.
 */
 #define ARM_MPU_ATTR_MEMORY_(NT, WB, RA, WA) \
   ((((NT) & 1U) << 3U) | (((WB) & 1U) << 2U) | (((RA) & 1U) << 1U) | ((WA) & 1U))

--- a/CMSIS/Core/Include/mpu_armv8.h
+++ b/CMSIS/Core/Include/mpu_armv8.h
@@ -37,11 +37,11 @@
 /** \brief Attribute for non-cacheable, normal memory */
 #define ARM_MPU_ATTR_NON_CACHEABLE                    ( 4U )
 
-/** \brief Attribute for normal memory (outer and inner)
-* \param NT Non-Transient: Set to 1 for non-transient data.
-* \param WB Write-Back: Set to 1 to use write-back update policy.
-* \param RA Read Allocation: Set to 1 to use cache allocation on read miss.
-* \param WA Write Allocation: Set to 1 to use cache allocation on write miss.
+/** \brief Attribute for Normal memory, Outer and Inner cacheability.
+* \param NT Non-Transient: Set to 1 for non-transient data. Set to 0 for transient data.
+* \param WB Write-Back: Set to 1 to use write-back update policy. Set to 0 to use non-write-back update policy.
+* \param RA Read Allocation: Set to 1 to use cache allocation on read miss. Set to 0 to not use cache allocation on read miss.
+* \param WA Write Allocation: Set to 1 to use cache allocation on write miss. Set to 0 to not use cache allocation on write miss.
 */
 #define ARM_MPU_ATTR_MEMORY_(NT, WB, RA, WA) \
   ((((NT) & 1U) << 3U) | (((WB) & 1U) << 2U) | (((RA) & 1U) << 1U) | ((WA) & 1U))
@@ -58,33 +58,95 @@
 /** \brief Device memory type Gathering, Re-ordering, Early Write Acknowledgement */
 #define ARM_MPU_ATTR_DEVICE_GRE    (3U)
 
+/** \brief Normal memory outer-cacheable and inner-cacheable attributes
+* WT = Write Through, WB = Write Back, TR = Transient, RA = Read-Allocate, WA = Write Allocate
+*/
+#define MPU_ATTR_NORMAL_OUTER_NON_CACHEABLE (0b0100)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_RA      (0b0010)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_WA      (0b0001)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_RA_WA   (0b0011)
+#define MPU_ATTR_NORMAL_OUTER_WT_RA         (0b1010)
+#define MPU_ATTR_NORMAL_OUTER_WT_WA         (0b1001)
+#define MPU_ATTR_NORMAL_OUTER_WT_RA_WA      (0b1011)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_RA      (0b0101)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_WA      (0b0110)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_RA_WA   (0b0111)
+#define MPU_ATTR_NORMAL_OUTER_WB_RA         (0b1101)
+#define MPU_ATTR_NORMAL_OUTER_WB_WA         (0b1110)
+#define MPU_ATTR_NORMAL_OUTER_WB_RA_WA      (0b1111)
+#define MPU_ATTR_NORMAL_INNER_NON_CACHEABLE (0b0100)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_RA      (0b0010)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_WA      (0b0001)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_RA_WA   (0b0011)
+#define MPU_ATTR_NORMAL_INNER_WT_RA         (0b1010)
+#define MPU_ATTR_NORMAL_INNER_WT_WA         (0b1001)
+#define MPU_ATTR_NORMAL_INNER_WT_RA_WA      (0b1011)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_RA      (0b0101)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_WA      (0b0110)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_RA_WA   (0b0111)
+#define MPU_ATTR_NORMAL_INNER_WB_RA         (0b1101)
+#define MPU_ATTR_NORMAL_INNER_WB_WA         (0b1110)
+#define MPU_ATTR_NORMAL_INNER_WB_RA_WA      (0b1111)
+
 /** \brief Memory Attribute
 * \param O Outer memory attributes
 * \param I O == ARM_MPU_ATTR_DEVICE: Device memory attributes, else: Inner memory attributes
 */
 #define ARM_MPU_ATTR(O, I) ((((O) & 0xFU) << 4U) | ((((O) & 0xFU) != 0U) ? ((I) & 0xFU) : (((I) & 0x3U) << 2U)))
 
-/** \brief Normal memory non-shareable  */
+/* \brief Specifies MAIR_ATTR number */
+#define MAIR_ATTR(x)						((x > 7 || x < 0) ? 0 : x)
+
+/**
+ * Shareability
+ */
+/** \brief Normal memory, non-shareable  */
 #define ARM_MPU_SH_NON   (0U)
 
-/** \brief Normal memory outer shareable  */
+/** \brief Normal memory, outer shareable  */
 #define ARM_MPU_SH_OUTER (2U)
 
-/** \brief Normal memory inner shareable  */
+/** \brief Normal memory, inner shareable  */
 #define ARM_MPU_SH_INNER (3U)
 
+/**
+ * Access permissions
+ * AP = Access permission, RO = Read-only, RW = Read/Write, NP = Any privilege, PO = Privileged code only
+ */
+/** \brief Normal memory, read/write */
+#define ARM_MPU_AP_RW (0U)
+
+/** \brief Normal memory, read-only */
+#define ARM_MPU_AP_RO (1U)
+
+/** \brief Normal memory, any privilege level */
+#define ARM_MPU_AP_NP (1U)
+
+/** \brief Normal memory, privileged access only */
+#define ARM_MPU_AP_PO (0U)
+
+/*
+ * Execute-never
+ * XN = Execute-never, EX = Executable
+ */
+/** \brief Normal memory, Execution only permitted if read permitted */
+#define ARM_MPU_XN (1U)
+
+/** \brief Normal memory, Execution only permitted if read permitted */
+#define ARM_MPU_EX (0U)
+
 /** \brief Memory access permissions
-* \param RO Read-Only: Set to 1 for read-only memory.
-* \param NP Non-Privileged: Set to 1 for non-privileged memory.
+* \param RO Read-Only: Set to 1 for read-only memory. Set to 0 for a read/write memory.
+* \param NP Non-Privileged: Set to 1 for non-privileged memory. Set to 0 for privileged memory.
 */
 #define ARM_MPU_AP_(RO, NP) ((((RO) & 1U) << 1U) | ((NP) & 1U))
 
 /** \brief Region Base Address Register value
 * \param BASE The base address bits [31:5] of a memory region. The value is zero extended. Effective address gets 32 byte aligned.
 * \param SH Defines the Shareability domain for this memory region.
-* \param RO Read-Only: Set to 1 for a read-only memory region.
-* \param NP Non-Privileged: Set to 1 for a non-privileged memory region.
-* \param XN eXecute Never: Set to 1 for a non-executable memory region.
+* \param RO Read-Only: Set to 1 for a read-only memory region. Set to 0 for a read/write memory region.
+* \param NP Non-Privileged: Set to 1 for a non-privileged memory region. Set to 0 for privileged memory region.
+* \param XN eXecute Never: Set to 1 for a non-executable memory region. Set to 0 for an executable memory region.
 */
 #define ARM_MPU_RBAR(BASE, SH, RO, NP, XN) \
   (((BASE) & MPU_RBAR_BASE_Msk) | \
@@ -123,6 +185,15 @@ typedef struct {
   uint32_t RBAR;                   /*!< Region Base Address Register value */
   uint32_t RLAR;                   /*!< Region Limit Address Register value */
 } ARM_MPU_Region_t;
+
+/**
+  \brief  Read MPU Type Register
+  \return Number of MPU regions
+*/
+__STATIC_INLINE uint32_t ARM_MPU_TYPE()
+{
+  return ((MPU->TYPE) >> 8);
+}
     
 /** Enable the MPU.
 * \param MPU_Control Default access permissions for unconfigured regions.

--- a/CMSIS/Core/Include/mpu_armv8.h
+++ b/CMSIS/Core/Include/mpu_armv8.h
@@ -1,8 +1,8 @@
 /******************************************************************************
  * @file     mpu_armv8.h
  * @brief    CMSIS MPU API for Armv8-M and Armv8.1-M MPU
- * @version  V5.1.4
- * @date     30. May 2022
+ * @version  V5.9.0
+ * @date     11. April 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2017-2022 Arm Limited. All rights reserved.


### PR DESCRIPTION
Functional changes:
- There already were macros for MPU_RBAR shareability field (`ARM_MPU_SH_NON`, `ARM_MPU_SH_OUTER` and `ARM_MPU_SH_INNER`), so I added macros for the access permissions and execute-never fields.
- Added some handy functions and macros for better readability, like `ARM_MPU_TYPE` function and the macro `MAIR_ATTR`.
- Added input macros for `ARM_MPU_ATTR`

Docs:
- Changed wording for clarity and consistency with the Architecture Reference Manual.