### PR TITLE
Core/Include: Fix GCC __USAT() macro function + Improve USAT doc

### DIFF
--- a/CMSIS/Core/Include/cmsis_armcc.h
+++ b/CMSIS/Core/Include/cmsis_armcc.h
@@ -397,10 +397,10 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __RBIT(uint32_t value)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 #define __USAT                            __usat
 
@@ -504,10 +504,10 @@ __attribute__((always_inline)) __STATIC_INLINE int32_t __SSAT(int32_t val, uint3
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 __attribute__((always_inline)) __STATIC_INLINE uint32_t __USAT(int32_t val, uint32_t sat)
 {

--- a/CMSIS/Core/Include/cmsis_armclang.h
+++ b/CMSIS/Core/Include/cmsis_armclang.h
@@ -414,10 +414,10 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 #define __USAT             __builtin_arm_usat
 
@@ -550,10 +550,10 @@ __STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 __STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
 {

--- a/CMSIS/Core/Include/cmsis_armclang_ltm.h
+++ b/CMSIS/Core/Include/cmsis_armclang_ltm.h
@@ -407,10 +407,10 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 #define __USAT             __builtin_arm_usat
 
@@ -542,10 +542,10 @@ __STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 __STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
 {

--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -575,15 +575,16 @@ __extension__ \
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  ARG1  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  ARG1  Value to be saturated (signed)
   \param [in]  ARG2  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 #define __USAT(ARG1, ARG2) \
 __extension__ \
 ({                          \
-  uint32_t __RES, __ARG1 = (ARG1); \
+  uint32_t __RES; \
+  int32_t __ARG1 = (ARG1); \
   __ASM volatile ("usat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) : "cc" ); \
   __RES; \
  })
@@ -730,10 +731,10 @@ __STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 __STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
 {

--- a/CMSIS/Core/Include/cmsis_tiarmclang.h
+++ b/CMSIS/Core/Include/cmsis_tiarmclang.h
@@ -414,10 +414,10 @@ __STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 #define __USAT             __builtin_arm_usat
 
@@ -550,10 +550,10 @@ __STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
 
 /**
   \brief   Unsigned Saturate
-  \details Saturates an unsigned value.
-  \param [in]  value  Value to be saturated
+  \details Saturates a signed value into an unsigned value.
+  \param [in]  value  Value to be saturated (signed)
   \param [in]    sat  Bit position to saturate to (0..31)
-  \return             Saturated value
+  \return             Saturated value (unsigned)
  */
 __STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
 {


### PR DESCRIPTION
First argument of USAT instruction is a signed number, not an unsigned value. Update documentation everywhere else to clarify that.