### PR TITLE
IRQn_Type: Ensure enum size matches maximum value.

### DIFF
--- a/Device/ARM/ARMCM0/Include/ARMCM0.h
+++ b/Device/ARM/ARMCM0/Include/ARMCM0.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 31 are left out */
+  /* Interrupts 1 .. 30 are left out */
+  Interrupt31_IRQn              =   31
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM0/Include/ARMCM0.h
+++ b/Device/ARM/ARMCM0/Include/ARMCM0.h
@@ -2,8 +2,8 @@
  * @file     ARMCM0.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM0 Device
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 30 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 30 are left out */
   Interrupt31_IRQn              =   31
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM0plus/Include/ARMCM0plus.h
+++ b/Device/ARM/ARMCM0plus/Include/ARMCM0plus.h
@@ -2,8 +2,8 @@
  * @file     ARMCM0plus.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM0plus Device
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,8 +48,17 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 30 are left out */
-  Interrupt31_IRQn             =   31
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 30 are left out */
+  Interrupt31_IRQn              =   31
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM0plus/Include/ARMCM0plus.h
+++ b/Device/ARM/ARMCM0plus/Include/ARMCM0plus.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 31 are left out */
+  /* Interrupts 1 .. 30 are left out */
+  Interrupt31_IRQn             =   31
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM0plus/Include/ARMCM0plus_MPU.h
+++ b/Device/ARM/ARMCM0plus/Include/ARMCM0plus_MPU.h
@@ -2,8 +2,8 @@
  * @file     ARMCM0plus_MPU.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM0plus Device (configured for CM0+ with MPU)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 30 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 30 are left out */
   Interrupt31_IRQn              =   31
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM0plus/Include/ARMCM0plus_MPU.h
+++ b/Device/ARM/ARMCM0plus/Include/ARMCM0plus_MPU.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 31 are left out */
+  /* Interrupts 1 .. 30 are left out */
+  Interrupt31_IRQn              =   31
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM1/Include/ARMCM1.h
+++ b/Device/ARM/ARMCM1/Include/ARMCM1.h
@@ -2,8 +2,8 @@
  * @file     ARMCM1.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM1 Device
- * @version  V5.3.1
- * @date     20. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 30 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 30 are left out */
   Interrupt31_IRQn              =   31
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM1/Include/ARMCM1.h
+++ b/Device/ARM/ARMCM1/Include/ARMCM1.h
@@ -48,17 +48,10 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 31 are left out */
+  /* Interrupts 1 .. 30 are left out */
+  Interrupt31_IRQn              =   31
 } IRQn_Type;
+
 
 
 /* ================================================================================ */

--- a/Device/ARM/ARMCM23/Include/ARMCM23.h
+++ b/Device/ARM/ARMCM23/Include/ARMCM23.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM23/Include/ARMCM23.h
+++ b/Device/ARM/ARMCM23/Include/ARMCM23.h
@@ -2,8 +2,8 @@
  * @file     ARMCM23.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM23 Device
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM23/Include/ARMCM23_TZ.h
+++ b/Device/ARM/ARMCM23/Include/ARMCM23_TZ.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM23/Include/ARMCM23_TZ.h
+++ b/Device/ARM/ARMCM23/Include/ARMCM23_TZ.h
@@ -2,8 +2,8 @@
  * @file     ARMCM23_TZ.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM23 Device (configured for TrustZone)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM3/Include/ARMCM3.h
+++ b/Device/ARM/ARMCM3/Include/ARMCM3.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM3/Include/ARMCM3.h
+++ b/Device/ARM/ARMCM3/Include/ARMCM3.h
@@ -2,8 +2,8 @@
  * @file     ARMCM3.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM3 Device
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33.h
@@ -2,8 +2,8 @@
  * @file     ARMCM33.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM33 Device (configured for ARMCM33 without FPU, without DSP extension, without TrustZone)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP.h
@@ -2,8 +2,8 @@
  * @file     ARMCM33_DSP_FP.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM33 Device (configured for ARMCM33 with FPU, with DSP extension)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP_TZ.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP_TZ.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP_TZ.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33_DSP_FP_TZ.h
@@ -2,8 +2,8 @@
  * @file     ARMCM33_DSP_FP_TZ.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM33 Device (configured for ARMCM33 with FPU, with DSP extension, with TrustZone)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33_TZ.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33_TZ.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM33/Include/ARMCM33_TZ.h
+++ b/Device/ARM/ARMCM33/Include/ARMCM33_TZ.h
@@ -2,8 +2,8 @@
  * @file     ARMCM33_TZ.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM33 Device (configured for ARMCM33 without FPU, without DSP extension, with TrustZone)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P.h
@@ -2,8 +2,8 @@
  * @file     ARMCM35P.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM35P Device (configured for ARMCM35P without FPU, without DSP extension, without TrustZone)
- * @version  V1.0.0
- * @date     03. September 2018
+ * @version  V1.0.1
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP.h
@@ -2,8 +2,8 @@
  * @file     ARMCM35P_DSP_FP.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM35P Device (configured for ARMCM35P with FPU, with DSP extension)
- * @version  V1.0.0
- * @date     03. September 2018
+ * @version  V1.0.1
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP_TZ.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP_TZ.h
@@ -2,8 +2,8 @@
  * @file     ARMCM35P_DSP_FP_TZ.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM35P Device (configured for ARMCM35P with FPU, with DSP extension, with TrustZone)
- * @version  V1.0.0
- * @date     03. September 2018
+ * @version  V1.0.1
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP_TZ.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P_DSP_FP_TZ.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P_TZ.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P_TZ.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM35P/Include/ARMCM35P_TZ.h
+++ b/Device/ARM/ARMCM35P/Include/ARMCM35P_TZ.h
@@ -2,8 +2,8 @@
  * @file     ARMCM35P_TZ.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM35P Device (configured for ARMCM35P without FPU, without DSP extension, with TrustZone)
- * @version  V1.0.0
- * @date     03. September 2018
+ * @version  V1.0.1
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM4/Include/ARMCM4.h
+++ b/Device/ARM/ARMCM4/Include/ARMCM4.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM4/Include/ARMCM4.h
+++ b/Device/ARM/ARMCM4/Include/ARMCM4.h
@@ -2,8 +2,8 @@
  * @file     ARMCM4.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM4 Device (configured for CM4 without FPU)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM4/Include/ARMCM4_FP.h
+++ b/Device/ARM/ARMCM4/Include/ARMCM4_FP.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM4/Include/ARMCM4_FP.h
+++ b/Device/ARM/ARMCM4/Include/ARMCM4_FP.h
@@ -2,8 +2,8 @@
  * @file     ARMCM4_FP.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM4 Device (configured for CM4 with FPU)
- * @version  V5.3.1
- * @date     09. July 2018
+ * @version  V5.3.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM55/Include/ARMCM55.h
+++ b/Device/ARM/ARMCM55/Include/ARMCM55.h
@@ -3,8 +3,8 @@
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM55 Device Series (configured for ARMCM55 with double precision FPU,
  *                                  DSP extension, MVE, TrustZone)
- * @version  V1.0.0
- * @date     27. March 2020
+ * @version  V1.0.1
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2020 Arm Limited. All rights reserved.
@@ -50,7 +50,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM55/Include/ARMCM55.h
+++ b/Device/ARM/ARMCM55/Include/ARMCM55.h
@@ -50,16 +50,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM7/Include/ARMCM7.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM7/Include/ARMCM7.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7.h
@@ -2,8 +2,8 @@
  * @file     ARMCM7.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM7 Device (configured for CM7 without FPU)
- * @version  V5.3.2
- * @date     27. March 2020
+ * @version  V5.3.3
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2020 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM7/Include/ARMCM7_DP.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7_DP.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM7/Include/ARMCM7_DP.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7_DP.h
@@ -2,8 +2,8 @@
  * @file     ARMCM7_DP.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM7 Device (configured for CM7 with double precision FPU)
- * @version  V5.3.2
- * @date     27. March 2020
+ * @version  V5.3.3
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2020 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM7/Include/ARMCM7_SP.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7_SP.h
@@ -48,16 +48,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 224 are left out */
+  /* Interrupts 1 .. 223 are left out */
+  Interrupt224_IRQn             =   224
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM7/Include/ARMCM7_SP.h
+++ b/Device/ARM/ARMCM7/Include/ARMCM7_SP.h
@@ -2,8 +2,8 @@
  * @file     ARMCM7_SP.h
  * @brief    CMSIS Core Peripheral Access Layer Header File for
  *           ARMCM7 Device (configured for CM7 with single precision FPU)
- * @version  V5.3.2
- * @date     27. March 2020
+ * @version  V5.3.3
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2020 Arm Limited. All rights reserved.
@@ -48,7 +48,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 223 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 223 are left out */
   Interrupt224_IRQn             =   224
 } IRQn_Type;
 

--- a/Device/ARM/ARMCM85/Include/ARMCM85.h
+++ b/Device/ARM/ARMCM85/Include/ARMCM85.h
@@ -49,16 +49,8 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  Interrupt1_IRQn               =   1,
-  Interrupt2_IRQn               =   2,
-  Interrupt3_IRQn               =   3,
-  Interrupt4_IRQn               =   4,
-  Interrupt5_IRQn               =   5,
-  Interrupt6_IRQn               =   6,
-  Interrupt7_IRQn               =   7,
-  Interrupt8_IRQn               =   8,
-  Interrupt9_IRQn               =   9
-  /* Interrupts 10 .. 480 are left out */
+  /* Interrupts 1 .. 479 are left out */
+  Interrupt480_IRQn             =   480
 } IRQn_Type;
 
 

--- a/Device/ARM/ARMCM85/Include/ARMCM85.h
+++ b/Device/ARM/ARMCM85/Include/ARMCM85.h
@@ -2,8 +2,8 @@
  * @file     ARMCM85.h
  * @brief    CMSIS Device Header File for ARMCM85 Device
  *           (double precision FPU, DSP extension, MVE, TrustZone)
- * @version  V1.0.1
- * @date     21. July 2022
+ * @version  V1.0.2
+ * @date     01. May 2023
  ******************************************************************************/
 /*
  * Copyright (c) 2022 Arm Limited. All rights reserved.
@@ -49,7 +49,16 @@ typedef enum IRQn
 
 /* -------------------  Processor Interrupt Numbers  ------------------------------ */
   Interrupt0_IRQn               =   0,
-  /* Interrupts 1 .. 479 are left out */
+  Interrupt1_IRQn               =   1,
+  Interrupt2_IRQn               =   2,
+  Interrupt3_IRQn               =   3,
+  Interrupt4_IRQn               =   4,
+  Interrupt5_IRQn               =   5,
+  Interrupt6_IRQn               =   6,
+  Interrupt7_IRQn               =   7,
+  Interrupt8_IRQn               =   8,
+  Interrupt9_IRQn               =   9,
+  /* Interrupts 10 .. 479 are left out */
   Interrupt480_IRQn             =   480
 } IRQn_Type;
 


### PR DESCRIPTION
This change fixes a bug where a compiler choses a signed byte to store the IRQn_Type enum type as all listed enum values fit a signed byte. This causes undefined behavior when calling functions such as NVIC_EnableIRQ with interrupt channels greater than 127 as these do not fit a signed byte. As a result, interrupt channels higher than 127 cannot be enabled, disabled, or triggered.

Fix this by listing the highest possible interrupt channel in each enum declaration which ensures that a storage type is chosen that can accommodate all valid interrupt channels.

Tested on a MEC1527 devices by triggering interrupt channel 171 (watchdog) and observing that the ISR is executed.